### PR TITLE
Use different pinocchio methods to compute kinematics of frames and not just joints

### DIFF
--- a/source/robot_model/include/robot_model/Exceptions/FrameNotFoundException.hpp
+++ b/source/robot_model/include/robot_model/Exceptions/FrameNotFoundException.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
 #include <exception>
-#include <iostream>
 
-namespace RobotModel {
-namespace Exceptions {
-class FrameNotFoundException : public std::runtime_error {
+namespace RobotModel::Exceptions {
+class FrameNotFoundException : public std::invalid_argument {
 public:
-  explicit FrameNotFoundException(const std::string& frame_name) : runtime_error("Frame with name " + frame_name + " is not in the robot model"){};
+  explicit FrameNotFoundException(const std::string& frame_name) :
+      invalid_argument("Frame with name " + frame_name + " is not in the robot model") {};
 };
-}// namespace Exceptions
-}// namespace RobotModel
+}

--- a/source/robot_model/include/robot_model/Exceptions/FrameNotFoundException.hpp
+++ b/source/robot_model/include/robot_model/Exceptions/FrameNotFoundException.hpp
@@ -8,4 +8,4 @@ public:
   explicit FrameNotFoundException(const std::string& frame_name) :
       invalid_argument("Frame with name " + frame_name + " is not in the robot model") {};
 };
-}
+}// namespace RobotModel::Exceptions

--- a/source/robot_model/include/robot_model/Exceptions/InvalidJointStateSizeException.hpp
+++ b/source/robot_model/include/robot_model/Exceptions/InvalidJointStateSizeException.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <exception>
+#include <iostream>
+
+namespace RobotModel {
+namespace Exceptions {
+class InvalidJointStateSizeException : public std::runtime_error {
+public:
+  explicit InvalidJointStateSizeException(unsigned int state_nb_joints, int robot_nb_joints)
+      : runtime_error("The robot has " + std::to_string(robot_nb_joints) + " joints, but the current joint state size "
+                          + std::to_string(state_nb_joints) + ".") {};
+};
+}// namespace Exceptions
+}// namespace RobotModel

--- a/source/robot_model/include/robot_model/Exceptions/InvalidJointStateSizeException.hpp
+++ b/source/robot_model/include/robot_model/Exceptions/InvalidJointStateSizeException.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
 #include <exception>
-#include <iostream>
 
-namespace RobotModel {
-namespace Exceptions {
-class InvalidJointStateSizeException : public std::runtime_error {
+namespace RobotModel::Exceptions {
+class InvalidJointStateSizeException : public std::invalid_argument {
 public:
-  explicit InvalidJointStateSizeException(unsigned int state_nb_joints, int robot_nb_joints)
-      : runtime_error("The robot has " + std::to_string(robot_nb_joints) + " joints, but the current joint state size "
-                          + std::to_string(state_nb_joints) + ".") {};
+  explicit InvalidJointStateSizeException(int state_nb_joints, int robot_nb_joints) :
+      invalid_argument("The robot has " + std::to_string(robot_nb_joints) + " joints, but the current joint state size "
+                           + std::to_string(state_nb_joints) + ".") {};
 };
-}// namespace Exceptions
-}// namespace RobotModel
+}

--- a/source/robot_model/include/robot_model/Exceptions/InvalidJointStateSizeException.hpp
+++ b/source/robot_model/include/robot_model/Exceptions/InvalidJointStateSizeException.hpp
@@ -5,8 +5,8 @@
 namespace RobotModel::Exceptions {
 class InvalidJointStateSizeException : public std::invalid_argument {
 public:
-  explicit InvalidJointStateSizeException(int state_nb_joints, int robot_nb_joints) :
+  explicit InvalidJointStateSizeException(unsigned int state_nb_joints, unsigned int robot_nb_joints) :
       invalid_argument("The robot has " + std::to_string(robot_nb_joints) + " joints, but the current joint state size "
                            + std::to_string(state_nb_joints) + ".") {};
 };
-}
+}// namespace RobotModel::Exceptions

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -5,6 +5,7 @@
 #include <pinocchio/algorithm/jacobian.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>
 #include <pinocchio/algorithm/kinematics.hpp>
+#include <pinocchio/algorithm/frames.hpp>
 #include <pinocchio/parsers/urdf.hpp>
 #include <pinocchio/spatial/explog.hpp>
 #include <state_representation/Parameters/Parameter.hpp>
@@ -27,17 +28,28 @@ private:
   std::vector<std::string> joint_names_;                                          ///< name of the joints in the model
   pinocchio::Model robot_model_;                                                  ///< the robot model with pinocchio
   pinocchio::Data robot_data_;                                                    ///< the robot data with pinocchio
