### PR TITLE
Feature/docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+./source/dynamical_systems/build
+./source/robot_model/build
+./source/state_representation/build

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 ./source/dynamical_systems/build
 ./source/robot_model/build
 ./source/state_representation/build
+./source/dynamical_systems/lib
+./source/robot_model/lib
+./source/state_representation/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# install dependencies for building the robot_model library
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    git \
+    wget \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+# import previously downloaded packages
+RUN mkdir -p lib
+WORKDIR lib
+COPY ./source/ .
+# install libraries and dependencies
+RUN . ./install.sh
+
+# Clean image
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,15 @@ RUN apt-get update && apt-get install -y \
 
 # import previously downloaded packages
 WORKDIR /root/control_lib
-COPY ./source/ .
 # install libraries and dependencies
-RUN . ./install.sh
+COPY ./source/state_representation ./state_representation
+RUN /bin/bash -c "source ./state_representation/install.sh"
+
+COPY ./source/dynamical_systems ./dynamical_systems
+RUN /bin/bash -c "source ./dynamical_systems/install.sh"
+
+COPY ./source/robot_model ./robot_model
+RUN /bin/bash -c "source ./robot_model/install.sh"
 
 # change directory
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-# install dependencies for building the robot_model library
+# install dependencies for building the libraries
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,15 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # import previously downloaded packages
-RUN mkdir -p lib
-WORKDIR lib
+WORKDIR /root/control_lib
 COPY ./source/ .
 # install libraries and dependencies
 RUN . ./install.sh
 
+# change directory
+WORKDIR /root
+
 # Clean image
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["entrypoint.sh"]
 CMD ["bash"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+REBUILD=0
+
+while getopts 'r' opt; do
+    case $opt in
+        r) REBUILD=1 ;;
+        *) echo 'Error in command line parsing' >&2
+           exit 1
+    esac
+done
+shift "$(( OPTIND - 1 ))"
+
+NAME=$(echo "${PWD##*/}" | tr _ -)
+TAG="latest"
+
+if [ "$REBUILD" -eq 1 ]; then
+    docker build \
+        --no-cache \
+        -t "${NAME}:${TAG}" .
+else
+    docker build \
+        -t "${NAME}:${TAG}" .
+fi

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+NAME=$(echo "${PWD##*/}" | tr _ -)
+TAG=$(echo "$1" | tr _/ -)
+
+ISISOLATED=true # change to  false to use host network
+
+NETWORK=host
+if [ "${ISISOLATED}" = true ]; then
+    docker network inspect isolated >/dev/null 2>&1 || docker network create --driver bridge isolated
+    NETWORK=isolated
+fi
+
+if [ -z "$TAG" ]; then
+	TAG="latest"
+fi
+
+#create a shared volume to store the lib folder
+docker volume create --driver local \
+    --opt type="none" \
+    --opt device="${PWD}/source/lib/" \
+    --opt o="bind" \
+    "${NAME}_lib_vol"
+
+xhost +
+docker run \
+    --privileged \
+	--net="${NETWORK}" \
+	-it \
+    --rm \
+	--volume="${NAME}_lib_vol:/lib/:rw" \
+	"${NAME}:${TAG}"

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ fi
 #create a shared volume to store the lib folder
 docker volume create --driver local \
     --opt type="none" \
-    --opt device="${PWD}/source/lib/" \
+    --opt device="${PWD}/source/" \
     --opt o="bind" \
     "${NAME}_lib_vol"
 
@@ -27,5 +27,5 @@ docker run \
 	--net="${NETWORK}" \
 	-it \
     --rm \
-	--volume="${NAME}_lib_vol:/lib/:rw" \
+	--volume="${NAME}_lib_vol:/root/control_lib/:rw" \
 	"${NAME}:${TAG}"

--- a/source/build.sh
+++ b/source/build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-CURRPATH=${PWD}
-# turn on testing
-IS_TEST="OFF"
-
-# cpp
-cd "${CURRPATH}/state_representation" && mkdir -p build && cd build && cmake -Druntests="${IS_TEST}" .. && make -j && sudo make install
-cd "${CURRPATH}/dynamical_systems" && mkdir -p build && cd build && cmake -Druntests="${IS_TEST}" .. && make -j && sudo make install
-cd "${CURRPATH}/robot_model" && mkdir -p build && cd build && cmake -Druntests="${IS_TEST}" .. && make -j && sudo make install

