### PR TITLE
Remove slash from volume name in toplevel run

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 MULTISTAGE_TARGET="development"
 
-NAME=$(echo "${PWD##*/}" | tr _ -)/$MULTISTAGE_TARGET
+NAME=$(echo "${PWD##*/}" | tr _ -)/"${MULTISTAGE_TARGET}"
 TAG=$(echo "$1" | tr _/ -)
 
 ISISOLATED=true # change to  false to use host network
@@ -16,12 +16,14 @@ if [ -z "$TAG" ]; then
     TAG="latest"
 fi
 
+VOLUME_NAME=$(echo "${NAME}_lib_vol" | tr / -)
+
 #create a shared volume to store the lib folder
 docker volume create --driver local \
     --opt type="none" \
     --opt device="${PWD}/source/" \
     --opt o="bind" \
-    "${NAME}_lib_vol"
+    "${VOLUME_NAME}"
 
 xhost +
 docker run \
@@ -29,5 +31,5 @@ docker run \
     --net="${NETWORK}" \
     -it \
     --rm \
-    --volume="${NAME}_lib_vol:/home/udev/control_lib/:rw" \
+    --volume="${VOLUME_NAME}:/home/udev/control_lib/:rw" \
     "${NAME}:${TAG}"


### PR DESCRIPTION
There was an issue introduced by the last PR that added the multistage target to the image name with a slash separator. The attempt to create a volume fails when there is a slash in the name.

Because slashes in image names are very common, they should be stripped when creating a volume.

The way we handle image names, tags and volumes in scripts is quite brittle overall.