-  OsqpEigen::Solver solver_;                                                      ///< osqp solver for the quadratic programming based inverse kinematics
-  Eigen::SparseMatrix<double> hessian_;                                           ///< hessian matrix for the quadratic programming based inverse kinematics
-  Eigen::VectorXd gradient_;                                                      ///< gradient vector for the quadratic programming based inverse kinematics
-  Eigen::SparseMatrix<double> constraint_matrix_;                                 ///< constraint matrix for the quadratic programming based inverse kinematics
-  Eigen::VectorXd lower_bound_constraints_;                                       ///< lower bound matrix for the quadratic programming based inverse kinematics
-  Eigen::VectorXd upper_bound_constraints_;                                       ///< upper bound matrix for the quadratic programming based inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>> alpha_;                 ///< gain for the time optimization in the quadratic programming based inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>> epsilon_;               ///< minimal time for the time optimization in the quadratic programming based inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>> linear_velocity_limit_; ///< maximum linear velocity allowed in the inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>> angular_velocity_limit_;///< maximum angular velocity allowed in the inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>> proportional_gain_;     ///< gain to weight the cartesian coordinates in the gradient
+  OsqpEigen::Solver
+      solver_;                                                      ///< osqp solver for the quadratic programming based inverse kinematics
+  Eigen::SparseMatrix<double>
+      hessian_;                                           ///< hessian matrix for the quadratic programming based inverse kinematics
+  Eigen::VectorXd
+      gradient_;                                                      ///< gradient vector for the quadratic programming based inverse kinematics
+  Eigen::SparseMatrix<double>
+      constraint_matrix_;                                 ///< constraint matrix for the quadratic programming based inverse kinematics
+  Eigen::VectorXd
+      lower_bound_constraints_;                                       ///< lower bound matrix for the quadratic programming based inverse kinematics
+  Eigen::VectorXd
+      upper_bound_constraints_;                                       ///< upper bound matrix for the quadratic programming based inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      alpha_;                 ///< gain for the time optimization in the quadratic programming based inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      epsilon_;               ///< minimal time for the time optimization in the quadratic programming based inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      linear_velocity_limit_; ///< maximum linear velocity allowed in the inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      angular_velocity_limit_;///< maximum angular velocity allowed in the inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      proportional_gain_;     ///< gain to weight the cartesian coordinates in the gradient
 
   /**
    * @brief initialize the constraints for the QP solver
@@ -109,38 +121,48 @@ public:
   void init_model();
 
   /**
-   * @brief Compute the jacobian from a given joint state at the joint level given in parameter
+   * @brief Compute the jacobian from a given joint state at the frame in parameter
    * @param joint_state containing the joint values of the robot
-   * @param joint_id id of the joint at which to compute the jacobian
+   * @param joint_id id of the frame at which to compute the jacobian
    * @return the jacobian matrix
    */
-  const StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state, unsigned int joint_id);
+  StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state, int frame_id);
 
   /**
-   * @brief Compute the jacobian from a given joint state at the joint level given in parameter
+   * @brief Compute the jacobian from a given joint state at the frame given in parameter
    * @param joint_state containing the joint values of the robot
-   * @param jonint_name name of the joint at which to compute the jacobian, if empty computed for the last joint
+   * @param jonint_name name of the frame at which to compute the jacobian, if empty computed for the last frame
    * @return the jacobian matrix
    */
-  const StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state, const std::string& frame_name = "");
+  StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state,
+                                                 const std::string& frame_name = "");
 
   /**
-   * @brief Compute the forward geometry, i.e. the pose of the end-effector from the joint values
+   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
    * @param joint_state the joint state of the robot
-   * @param joint_ids ids of the joint at wich we want to extract the pose
-   * @return the pose of the end-effector
+   * @param frame_ids ids of the frames at which we want to extract the pose
+   * @return the poses of the desired poses
    */
-  const std::vector<StateRepresentation::CartesianPose> forward_geometry(const StateRepresentation::JointState& joint_state,
-                                                                         const std::vector<unsigned int> joint_ids);
+  std::vector<StateRepresentation::CartesianPose> forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                                   const std::vector<unsigned int>& frame_ids);
 
   /**
-   * @brief Compute the forward geometry, i.e. the pose of the end-effector from the joint values
+   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
    * @param joint_state the joint state of the robot
-   * @param frame_names names of the frames at wich we want to extract the pose
-   * @return the pose of the end-effector
+   * @param frame_names names of the frames at which we want to extract the pose
+   * @return the pose of desired frames
    */
-  const std::vector<StateRepresentation::CartesianPose> forward_geometry(const StateRepresentation::JointState& joint_state,
-                                                                         const std::vector<std::string> frame_names);
+  std::vector<StateRepresentation::CartesianPose> forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                                   const std::vector<std::string>& frame_names);
+
+  /**
+ * @brief Compute the forward geometry, i.e. the pose of the frame from the joint values
+ * @param joint_state the joint state of the robot
+ * @param frame_name name of the frame at which we want to extract the pose
+ * @return the pose of the desired frame
+ */
+  StateRepresentation::CartesianPose forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                      const std::string& frame_names);
 
   /**
    * @brief Compute the inverse geometry, i.e. joint values from the pose of the end-effector
@@ -157,13 +179,13 @@ public:
   const StateRepresentation::CartesianTwist forward_kinematic(const StateRepresentation::JointState& joint_state);
 
   /**
-   * @brief Compute the inverse kinematic, i.e. joint velocities from the velocities of the frames in parameter
+   * @brief Compute the inverse kinematics, i.e. joint velocities from the velocities of the frames in parameter
    * @param joint_state usually the current joint state, used to compute the jacobian matrix
    * @param cartesian_states vector of twist
    * @return the joint velocities of the robot
    */