--- a/source/dynamical_systems/CMakeLists.txt
+++ b/source/dynamical_systems/CMakeLists.txt
@@ -7,24 +7,24 @@ project(dynamical_systems)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
-  	set(CMAKE_C_STANDARD 99)
+    set(CMAKE_C_STANDARD 99)
 endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  	set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 14)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  	add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(Eigen3 REQUIRED)
 
 include_directories(
-  	include
+    include
     state_representation/include
-  	${Eigen3_INCLUDE_DIRS}
+    ${Eigen3_INCLUDE_DIRS}
 )
 
 set(CORE_SOURCES
@@ -37,16 +37,21 @@ add_library(${PROJECT_NAME} SHARED
   ${CORE_SOURCES}
 )
 
+target_link_libraries(${PROJECT_NAME}
+  Eigen3::Eigen
+  state_representation
+)
+
 install(DIRECTORY include/
-  	DESTINATION include)
+    DESTINATION include)
 
 install(TARGETS ${PROJECT_NAME}
-  	ARCHIVE DESTINATION lib
-  	LIBRARY DESTINATION lib
-  	RUNTIME DESTINATION bin)
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
 
 if (runtests)
-	  if (APPLE)
+    if (APPLE)
       add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
       add_definitions(-D__GLIBCXX__)
     endif (APPLE)
@@ -55,18 +60,18 @@ if (runtests)
 
     enable_testing()
 