-  const StateRepresentation::JointVelocities inverse_kinematic(const StateRepresentation::JointState& joint_state,
-                                                               const std::vector<StateRepresentation::CartesianState>& cartesian_states);
+  StateRepresentation::JointVelocities inverse_kinematic(const StateRepresentation::JointState& joint_state,
+                                                         const std::vector<StateRepresentation::CartesianState>& cartesian_states);
 
   /**
    * @brief Compute the inverse kinematic, i.e. joint velocities from the twist of the end-effector
@@ -171,16 +193,8 @@ public:
    * @param cartesian_state containing the twist of the end-effector
    * @return the joint velocities of the robot
    */
-  const StateRepresentation::JointVelocities inverse_kinematic(const StateRepresentation::JointState& joint_state,
-                                                               const StateRepresentation::CartesianState& cartesian_state);
-
-  /**
-   * @brief Compute the inverse kinematic, i.e. joint velocities from the twist of the end-effector as Eigen vectors
-   * @param joint_positions current joint positions to compute the jacobian
-   * @param cartesian_twist the twist of the end-effector
-   * @return the joint velocities of the robot
-   */
-  const Eigen::VectorXd inverse_kinematic(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& cartesian_twist);
+  StateRepresentation::JointVelocities inverse_kinematic(const StateRepresentation::JointState& joint_state,
+                                                         const StateRepresentation::CartesianState& cartesian_state);
 
   /**
    * @brief Helper funtion to print the qp_problem (for debugging)
@@ -211,6 +225,7 @@ inline const std::vector<std::string>& Model::get_joint_names() const {
 }
 
 inline unsigned int Model::get_nb_joints() const {
+  // this is technically not correct
   return this->robot_model_.nv;
 }
 
@@ -220,7 +235,7 @@ inline void Model::init_model() {
   // get the joint names
   this->joint_names_ = this->robot_model_.names;
   // the first element is not a joint so remove it
-  this->joint_names_.erase(this->joint_names_.begin());
+//  this->joint_names_.erase(this->joint_names_.begin()); // dont erase this because the universe joint is everywhere
 }
 
 inline const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Model::get_parameters() const {

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -73,6 +73,12 @@ public:
   const std::string& get_robot_name() const;
 
   /**
+   * @brief Setter of the robot name
+   * @param robot_name the new value of the robot name
+   */
+  void set_robot_name(const std::string& robot_name);
+
+  /**
    * @brief Getter of the URDF path
    * @return the URDF path
    */
@@ -85,16 +91,10 @@ public:
   void set_urdf_path(const std::string& urdf_path);
 
   /**
-   * @brief Getter of the joint names attribute
-   * @return the vector of joint names
-   */
-  const std::vector<std::string>& get_joint_names() const;
-
-  /**
    * @brief Getter of the number of joints
    * @return the number of joints
    */
-  unsigned int get_nb_joints() const;
+  const int& get_nb_joints() const;
 
   /**
    * @brief Initialize the pinocchio model from the URDF
@@ -193,6 +193,10 @@ inline const std::string& Model::get_robot_name() const {
   return this->robot_name_->get_value();
 }
 
+inline void Model::set_robot_name(const std::string& robot_name) {
+  this->robot_name_->set_value(robot_name);
+}
+
 inline const std::string& Model::get_urdf_path() const {
   return this->urdf_path_->get_value();
 }
@@ -201,11 +205,7 @@ inline void Model::set_urdf_path(const std::string& urdf_path) {
   this->urdf_path_->set_value(urdf_path);
 }
 
-inline const std::vector<std::string>& Model::get_joint_names() const {
-  return this->joint_names_;
-}
-
-inline unsigned int Model::get_nb_joints() const {
+inline const int& Model::get_nb_joints() const {
   // this is technically not correct
   return this->robot_model_.nv;
 }

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -23,34 +23,23 @@
 namespace RobotModel {
 class Model {
 private:
+  // @format:off
   std::shared_ptr<StateRepresentation::Parameter<std::string>> robot_name_;       ///< name of the robot
   std::shared_ptr<StateRepresentation::Parameter<std::string>> urdf_path_;        ///< path to the urdf file
-  std::vector<std::string> joint_names_;                                          ///< name of the joints in the model
   pinocchio::Model robot_model_;                                                  ///< the robot model with pinocchio
   pinocchio::Data robot_data_;                                                    ///< the robot data with pinocchio
-  OsqpEigen::Solver
-      solver_;                                                      ///< osqp solver for the quadratic programming based inverse kinematics
-  Eigen::SparseMatrix<double>
-      hessian_;                                           ///< hessian matrix for the quadratic programming based inverse kinematics
-  Eigen::VectorXd
-      gradient_;                                                      ///< gradient vector for the quadratic programming based inverse kinematics
-  Eigen::SparseMatrix<double>
-      constraint_matrix_;                                 ///< constraint matrix for the quadratic programming based inverse kinematics
-  Eigen::VectorXd
-      lower_bound_constraints_;                                       ///< lower bound matrix for the quadratic programming based inverse kinematics
-  Eigen::VectorXd
-      upper_bound_constraints_;                                       ///< upper bound matrix for the quadratic programming based inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>>
-      alpha_;                 ///< gain for the time optimization in the quadratic programming based inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>>
-      epsilon_;               ///< minimal time for the time optimization in the quadratic programming based inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>>
-      linear_velocity_limit_; ///< maximum linear velocity allowed in the inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>>
-      angular_velocity_limit_;///< maximum angular velocity allowed in the inverse kinematics
-  std::shared_ptr<StateRepresentation::Parameter<double>>
-      proportional_gain_;     ///< gain to weight the cartesian coordinates in the gradient
-
+  OsqpEigen::Solver solver_;                                                      ///< osqp solver for the quadratic programming based inverse kinematics
+  Eigen::SparseMatrix<double> hessian_;                                           ///< hessian matrix for the quadratic programming based inverse kinematics
+  Eigen::VectorXd gradient_;                                                      ///< gradient vector for the quadratic programming based inverse kinematics
+  Eigen::SparseMatrix<double> constraint_matrix_;                                 ///< constraint matrix for the quadratic programming based inverse kinematics
+  Eigen::VectorXd lower_bound_constraints_;                                       ///< lower bound matrix for the quadratic programming based inverse kinematics
+  Eigen::VectorXd upper_bound_constraints_;                                       ///< upper bound matrix for the quadratic programming based inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>> alpha_;                 ///< gain for the time optimization in the quadratic programming based inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>> epsilon_;               ///< minimal time for the time optimization in the quadratic programming based inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>> linear_velocity_limit_; ///< maximum linear velocity allowed in the inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>> angular_velocity_limit_;///< maximum angular velocity allowed in the inverse kinematics
+  std::shared_ptr<StateRepresentation::Parameter<double>> proportional_gain_;     ///< gain to weight the cartesian coordinates in the gradient
+  // @format:on
   /**
    * @brief initialize the constraints for the QP solver
    */
@@ -247,4 +236,4 @@ inline const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>>
   param_list.push_back(this->proportional_gain_);
   return param_list;
 }
-}// namespace RobotModel
+}

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -94,7 +94,7 @@ public:
    * @brief Getter of the number of joints
    * @return the number of joints
    */
-  const int& get_nb_joints() const;
+  unsigned int get_nb_joints() const;
 
   /**
    * @brief Initialize the pinocchio model from the URDF
@@ -107,7 +107,8 @@ public:
    * @param joint_id id of the frame at which to compute the jacobian
    * @return the jacobian matrix
    */
-  StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state, int frame_id);
+  StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state,
+                                                 unsigned int frame_id);
 
   /**
    * @brief Compute the jacobian from a given joint state at the frame given in parameter
@@ -143,24 +144,24 @@ public:
  * @return the pose of the desired frame
  */
   StateRepresentation::CartesianPose forward_geometry(const StateRepresentation::JointState& joint_state,
-                                                      const std::string& frame_names);
+                                                      std::string frame_name = "");
 
   /**
    * @brief Compute the inverse geometry, i.e. joint values from the pose of the end-effector
    * @param cartesian_state containing the pose of the end-effector
    * @return the joint state of the robot
    */
-  const StateRepresentation::JointPositions inverse_geometry(const StateRepresentation::CartesianState& cartesian_state) const;
+  StateRepresentation::JointPositions inverse_geometry(const StateRepresentation::CartesianState& cartesian_state) const;
 
   /**
    * @brief Compute the forward kinematic, i.e. the twist of the end-effector from the joint velocities
    * @param joint_state the joint state of the robot
    * @return the twist of the end-effector
    */