-  	# Include the gtest library. gtest_SOURCE_DIR is available due to
-  	# 'project(gtest)' above.
-  	include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+    # Include the gtest library. gtest_SOURCE_DIR is available due to
+    # 'project(gtest)' above.
+    include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
-  	add_executable(runTestLinear tests/testLinear.cpp)
-  	target_link_libraries(runTestLinear
-  		gtest 
-  		gtest_main
-  		${PROJECT_NAME}
+    add_executable(runTestLinear tests/testLinear.cpp)
+    target_link_libraries(runTestLinear
+      gtest
+      gtest_main
+      ${PROJECT_NAME}
       state_representation
-  	)
-	  add_test(NAME runTestLinear COMMAND runTestLinear)
+    )
+    add_test(NAME runTestLinear COMMAND runTestLinear)
 
     add_executable(runTestCircular tests/testCircular.cpp)
     target_link_libraries(runTestCircular

--- a/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
@@ -6,85 +6,77 @@
 
 #pragma once
 
+#include "state_representation/Parameters/ParameterInterface.hpp"
 #include <list>
 #include <memory>
-#include "state_representation/Parameters/ParameterInterface.hpp"
 
+namespace DynamicalSystems {
+/**
+ * @class DynamicalSystem
+ * @brief Abstract class to define a DynamicalSystem either in joint or cartesian spaces
+ */
+template <class S>
+class DynamicalSystem {
+private:
+  S reference_frame_;
 
-namespace DynamicalSystems
-{
-	/**
-	 * @class DynamicalSystem
-	 * @brief Abstract class to define a DynamicalSystem either in joint or cartesian spaces
-	 */
-	template<class S>
-	class DynamicalSystem 
-	{
-	private:
-		S reference_frame_;
+protected:
+  /**
+   * @brief Compute the dynamics of the input state.
+   * Internal function, to be redefined based on the
+   * type of dynamical system, called by the evaluate
+   * function
+   * @param state the input state
+   * @return the output state
+   */
+  virtual const S compute_dynamics(const S& state) const = 0;
 
-	protected:
-		/**
-		 * @brief Compute the dynamics of the input state.
-		 * Internal function, to be redefined based on the
-		 * type of dynamical system, called by the evaluate
-		 * function
-		 * @param state the input state
-		 * @return the output state
-		 */
-		virtual const S compute_dynamics(const S& state) const=0;
+public:
+  /**
+   * @brief Empty constructor
+   */
+  explicit DynamicalSystem();
 
-	public:
-		/**
-		 * @brief Empty constructor
-		 */
-		explicit DynamicalSystem();
+  /**
+   * @brief Constructor with a provided reference frame
+   * @param reference_frame the reference frame in which the dynamics is computed
+   */
+  explicit DynamicalSystem(const S& reference_frame);
 
-		/**
-		 * @brief Constructor with a provided reference frame
-		 * @param reference_frame the reference frame in which the dynamics is computed
-		 */
-		explicit DynamicalSystem(const S& reference_frame);
+  /**
+   * @brief Evaluate the value of the dynamical system at a given state
+   * @param state state at wich to perform the evaluation
+   * @return the state (velocity) to move toward the attractor
+   */
+  const S evaluate(const S& state) const;
 
-		/**
-		 * @brief Evaluate the value of the dynamical system at a given state
-		 * @param state state at wich to perform the evaluation
-		 * @return the state (velocity) to move toward the attractor
-		 */
-		const S evaluate(const S& state) const;
+  /**
+   * @brief Return a list of all the parameters of the dynamical system
+   * @return the list of parameters
+   */
+  virtual const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
 
-		/**
-		 * @brief Return a list of all the parameters of the dynamical system
-		 * @return the list of parameters
-		 */
-		virtual const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
+  const S& get_reference_frame() const;
 
-		const S& get_reference_frame() const;
+  void set_reference_frame(const S& reference_frame);
+};
 
-		void set_reference_frame(const S& reference_frame);
-	};
+template <class S>
+DynamicalSystem<S>::DynamicalSystem(const S& reference_frame) : reference_frame_(reference_frame) {}
 
-	template<class S>
-	DynamicalSystem<S>::DynamicalSystem(const S& reference_frame):
-	reference_frame_(reference_frame)
-	{}
-
-	template<class S>
-	const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> DynamicalSystem<S>::get_parameters() const
-	{
-		std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
-		return param_list;
-	}
-
-	template<class S>
-	inline const S& DynamicalSystem<S>::get_reference_frame() const
-	{
-		return this->reference_frame_;
-	}
-
-	template<class S>
-	inline void DynamicalSystem<S>::set_reference_frame(const S& reference_frame)
-	{
-		this->reference_frame_ = reference_frame;
-	}
+template <class S>
+const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> DynamicalSystem<S>::get_parameters() const {
+  std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
+  return param_list;
 }
+
+template <class S>
+inline const S& DynamicalSystem<S>::get_reference_frame() const {
+  return this->reference_frame_;
+}
+
+template <class S>
+inline void DynamicalSystem<S>::set_reference_frame(const S& reference_frame) {
+  this->reference_frame_ = reference_frame;
+}
+}// namespace DynamicalSystems

--- a/source/dynamical_systems/install.sh
+++ b/source/dynamical_systems/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+SOURCE_PATH=${PWD}
+
+apt-get update && apt-get install -y \
+    libeigen3-dev
+
+# install robot_model
+cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install

--- a/source/dynamical_systems/install.sh
+++ b/source/dynamical_systems/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-SOURCE_PATH=${PWD}
+SCRIPT=$(readlink -f "$BASH_SOURCE")
+SOURCE_PATH=$(dirname "$SCRIPT")
 
 apt-get update && apt-get install -y \
     libeigen3-dev
@@ -10,3 +11,6 @@ cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
 
 # install dynamical_systems
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install
+
+# reset location
+cd ${SOURCE_PATH}

--- a/source/dynamical_systems/install.sh
+++ b/source/dynamical_systems/install.sh
@@ -4,5 +4,9 @@ SOURCE_PATH=${PWD}
 apt-get update && apt-get install -y \
     libeigen3-dev
 
-# install robot_model
+# install googletest
+mkdir ${SOURCE_PATH}/lib
+cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
+
+# install dynamical_systems
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install

--- a/source/install.sh
+++ b/source/install.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 SCRIPT=$(readlink -f "$BASH_SOURCE")
-SOURCE_PATH=$(dirname "$SCRIPT")
+CURRENT_PATH=$(dirname "$SCRIPT")
 
 # turn on testing
 IS_TEST="OFF"
 
 # cpp
-cd "${SOURCE_PATH}/state_representation" && . ./install.sh
-cd "${SOURCE_PATH}/dynamical_systems" && . ./install.sh
-cd "${SOURCE_PATH}/robot_model" && . ./install.sh
+cd "${CURRENT_PATH}/state_representation" && . ./install.sh
+cd "${CURRENT_PATH}/dynamical_systems" && . ./install.sh
+cd "${CURRENT_PATH}/robot_model" && . ./install.sh

--- a/source/install.sh
+++ b/source/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+CURRPATH=${PWD}
+# turn on testing
+IS_TEST="OFF"
+
+# cpp
+cd "${CURRPATH}/state_representation" && . ./install.sh
+cd "${CURRPATH}/dynamical_systems" . ./install.sh
+cd "${CURRPATH}/robot_model" && . ./install.sh

--- a/source/install.sh
+++ b/source/install.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-CURRPATH=${PWD}
+SCRIPT=$(readlink -f "$BASH_SOURCE")
+SOURCE_PATH=$(dirname "$SCRIPT")
+
 # turn on testing
 IS_TEST="OFF"
 
 # cpp
-cd "${CURRPATH}/state_representation" && . ./install.sh
-cd "${CURRPATH}/dynamical_systems" && . ./install.sh
-cd "${CURRPATH}/robot_model" && . ./install.sh
+cd "${SOURCE_PATH}/state_representation" && . ./install.sh
+cd "${SOURCE_PATH}/dynamical_systems" && . ./install.sh
+cd "${SOURCE_PATH}/robot_model" && . ./install.sh

--- a/source/install.sh
+++ b/source/install.sh
@@ -5,5 +5,5 @@ IS_TEST="OFF"
 
 # cpp
 cd "${CURRPATH}/state_representation" && . ./install.sh
-cd "${CURRPATH}/dynamical_systems" . ./install.sh
+cd "${CURRPATH}/dynamical_systems" && . ./install.sh
 cd "${CURRPATH}/robot_model" && . ./install.sh

--- a/source/robot_model/CMakeLists.txt
+++ b/source/robot_model/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(
   include
   ${Eigen3_INCLUDE_DIRS}
   ${PINOCCHIO_INCLUDE_DIR}
-  ${PROJECT_SOURCE_DIR}/lib/openrobots/include
+  /opt/openrobots/include
   ${OsqpEigen_INCLUDE_DIR}
 )
 

--- a/source/robot_model/CMakeLists.txt
+++ b/source/robot_model/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(
   include
   ${Eigen3_INCLUDE_DIRS}
   ${PINOCCHIO_INCLUDE_DIR}
-  /home/ros2/openrobots/include
+  ${PROJECT_SOURCE_DIR}/lib/openrobots/include
   ${OsqpEigen_INCLUDE_DIR}
 )
 

--- a/source/robot_model/install.sh
+++ b/source/robot_model/install.sh
@@ -1,42 +1,28 @@
 #!/bin/sh
-SOURCE_PATH=${PWD}
+SCRIPT=$(readlink -f "$BASH_SOURCE")
+SOURCE_PATH=$(dirname "$SCRIPT")
 
 apt-get update && apt-get install -y \
     libeigen3-dev \
-    zlib1g-dev \
-    libssl-dev \
-    libboost-all-dev \
-    libboost-dev \
-    libboost-filesystem-dev \
-    libboost-system-dev \
-    libboost-chrono-dev \
-    libboost-date-time-dev \
-    libboost-thread-dev \
-    libboost-test-dev \
-    libbz2-dev \
-    libncurses-dev \
-    pax \
-    tar \
-    liburdfdom-dev \
-    libassimp-dev \
-    assimp-utils \
-    doxygen \
-    texlive-latex-extra
+    lsb-release \
+    gnupg2 \
+    curl
 
 # install googletest
 mkdir ${SOURCE_PATH}/lib
 cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
 
 # install pinocchio
-cd ${SOURCE_PATH}/lib && git clone git://git.openrobots.org/robots/robotpkg
-cd ${SOURCE_PATH}/lib/robotpkg/bootstrap && ./bootstrap --prefix=${SOURCE_PATH}/lib/openrobots
-export ROBOTPKG_BASE="${SOURCE_PATH}/lib/openrobots"
-cd ${SOURCE_PATH}/lib/robotpkg/math/pinocchio && make update
+echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list
+curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | apt-key add -
 
-export PATH="${SOURCE_PATH}/lib/openrobots/bin:${PATH}"
-export PKG_CONFIG_PATH="${SOURCE_PATH}/lib/openrobots/lib/pkgconfig:${PKG_CONFIG_PATH}"
-export LD_LIBRARY_PATH="${SOURCE_PATH}/lib/openrobots/lib:${LD_LIBRARY_PATH}"
-export PYTHONPATH="${SOURCE_PATH}/lib/openrobots/lib/python3.6/site-packages:${PYTHONPATH}"
+apt-get update && apt-get install -y robotpkg-py38-pinocchio
+
+export PATH=/opt/openrobots/bin:$PATH
+export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:$PKG_CONFIG_PATH
+export LD_LIBRARY_PATH=/opt/openrobots/lib:$LD_LIBRARY_PATH
+export PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:$PYTHONPATH # Adapt your desired python version here
+export CMAKE_PREFIX_PATH=/opt/openrobots:$CMAKE_PREFIX_PATH
 
 # install osqp
 cd ${SOURCE_PATH}/lib && git clone --recursive https://github.com/oxfordcontrol/osqp
@@ -47,3 +33,6 @@ cd ${SOURCE_PATH}/lib/osqp-eigen && mkdir build && cd build && cmake .. && make 
 
 # install robot_model
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install
+
+# reset location
+cd ${SOURCE_PATH}

--- a/source/robot_model/install.sh
+++ b/source/robot_model/install.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+SOURCE_PATH=${PWD}
+
+apt-get update && apt-get install -y \
+    libeigen3-dev \
+    zlib1g-dev \
+    libssl-dev \
+    libboost-all-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libboost-chrono-dev \
+    libboost-date-time-dev \
+    libboost-thread-dev \
+    libboost-test-dev \
+    libbz2-dev \
+    libncurses-dev \
+    pax \
+    tar \
+    liburdfdom-dev \
+    libassimp-dev \
+    assimp-utils \
+    doxygen \
+    texlive-latex-extra
+
+# install pinocchio
+cd ${SOURCE_PATH}/lib && git clone git://git.openrobots.org/robots/robotpkg
+cd ${SOURCE_PATH}/lib/robotpkg/bootstrap && ./bootstrap --prefix=${SOURCE_PATH}/lib/openrobots
+export ROBOTPKG_BASE="${SOURCE_PATH}/lib/openrobots"
+cd ${SOURCE_PATH}/lib/robotpkg/math/pinocchio && make update
+
+export PATH="${SOURCE_PATH}/lib/openrobots/bin:${PATH}"
+export PKG_CONFIG_PATH="${SOURCE_PATH}/lib/openrobots/lib/pkgconfig:${PKG_CONFIG_PATH}"
+export LD_LIBRARY_PATH="${SOURCE_PATH}/lib/openrobots/lib:${LD_LIBRARY_PATH}"
+export PYTHONPATH="${SOURCE_PATH}/lib/openrobots/lib/python3.6/site-packages:${PYTHONPATH}"
+
+# install osqp
+cd ${SOURCE_PATH}/lib && git clone --recursive https://github.com/oxfordcontrol/osqp
+cd ${SOURCE_PATH}/lib/osqp/ && mkdir build && cd build && cmake -G "Unix Makefiles" .. && cmake --build . --target install
+# install osqp eigen wrapper
+cd ${SOURCE_PATH}/lib && git clone https://github.com/robotology/osqp-eigen.git
+cd ${SOURCE_PATH}/lib/osqp-eigen && mkdir build && cd build && cmake .. && make -j && make install
+
+# install robot_model
+cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install

--- a/source/robot_model/install.sh
+++ b/source/robot_model/install.sh
@@ -23,6 +23,10 @@ apt-get update && apt-get install -y \
     doxygen \
     texlive-latex-extra
 
+# install googletest
+mkdir ${SOURCE_PATH}/lib
+cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
+
 # install pinocchio
 cd ${SOURCE_PATH}/lib && git clone git://git.openrobots.org/robots/robotpkg
 cd ${SOURCE_PATH}/lib/robotpkg/bootstrap && ./bootstrap --prefix=${SOURCE_PATH}/lib/openrobots

--- a/source/state_representation/CMakeLists.txt
+++ b/source/state_representation/CMakeLists.txt
@@ -7,23 +7,23 @@ project(state_representation)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
-  	set(CMAKE_C_STANDARD 99)
+    set(CMAKE_C_STANDARD 99)
 endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  	set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  	add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(Eigen3 REQUIRED)
 
 include_directories(
- 	include
- 	${Eigen3_INCLUDE_DIRS}
+  include
+  ${Eigen3_INCLUDE_DIRS}
 )
 
 set(CORE_SOURCES
@@ -31,7 +31,7 @@ set(CORE_SOURCES
   src/State.cpp
   src/Space/SpatialState.cpp
   src/Space/Cartesian/CartesianState.cpp
-	src/Space/Cartesian/CartesianPose.cpp
+  src/Space/Cartesian/CartesianPose.cpp
   src/Space/Cartesian/CartesianTwist.cpp
   src/Space/Cartesian/CartesianWrench.cpp
   src/Robot/JointState.cpp
@@ -55,17 +55,17 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 install(DIRECTORY include/
-  	DESTINATION include
+    DESTINATION include
 )
 
 install(TARGETS ${PROJECT_NAME}
-  	ARCHIVE DESTINATION lib
-  	LIBRARY DESTINATION lib
-  	RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
 )
 
 if (runtests)
-	  if (APPLE)
+    if (APPLE)
       add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
       add_definitions(-D__GLIBCXX__)
     endif (APPLE)
@@ -74,29 +74,29 @@ if (runtests)
 
     enable_testing()
 
-  	# Include the gtest library. gtest_SOURCE_DIR is available due to
-  	# 'project(gtest)' above.
-  	include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+    # Include the gtest library. gtest_SOURCE_DIR is available due to
+    # 'project(gtest)' above.
+    include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
     add_executable(runTestUnits tests/testUnits.cpp)
     target_link_libraries(runTestUnits
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )
     add_test(NAME runTestUnits COMMAND runTestUnits)
 
-  	add_executable(runTestCartesianState tests/testCartesianState.cpp)
-  	target_link_libraries(runTestCartesianState
-  		gtest 
-  		gtest_main
-  		${PROJECT_NAME}
-  	)
-	  add_test(NAME runTestCartesianState COMMAND runTestCartesianState)
+    add_executable(runTestCartesianState tests/testCartesianState.cpp)
+    target_link_libraries(runTestCartesianState
+      gtest
+      gtest_main
+      ${PROJECT_NAME}
+    )
+    add_test(NAME runTestCartesianState COMMAND runTestCartesianState)
 
     add_executable(runTestJointState tests/testJointState.cpp)
     target_link_libraries(runTestJointState
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )
@@ -104,7 +104,7 @@ if (runtests)
 
     add_executable(runTestDualQuaternionState tests/testDualQuaternionState.cpp)
     target_link_libraries(runTestDualQuaternionState
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )
@@ -112,7 +112,7 @@ if (runtests)
 
     add_executable(runTestJacobian tests/testJacobian.cpp)
     target_link_libraries(runTestJacobian
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )
@@ -120,7 +120,7 @@ if (runtests)
 
     add_executable(runTestTrajectory tests/testTrajectory.cpp)
     target_link_libraries(runTestTrajectory
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )
@@ -128,7 +128,7 @@ if (runtests)
 
     add_executable(runTestParameter tests/testParameter.cpp)
     target_link_libraries(runTestParameter
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )
@@ -136,7 +136,7 @@ if (runtests)
 
     add_executable(runTestEllipsoid tests/testEllipsoid.cpp)
     target_link_libraries(runTestEllipsoid
-      gtest 
+      gtest
       gtest_main
       ${PROJECT_NAME}
     )

--- a/source/state_representation/install.sh
+++ b/source/state_representation/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+SOURCE_PATH=${PWD}
+
+apt-get update && apt-get install -y \
+    libeigen3-dev
+
+# install robot_model
+cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install

--- a/source/state_representation/install.sh
+++ b/source/state_representation/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-SOURCE_PATH=${PWD}
+SCRIPT=$(readlink -f "$BASH_SOURCE")
+SOURCE_PATH=$(dirname "$SCRIPT")
 
 apt-get update && apt-get install -y \
     libeigen3-dev
@@ -10,3 +11,6 @@ cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
 
 # install state_representation
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install
+
+# reset location
+cd ${SOURCE_PATH}

--- a/source/state_representation/install.sh
+++ b/source/state_representation/install.sh
@@ -4,5 +4,9 @@ SOURCE_PATH=${PWD}
 apt-get update && apt-get install -y \
     libeigen3-dev
 
-# install robot_model
+# install googletest
+mkdir ${SOURCE_PATH}/lib
+cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
+
+# install state_representation
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install


### PR DESCRIPTION
This PR changes the way libraries are installed by using an `install.sh` script in each of them. At the moment, the top level `install.sh` script (previously `build.sh`) simply install all the libraries and test are turned off. Create install conditions and turning on test are both features we can add later.

The PR also introduce a simplified `docker` environment for development purposes.