-  const StateRepresentation::CartesianTwist forward_kinematic(const StateRepresentation::JointState& joint_state);
+  StateRepresentation::CartesianTwist forward_kinematic(const StateRepresentation::JointState& joint_state);
 
   /**
-   * @brief Compute the inverse kinematics, i.e. joint velocities from the velocities of the frames in parameter
+   * @brief Compute the inverse kinematic, i.e. joint velocities from the velocities of the frames in parameter
    * @param joint_state usually the current joint state, used to compute the jacobian matrix
    * @param cartesian_states vector of twist
    * @return the joint velocities of the robot
@@ -205,9 +206,9 @@ inline void Model::set_urdf_path(const std::string& urdf_path) {
   this->urdf_path_->set_value(urdf_path);
 }
 
-inline const int& Model::get_nb_joints() const {
-  // this is technically not correct
-  return this->robot_model_.nv;
+inline unsigned int Model::get_nb_joints() const {
+  // subtract 1 because of the 'universe' joint
+  return this->robot_model_.njoints - 1;
 }
 
 inline void Model::init_model() {
@@ -224,4 +225,4 @@ inline const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>>
   param_list.push_back(this->proportional_gain_);
   return param_list;
 }
-}
+}// namespace RobotModel

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -1,24 +1,16 @@
 #pragma once
 
-#include <OsqpEigen/OsqpEigen.h>
 #include <iostream>
-#include <pinocchio/algorithm/jacobian.hpp>
-#include <pinocchio/algorithm/joint-configuration.hpp>
-#include <pinocchio/algorithm/kinematics.hpp>
-#include <pinocchio/algorithm/frames.hpp>
+#include <string>
+#include <vector>
+#include <OsqpEigen/OsqpEigen.h>
 #include <pinocchio/parsers/urdf.hpp>
-#include <pinocchio/spatial/explog.hpp>
+#include <pinocchio/multibody/data.hpp>
 #include <state_representation/Parameters/Parameter.hpp>
 #include <state_representation/Parameters/ParameterInterface.hpp>
 #include <state_representation/Robot/Jacobian.hpp>
-#include <state_representation/Robot/JointPositions.hpp>
 #include <state_representation/Robot/JointState.hpp>
-#include <state_representation/Robot/JointVelocities.hpp>
-#include <state_representation/Space/Cartesian/CartesianPose.hpp>
 #include <state_representation/Space/Cartesian/CartesianState.hpp>
-#include <state_representation/Space/Cartesian/CartesianTwist.hpp>
-#include <string>
-#include <vector>
 
 namespace RobotModel {
 class Model {
@@ -52,7 +44,7 @@ public:
   explicit Model();
 
   /**
-   * @brief Constructor with path to URDF file
+   * @brief Constructor with robot name and path to URDF file
    */
   explicit Model(const std::string& robot_name, const std::string& urdf_path);
 
@@ -68,7 +60,7 @@ public:
   ~Model();
 
   /**
-   * @brief Copy assignement operator that have to be defined due to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined due to the custom assignment operator
    * @param model the model with value to assign
    * @return reference to the current model with new values
    */
@@ -120,7 +112,7 @@ public:
   /**
    * @brief Compute the jacobian from a given joint state at the frame given in parameter
    * @param joint_state containing the joint values of the robot
-   * @param jonint_name name of the frame at which to compute the jacobian, if empty computed for the last frame
+   * @param frame_name name of the frame at which to compute the jacobian, if empty computed for the last frame
    * @return the jacobian matrix
    */
   StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state,
@@ -221,10 +213,6 @@ inline unsigned int Model::get_nb_joints() const {
 inline void Model::init_model() {
   pinocchio::urdf::buildModel(this->get_urdf_path(), this->robot_model_);
   this->robot_data_ = pinocchio::Data(this->robot_model_);
-  // get the joint names
-  this->joint_names_ = this->robot_model_.names;
-  // the first element is not a joint so remove it
-//  this->joint_names_.erase(this->joint_names_.begin()); // dont erase this because the universe joint is everywhere
 }
 
 inline const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Model::get_parameters() const {

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -1,4 +1,7 @@
 #include "robot_model/Model.hpp"
+
+#include <pinocchio/algorithm/frames.hpp>
+
 #include "robot_model/Exceptions/FrameNotFoundException.hpp"
 #include "robot_model/Exceptions/InvalidJointStateSizeException.hpp"
 

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -121,7 +121,7 @@ bool Model::init_qp_solver() {
 StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
                                                       int frame_id) {
   if ((int) joint_state.get_size() != this->robot_model_.nq) {
-    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->robot_model_.nq));
+    throw (Exceptions::InvalidJointStateSizeException(static_cast<int>(joint_state.get_size()), this->robot_model_.nq));
   }
   // compute the jacobian from the joint state
   pinocchio::Data::Matrix6x J(6, this->robot_model_.nq);
@@ -149,7 +149,7 @@ StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation:
 std::vector<StateRepresentation::CartesianPose> Model::forward_geometry(const StateRepresentation::JointState& joint_state,
                                                                         const std::vector<unsigned int>& frame_ids) {
   if ((int) joint_state.get_size() != this->robot_model_.nq) {
-    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->robot_model_.nq));
+    throw (Exceptions::InvalidJointStateSizeException(static_cast<int>(joint_state.get_size()), this->robot_model_.nq));
   }
   std::vector<StateRepresentation::CartesianPose> pose_vector;
   pinocchio::forwardKinematics(this->robot_model_, this->robot_data_, joint_state.get_positions());

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -1,22 +1,44 @@
 #include "robot_model/Model.hpp"
 #include "robot_model/Exceptions/FrameNotFoundException.hpp"
+#include "robot_model/Exceptions/InvalidJointStateSizeException.hpp"
 
 namespace RobotModel {
 Model::Model() : robot_name_(std::make_shared<StateRepresentation::Parameter<std::string>>("robot_name")),
                  urdf_path_(std::make_shared<StateRepresentation::Parameter<std::string>>("urdf_path")),
                  alpha_(std::make_shared<StateRepresentation::Parameter<double>>("alpha", 0.1)),
                  epsilon_(std::make_shared<StateRepresentation::Parameter<double>>("epsilon", 1e-2)),
-                 linear_velocity_limit_(std::make_shared<StateRepresentation::Parameter<double>>("linear_velocity_limit", 2.0)),
-                 angular_velocity_limit_(std::make_shared<StateRepresentation::Parameter<double>>("angular_velocity_limit", 100.0)),
-                 proportional_gain_(std::make_shared<StateRepresentation::Parameter<double>>("proportional_gain", 1.0)) {}
+                 linear_velocity_limit_(std::make_shared<StateRepresentation::Parameter<double>>("linear_velocity_limit",
+                                                                                                 2.0)),
+                 angular_velocity_limit_(std::make_shared<StateRepresentation::Parameter<double>>(
+                     "angular_velocity_limit",
+                     100.0)),
+                 proportional_gain_(std::make_shared<StateRepresentation::Parameter<double>>("proportional_gain",
+                                                                                             1.0)) {}
 
-Model::Model(const std::string& robot_name, const std::string& urdf_path) : robot_name_(std::make_shared<StateRepresentation::Parameter<std::string>>("robot_name", robot_name)),
-                                                                            urdf_path_(std::make_shared<StateRepresentation::Parameter<std::string>>("urdf_path", urdf_path)),
-                                                                            alpha_(std::make_shared<StateRepresentation::Parameter<double>>("alpha", 0.1)),
-                                                                            epsilon_(std::make_shared<StateRepresentation::Parameter<double>>("epsilon", 1e-2)),
-                                                                            linear_velocity_limit_(std::make_shared<StateRepresentation::Parameter<double>>("linear_velocity_limit", 2.0)),
-                                                                            angular_velocity_limit_(std::make_shared<StateRepresentation::Parameter<double>>("angular_velocity_limit", 100.0)),
-                                                                            proportional_gain_(std::make_shared<StateRepresentation::Parameter<double>>("proportional_gain", 1.0)) {
+Model::Model(const std::string& robot_name, const std::string& urdf_path) : robot_name_(std::make_shared<
+    StateRepresentation::Parameter<std::string>>("robot_name", robot_name)),
+                                                                            urdf_path_(std::make_shared<
+                                                                                StateRepresentation::Parameter<std::string>>(
+                                                                                "urdf_path",
+                                                                                urdf_path)),
+                                                                            alpha_(std::make_shared<StateRepresentation::Parameter<
+                                                                                double>>("alpha", 0.1)),
+                                                                            epsilon_(std::make_shared<
+                                                                                StateRepresentation::Parameter<double>>(
+                                                                                "epsilon",
+                                                                                1e-2)),
+                                                                            linear_velocity_limit_(std::make_shared<
+                                                                                StateRepresentation::Parameter<double>>(
+                                                                                "linear_velocity_limit",
+                                                                                2.0)),
+                                                                            angular_velocity_limit_(std::make_shared<
+                                                                                StateRepresentation::Parameter<double>>(
+                                                                                "angular_velocity_limit",
+                                                                                100.0)),
+                                                                            proportional_gain_(std::make_shared<
+                                                                                StateRepresentation::Parameter<double>>(
+                                                                                "proportional_gain",
+                                                                                1.0)) {
   this->init_model();
   this->init_qp_solver();
 }
@@ -46,7 +68,7 @@ Model& Model::operator=(const Model& model) {
 }
 
 bool Model::init_qp_solver() {
-  size_t nb_joints = this->joint_names_.size();
+  size_t nb_joints = this->get_nb_joints();
   // initialize the matrices
   this->hessian_ = Eigen::SparseMatrix<double>(nb_joints + 1, nb_joints + 1);
   this->gradient_ = Eigen::VectorXd::Zero(nb_joints + 1);
@@ -102,67 +124,80 @@ bool Model::init_qp_solver() {
   // set the initial data of the QP solver_
   this->solver_.data()->setNumberOfVariables(nb_joints + 1);
   this->solver_.data()->setNumberOfConstraints(this->lower_bound_constraints_.size());
-  if (!this->solver_.data()->setHessianMatrix(this->hessian_)) return false;
-  if (!this->solver_.data()->setGradient(this->gradient_)) return false;
-  if (!this->solver_.data()->setLinearConstraintsMatrix(this->constraint_matrix_)) return false;
-  if (!this->solver_.data()->setLowerBound(this->lower_bound_constraints_)) return false;
-  if (!this->solver_.data()->setUpperBound(this->upper_bound_constraints_)) return false;
+  if (!this->solver_.data()->setHessianMatrix(this->hessian_)) { return false; }
+  if (!this->solver_.data()->setGradient(this->gradient_)) { return false; }
+  if (!this->solver_.data()->setLinearConstraintsMatrix(this->constraint_matrix_)) { return false; }
+  if (!this->solver_.data()->setLowerBound(this->lower_bound_constraints_)) { return false; }
+  if (!this->solver_.data()->setUpperBound(this->upper_bound_constraints_)) { return false; }
   // instantiate the solver_
   return this->solver_.initSolver();
 }
 
-const StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
-                                                            unsigned int joint_id) {
-  using namespace pinocchio;
+StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
+                                                      int frame_id) {
+  if ((int) joint_state.get_size() != this->robot_model_.nq) {
+    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->robot_model_.nq));
+  }
   // compute the jacobian from the joint state
-  Data::Matrix6x J(6, this->robot_model_.nv);
+  pinocchio::Data::Matrix6x J(6, this->robot_model_.nq);
   J.setZero();
-  computeJointJacobians(this->robot_model_, this->robot_data_, joint_state.get_positions());
-  getJointJacobian(this->robot_model_, this->robot_data_, joint_id, LOCAL_WORLD_ALIGNED, J);
+  pinocchio::computeFrameJacobian(this->robot_model_,
+                                  this->robot_data_,
+                                  joint_state.get_positions(),
+                                  frame_id,
+                                  pinocchio::LOCAL_WORLD_ALIGNED,
+                                  J);
   return StateRepresentation::Jacobian(this->get_robot_name(), J);
 }
 
-const StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
-                                                            const std::string& frame_name) {
-  using namespace pinocchio;
-  JointIndex joint_id;
-  if (frame_name == "") {
-    // get last joint if none specified
-    joint_id = this->robot_model_.nv;
+StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
+                                                      const std::string& frame_name) {
+  int frame_id;
+  if (frame_name.empty()) {
+    // get last frame if none specified
+    frame_id = this->robot_model_.getFrameId(this->robot_model_.frames.back().name);
   } else {
-    // throw error if specified joint does not exist
-    if (!this->robot_model_.existFrame(frame_name)) throw(Exceptions::FrameNotFoundException(frame_name));
-    // get the joint id and compute the jacobian at this joint
-    joint_id = this->robot_model_.frames[this->robot_model_.getFrameId(frame_name)].parent;
+    // throw error if specified frame does not exist
+    if (!this->robot_model_.existFrame(frame_name)) { throw (Exceptions::FrameNotFoundException(frame_name)); }
+    frame_id = this->robot_model_.getFrameId(frame_name);
   }
-  return this->compute_jacobian(joint_state, joint_id);
+  std::cout << frame_id << std::endl;
+  return this->compute_jacobian(joint_state, frame_id);
 }
 
-const std::vector<StateRepresentation::CartesianPose> Model::forward_geometry(const StateRepresentation::JointState& joint_state,
-                                                                              const std::vector<unsigned int> joint_ids) {
+std::vector<StateRepresentation::CartesianPose> Model::forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                                        const std::vector<unsigned int>& frame_ids) {
+  if ((int) joint_state.get_size() != this->robot_model_.nq) {
+    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->robot_model_.nq));
+  }
   std::vector<StateRepresentation::CartesianPose> pose_vector;
   pinocchio::forwardKinematics(this->robot_model_, this->robot_data_, joint_state.get_positions());
-  for (unsigned int id : joint_ids) {
-    pinocchio::JointIndex joint_id = id;
-    pinocchio::SE3 pose = this->robot_data_.oMi[joint_id];
+  for (unsigned int id : frame_ids) {
+    pinocchio::updateFramePlacement(this->robot_model_, this->robot_data_, id);
+    pinocchio::SE3 pose = this->robot_data_.oMf[id];
     Eigen::Vector3d translation = pose.translation();
     Eigen::Quaterniond quaternion;
     pinocchio::quaternion::assignQuaternion(quaternion, pose.rotation());
-    StateRepresentation::CartesianPose joint_pose(this->robot_model_.names[joint_id], translation, quaternion);
-    pose_vector.push_back(joint_pose);
+    StateRepresentation::CartesianPose frame_pose(this->robot_model_.frames[id].name, translation, quaternion);
+    pose_vector.push_back(frame_pose);
   }
   return pose_vector;
 }
 
-const std::vector<StateRepresentation::CartesianPose> Model::forward_geometry(const StateRepresentation::JointState& joint_state,
-                                                                              const std::vector<std::string> frame_names) {
-  std::vector<unsigned int> joint_ids(frame_names.size());
+std::vector<StateRepresentation::CartesianPose> Model::forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                                        const std::vector<std::string>& frame_names) {
+  std::vector<unsigned int> frame_ids(frame_names.size());
   for (std::size_t i = 0; i < frame_names.size(); ++i) {
     std::string name = frame_names[i];
-    if (!this->robot_model_.existFrame(name)) throw(Exceptions::FrameNotFoundException(name));
-    joint_ids[i] = this->robot_model_.frames[this->robot_model_.getFrameId(name)].parent;
+    if (!this->robot_model_.existFrame(name)) { throw (Exceptions::FrameNotFoundException(name)); }
+    frame_ids[i] = this->robot_model_.getFrameId(name);
   }
-  return this->forward_geometry(joint_state, joint_ids);
+  return this->forward_geometry(joint_state, frame_ids);
+}
+
+StateRepresentation::CartesianPose Model::forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                           const std::string& frame_name) {
+  return this->forward_geometry(joint_state, std::vector<std::string>{frame_name}).front();
 }
 
 const StateRepresentation::JointPositions Model::inverse_geometry(const StateRepresentation::CartesianState&) const {
@@ -174,8 +209,8 @@ const StateRepresentation::CartesianTwist Model::forward_kinematic(const StateRe
   return this->compute_jacobian(joint_state) * static_cast<StateRepresentation::JointVelocities>(joint_state);
 }
 
-const StateRepresentation::JointVelocities Model::inverse_kinematic(const StateRepresentation::JointState& joint_state,
-                                                                    const std::vector<StateRepresentation::CartesianState>& cartesian_states) {
+StateRepresentation::JointVelocities Model::inverse_kinematic(const StateRepresentation::JointState& joint_state,
+                                                              const std::vector<StateRepresentation::CartesianState>& cartesian_states) {
   const size_t nb_joints = this->get_nb_joints();
   using namespace StateRepresentation;
   // the velocity vector contains position of the intermediate frame and full pose of the end-effector
@@ -186,7 +221,8 @@ const StateRepresentation::JointVelocities Model::inverse_kinematic(const StateR
     CartesianState state = cartesian_states[i];
     // extract only the position for intermediate points
     delta_r.segment<3>(3 * i) = state.get_linear_velocity();
-    jacobian.block(3 * i, 0, 3 * i + 3, nb_joints) = this->compute_jacobian(joint_state, state.get_name()).get_data().block(0, 0, 3, nb_joints);
+    jacobian.block(3 * i, 0, 3 * i + 3, nb_joints) =
+        this->compute_jacobian(joint_state, state.get_name()).get_data().block(0, 0, 3, nb_joints);
   }
   // extract the orientation for the end-effector
   CartesianState state = cartesian_states.back();
@@ -203,7 +239,9 @@ const StateRepresentation::JointVelocities Model::inverse_kinematic(const StateR
       coefficients.push_back(Eigen::Triplet<double>(static_cast<int>(i), static_cast<int>(j), hessian_matrix(i, j)));
     }
   }
-  coefficients.push_back(Eigen::Triplet<double>(static_cast<int>(nb_joints), static_cast<int>(nb_joints), this->alpha_->get_value()));
+  coefficients.push_back(Eigen::Triplet<double>(static_cast<int>(nb_joints),
+                                                static_cast<int>(nb_joints),
+                                                this->alpha_->get_value()));
   this->hessian_.setFromTriplets(coefficients.begin(), coefficients.end());
 
   //set the gradient
@@ -231,19 +269,9 @@ const StateRepresentation::JointVelocities Model::inverse_kinematic(const StateR
   return result;
 }
 
-const StateRepresentation::JointVelocities Model::inverse_kinematic(const StateRepresentation::JointState& joint_state,
-                                                                    const StateRepresentation::CartesianState& cartesian_state) {
+StateRepresentation::JointVelocities Model::inverse_kinematic(const StateRepresentation::JointState& joint_state,
+                                                              const StateRepresentation::CartesianState& cartesian_state) {
   return this->inverse_kinematic(joint_state, std::vector<StateRepresentation::CartesianState>({cartesian_state}));
-}
-
-const Eigen::VectorXd Model::inverse_kinematic(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& cartesian_twist) {
-  StateRepresentation::JointState joint_state(this->get_robot_name(), this->get_joint_names());
-  joint_state.set_positions(joint_positions);
-  StateRepresentation::CartesianTwist twist(this->get_robot_name());
-  twist.set_twist(cartesian_twist);
-  // compute the IK
-  StateRepresentation::JointVelocities result = this->inverse_kinematic(joint_state, twist);
-  return result.get_velocities();
 }
 
 void Model::print_qp_problem() {


### PR DESCRIPTION
As discussed, we have to use different methods of pinocchio if we want to compute kinematics of fixed frames and not just joints. This is the implementation of this feature with minimal changes.

I have a few suggestions that could eventually lead to a refactoring of the robot_model lib but we should discuss that first. For example, I still don't fully agree with function nomenclature (forward_geometry is forward_kinematics in my opinion).

Also added a few other comments. The immediate next step would be to add some unit testing. Let me know what you think.