### PR TITLE
Refactor/state representation

### DIFF
--- a/source/dynamical_systems/install.sh
+++ b/source/dynamical_systems/install.sh
@@ -7,7 +7,7 @@ apt-get update && apt-get install -y \
 
 # install googletest
 mkdir ${SOURCE_PATH}/lib
-cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
+cd ${SOURCE_PATH}/lib && git clone --depth 1 --branch v1.10.x https://github.com/google/googletest.git
 
 # install dynamical_systems
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install

--- a/source/robot_model/install.sh
+++ b/source/robot_model/install.sh
@@ -10,7 +10,7 @@ apt-get update && apt-get install -y \
 
 # install googletest
 mkdir ${SOURCE_PATH}/lib
-cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
+cd ${SOURCE_PATH}/lib && git clone --depth 1 --branch v1.10.x https://github.com/google/googletest.git
 
 # install pinocchio
 echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
@@ -8,209 +8,226 @@
 #include "state_representation/Space/Cartesian/CartesianState.hpp"
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 
+namespace StateRepresentation {
+class CartesianTwist;
 
-namespace StateRepresentation 
-{
-	class CartesianTwist;
-	
-	/**
-	 * @class CartesianPose
-	 * @brief Class to define CartesianPose in cartesian space as 3D position and quaternion based orientation
-	 */
-	class CartesianPose: public CartesianState
-	{
-	public:
-		/**
-		 * Empty constructor
-		 */
-		explicit CartesianPose();
+/**
+ * @class CartesianPose
+ * @brief Class to define CartesianPose in cartesian space as 3D position and quaternion based orientation
+ */
+class CartesianPose : public CartesianState {
+public:
+  /**
+   * Empty constructor
+   */
+  explicit CartesianPose();
 
-		/**
-	 	 * @brief Constructor with name and reference frame provided
-	 	 * @param name the name of the state
-	 	 * @param reference the name of the reference frame
-	     */
-		explicit CartesianPose(const std::string& name, const std::string& reference="world");
+  /**
+   * @brief Constructor with name and reference frame provided
+   * @param name the name of the state
+   * @param reference the name of the reference frame
+   */
+  explicit CartesianPose(const std::string& name, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Copy constructor
-	     */
-		CartesianPose(const CartesianPose& pose);
+  /**
+   * @brief Copy constructor
+   */
+  CartesianPose(const CartesianPose& pose);
 
-		/**
-	 	 * @brief Copy constructor from a CartesianState
-	     */
-		CartesianPose(const CartesianState& state);
+  /**
+   * @brief Copy constructor from a CartesianState
+   */
+  CartesianPose(const CartesianState& state);
 
-		/**
-	 	 * @brief Copy constructor from a CartesianTwist by considering that it is a displacement over 1 second
-	     */
-		CartesianPose(const CartesianTwist& twist);
-		
-		/**
-	 	 * @brief Construct a CartesianPose from a position given as a vector of coordinates.
-	     */
-		explicit CartesianPose(const std::string& name, const Eigen::Vector3d& position, const std::string& reference="world");
+  /**
+   * @brief Copy constructor from a CartesianTwist by considering that it is a displacement over 1 second
+   */
+  CartesianPose(const CartesianTwist& twist);
 
-		/**
-	 	 * @brief Construct a CartesianPose from a position given as three scalar coordinates.
-	     */
-		explicit CartesianPose(const std::string& name, const double& x, const double& y, const double& z, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianPose from a position given as a vector of coordinates.
+   */
+  explicit CartesianPose(const std::string& name, const Eigen::Vector3d& position, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Construct a CartesianPose from a position given as a vector of coordinates and a quaternion.
-	     */
-		explicit CartesianPose(const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianPose from a position given as three scalar coordinates.
+   */
+  explicit CartesianPose(const std::string& name, const double& x, const double& y, const double& z, const std::string& reference = "world");
 
-		/**
-		 * @brief Constructor for the identity pose
-		 * @param name the name of the state
-		 * @param the name of the reference frame
-		 * @return CartesianPose identity pose
-		 */
-		static const CartesianPose Identity(const std::string& name, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianPose from a position given as a vector of coordinates and a quaternion.
+   */
+  explicit CartesianPose(const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation, const std::string& reference = "world");
 
-		/**
-		 * @brief Constructor for a random pose
-		 * @param name the name of the state
-		 * @param the name of the reference frame
-		 * @return CartesianPose random pose
-		 */
-		static const CartesianPose Random(const std::string& name, const std::string& reference="world");
+  /**
+   * @brief Constructor for the identity pose
+   * @param name the name of the state
+   * @param the name of the reference frame
+   * @return CartesianPose identity pose
+   */
+  static const CartesianPose Identity(const std::string& name, const std::string& reference = "world");
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param pose the pose with value to assign
-		 * @return reference to the current pose with new values
-		 */
-		CartesianPose& operator=(const CartesianPose& pose);
+  /**
+   * @brief Constructor for a random pose
+   * @param name the name of the state
+   * @param the name of the reference frame
+   * @return CartesianPose random pose
+   */
+  static const CartesianPose Random(const std::string& name, const std::string& reference = "world");
 
-		/**
-		 * @brief Set the values of the 6D pose from a 7D Eigen Vector (3 for position, 4 for quaternion)
-		 * @param pose the pose as an Eigen Vector
-		 */
-		CartesianPose& operator=(const Eigen::Matrix<double, 7, 1>& pose);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param pose the pose with value to assign
+   * @return reference to the current pose with new values
+   */
+  CartesianPose& operator=(const CartesianPose& pose);
 
-		/**
-		 * @brief Set the values of the 6D pose from a 7D std vector (3 for position, 4 for quaternion)
-		 * @param pose the pose as an Eigen Vector
-		 */
-		CartesianPose& operator=(const std::vector<double>& pose);
+  /**
+   * @brief Copy assignement operator from a state
+   * @param state the state with value to assign
+   * @return reference to the current pose with new values
+   */
+  CartesianPose& operator=(const CartesianState& state);
 
-		/**
-	 	 * @brief Overload the *= operator
-	 	 * @param pose CartesianPose to multiply with
-	 	 * @return the current CartesianPose multiply by the CartesianPose given in argument
-	     */
-		CartesianPose& operator*=(const CartesianPose& pose);
+  /**
+   * @brief Set the values of the 6D pose from a 7D Eigen Vector (3 for position, 4 for quaternion)
+   * @param pose the pose as an Eigen Vector
+   */
+  CartesianPose& operator=(const Eigen::Matrix<double, 7, 1>& pose);
 
-		/**
-	 	 * @brief Overload the * operator
-	 	 * @param pose CartesianPose to multiply with
-	 	 * @return the current CartesianPose multiply by the CartesianPose given in argument
-	     */
-		const CartesianPose operator*(const CartesianPose& pose) const;
+  /**
+   * @brief Set the values of the 6D pose from a 7D std vector (3 for position, 4 for quaternion)
+   * @param pose the pose as an Eigen Vector
+   */
+  CartesianPose& operator=(const std::vector<double>& pose);
 
-		/**
-	 	 * @brief Overload the * operator
-	 	 * @param pose CartesianPose to multiply with
-	 	 * @return the current CartesianPose multiply by the CartesianPose given in argument
-	     */
-		const CartesianState operator*(const CartesianState& state) const;
+  /**
+   * @brief Overload the * operator for a vector input
+   * @param vector vector to multiply with, representing either a position, velocity or acceleration
+   * @return the vector multiplied by the current CartesianPose
+   */
+  const Eigen::Vector3d operator*(const Eigen::Vector3d& vector) const;
 
-		/**
-	 	 * @brief Overload the * operator for a vector input
-	 	 * @param vector vector to multiply with, representing either a position, velocity or acceleration
-	 	 * @return the vector multiplied by the current CartesianPose
-	     */
-		const Eigen::Vector3d operator*(const Eigen::Vector3d& vector) const;
+  /**
+   * @brief Overload the *= operator
+   * @param pose CartesianPose to multiply with
+   * @return the current CartesianPose multiplied by the CartesianPose given in argument
+   */
+  CartesianPose& operator*=(const CartesianPose& pose);
 
-		/**
-	 	 * @brief Overload the += operator
-	 	 * @param pose CartesianPose to add
-	 	 * @return the current CartesianPose added the CartesianPose given in argument
-	     */
-		CartesianPose& operator+=(const CartesianPose& pose);
+  /**
+   * @brief Overload the * operator
+   * @param pose CartesianPose to multiply with
+   * @return the current CartesianPose multiplied by the CartesianPose given in argument
+   */
+  const CartesianPose operator*(const CartesianPose& pose) const;
 
-		/**
-	 	 * @brief Overload the + operator
-	 	 * @param pose CartesianPose to add
-	 	 * @return the current CartesianPose added the CartesianPose given in argument
-	     */
-		const CartesianPose operator+(const CartesianPose& pose) const;
+  /**
+   * @brief Overload the * operator
+   * @param pose CartesianPose to multiply with
+   * @return the current CartesianPose multiplied by the CartesianPose given in argument
+   */
+  const CartesianState operator*(const CartesianState& state) const;
 
-		/**
-	 	 * @brief Overload the -= operator
-	 	 * @param pose CartesianPose to substract
-	 	 * @return the current CartesianPose minus the CartesianPose given in argument
-	     */
-		CartesianPose& operator-=(const CartesianPose& pose);
+  /**
+   * @brief Overload the *= operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianPose multiplied by lambda
+   */
+  CartesianPose& operator*=(double lambda);
 
-		/**
-	 	 * @brief Overload the - operator
-	 	 * @param pose CartesianPose to substract
-	 	 * @return the current CartesianPose minus the CartesianPose given in argument
-	     */
-		const CartesianPose operator-(const CartesianPose& pose) const;
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianState multiplied by lambda
+   */
+  const CartesianPose operator*(double lambda) const;
 
-		/**
-	 	 * @brief Overload the *= operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianPose multiply by lambda
-	     */
-		CartesianPose& operator*=(double lambda);
+  /**
+   * @brief Overload the += operator
+   * @param pose CartesianPose to add to
+   * @return the current CartesianPose added the CartesianPose given in argument
+   */
+  CartesianPose& operator+=(const CartesianPose& pose);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianPose multiply by lambda
-	     */
-		const CartesianPose operator*(double lambda) const;
+  /**
+   * @brief Overload the + operator with a pose
+   * @param pose CartesianPose to add to
+   * @return the current CartesianPose added the CartesianPose given in argument
+   */
+  const CartesianPose operator+(const CartesianPose& pose) const;
 
-		/**
-		 * @brief Return a copy of the CartesianPose
-		 * @return the copy
-		 */
-		const CartesianPose copy() const;
+  /**
+   * @brief Overload the + operator with a state
+   * @param state CartesianState to add
+   * @return the current CartesianPose added the CartesianState given in argument
+   */
+  const CartesianState operator+(const CartesianState& state) const;
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to happend the string representing the CartesianPose to
-	 	 * @param CartesianPose the CartesianPose to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const CartesianPose& pose);
+  /**
+   * @brief Overload the -= operator
+   * @param pose CartesianPose to substract
+   * @return the current CartesianPose minus the CartesianPose given in argument
+   */
+  CartesianPose& operator-=(const CartesianPose& pose);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianPose provided multiply by lambda
-	     */
-		friend const CartesianPose operator*(double lambda, const CartesianPose& pose);
+  /**
+   * @brief Overload the - operator with a pose
+   * @param pose CartesianPose to substract
+   * @return the current CartesianPose minus the CartesianPose given in argument
+   */
+  const CartesianPose operator-(const CartesianPose& pose) const;
 
-		/**
-	 	 * @brief Overload the / operator with a time period
-	 	 * @param dt the time period to divise by
-	 	 * @return the corresponding CartesianTwist
-	     */
-		friend const CartesianTwist operator/(const CartesianPose& pose, const std::chrono::nanoseconds& dt);
+  /**
+   * @brief Overload the - operator with a state
+   * @param state CartesianState to substract
+   * @return the current CartesianPose minus the CartesianState given in argument
+   */
+  const CartesianState operator-(const CartesianState& state) const;
 
-		/**
-		 * @brief Return the pose as a std vector of floats
-		 * @return std::vector<float> the pose vector as a 7 elements vector
-		 */
-		const std::vector<double> to_std_vector() const override;
+  /**
+   * @brief Return a copy of the CartesianPose
+   * @return the copy
+   */
+  const CartesianPose copy() const;
 
-		/**
-		 * @brief Set the value from a std vector
-		 * @param value the value as a std vector
-		 */
-		void from_std_vector(const std::vector<double>& value);
-	};
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to happend the string representing the CartesianPose to
+   * @param CartesianPose the CartesianPose to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const CartesianPose& pose);
 
-	inline CartesianPose& CartesianPose::operator=(const CartesianPose& pose)
-	{
-		CartesianState::operator=(pose);
-		return (*this);
-	}
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianPose provided multiply by lambda
+   */
+  friend const CartesianPose operator*(double lambda, const CartesianPose& pose);
+
+  /**
+   * @brief Overload the / operator with a time period
+   * @param dt the time period to divise by
+   * @return the corresponding CartesianTwist
+   */
+  friend const CartesianTwist operator/(const CartesianPose& pose, const std::chrono::nanoseconds& dt);
+
+  /**
+   * @brief Return the pose as a std vector of floats
+   * @return std::vector<float> the pose vector as a 7 elements vector
+   */
+  const std::vector<double> to_std_vector() const override;
+
+  /**
+   * @brief Set the value from a std vector
+   * @param value the value as a std vector
+   */
+  void from_std_vector(const std::vector<double>& value);
+};
+
+inline CartesianPose& CartesianPose::operator=(const CartesianPose& pose) {
+  CartesianState::operator=(pose);
+  return (*this);
 }
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
@@ -65,7 +65,7 @@ public:
    * @param the name of the reference frame
    * @return CartesianPose identity pose
    */
-  static const CartesianPose Identity(const std::string& name, const std::string& reference = "world");
+  static CartesianPose Identity(const std::string& name, const std::string& reference = "world");
 
   /**
    * @brief Constructor for a random pose
@@ -73,7 +73,7 @@ public:
    * @param the name of the reference frame
    * @return CartesianPose random pose
    */
-  static const CartesianPose Random(const std::string& name, const std::string& reference = "world");
+  static CartesianPose Random(const std::string& name, const std::string& reference = "world");
 
   /**
    * @brief Copy assignement operator that have to be defined to the custom assignement operator
@@ -90,23 +90,11 @@ public:
   CartesianPose& operator=(const CartesianState& state);
 
   /**
-   * @brief Set the values of the 6D pose from a 7D Eigen Vector (3 for position, 4 for quaternion)
-   * @param pose the pose as an Eigen Vector
-   */
-  CartesianPose& operator=(const Eigen::Matrix<double, 7, 1>& pose);
-
-  /**
-   * @brief Set the values of the 6D pose from a 7D std vector (3 for position, 4 for quaternion)
-   * @param pose the pose as an Eigen Vector
-   */
-  CartesianPose& operator=(const std::vector<double>& pose);
-
-  /**
    * @brief Overload the * operator for a vector input
    * @param vector vector to multiply with, representing either a position, velocity or acceleration
    * @return the vector multiplied by the current CartesianPose
    */
-  const Eigen::Vector3d operator*(const Eigen::Vector3d& vector) const;
+  Eigen::Vector3d operator*(const Eigen::Vector3d& vector) const;
 
   /**
    * @brief Overload the *= operator
@@ -120,14 +108,7 @@ public:
    * @param pose CartesianPose to multiply with
    * @return the current CartesianPose multiplied by the CartesianPose given in argument
    */
-  const CartesianPose operator*(const CartesianPose& pose) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param pose CartesianPose to multiply with
-   * @return the current CartesianPose multiplied by the CartesianPose given in argument
-   */
-  const CartesianState operator*(const CartesianState& state) const;
+  CartesianPose operator*(const CartesianPose& pose) const;
 
   /**
    * @brief Overload the *= operator with a scalar
@@ -141,7 +122,7 @@ public:
    * @param lambda the scalar to multiply with
    * @return the CartesianState multiplied by lambda
    */
-  const CartesianPose operator*(double lambda) const;
+  CartesianPose operator*(double lambda) const;
 
   /**
    * @brief Overload the += operator
@@ -155,14 +136,14 @@ public:
    * @param pose CartesianPose to add to
    * @return the current CartesianPose added the CartesianPose given in argument
    */
-  const CartesianPose operator+(const CartesianPose& pose) const;
+  CartesianPose operator+(const CartesianPose& pose) const;
 
   /**
    * @brief Overload the + operator with a state
    * @param state CartesianState to add
    * @return the current CartesianPose added the CartesianState given in argument
    */
-  const CartesianState operator+(const CartesianState& state) const;
+  CartesianState operator+(const CartesianState& state) const;
 
   /**
    * @brief Overload the -= operator
@@ -176,20 +157,27 @@ public:
    * @param pose CartesianPose to substract
    * @return the current CartesianPose minus the CartesianPose given in argument
    */
-  const CartesianPose operator-(const CartesianPose& pose) const;
+  CartesianPose operator-(const CartesianPose& pose) const;
 
   /**
    * @brief Overload the - operator with a state
    * @param state CartesianState to substract
    * @return the current CartesianPose minus the CartesianState given in argument
    */
-  const CartesianState operator-(const CartesianState& state) const;
+  CartesianState operator-(const CartesianState& state) const;
+
+  /**
+   * @brief Overload the / operator with a time period
+   * @param dt the time period to divise by
+   * @return the corresponding CartesianTwist
+   */
+  CartesianTwist operator/(const std::chrono::nanoseconds& dt) const;
 
   /**
    * @brief Return a copy of the CartesianPose
    * @return the copy
    */
-  const CartesianPose copy() const;
+  CartesianPose copy() const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -204,20 +192,13 @@ public:
    * @param lambda the scalar to multiply with
    * @return the CartesianPose provided multiply by lambda
    */
-  friend const CartesianPose operator*(double lambda, const CartesianPose& pose);
-
-  /**
-   * @brief Overload the / operator with a time period
-   * @param dt the time period to divise by
-   * @return the corresponding CartesianTwist
-   */
-  friend const CartesianTwist operator/(const CartesianPose& pose, const std::chrono::nanoseconds& dt);
+  friend CartesianPose operator*(double lambda, const CartesianPose& pose);
 
   /**
    * @brief Return the pose as a std vector of floats
    * @return std::vector<float> the pose vector as a 7 elements vector
    */
-  const std::vector<double> to_std_vector() const override;
+  std::vector<double> to_std_vector() const override;
 
   /**
    * @brief Set the value from a std vector

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -97,7 +97,7 @@ protected:
    * @param state_variable_type the type of variable to get
    * @return the value of the variable as a vector
    */
-  const Eigen::VectorXd get_state_variable(const CartesianStateVariable& state_variable_type) const;
+  Eigen::VectorXd get_state_variable(const CartesianStateVariable& state_variable_type) const;
 
   /**
    * @brief Setter of the variable value corresponding to the input
@@ -145,20 +145,20 @@ public:
    * @brief Getter of the orientation attribute as Vector4d of coefficients.
    * Beware, quaternion coefficients are returned using the (w, x, y, z) convention
    */
-  const Eigen::Vector4d get_orientation_coefficients() const;
+  Eigen::Vector4d get_orientation_coefficients() const;
 
   /**
    * @brief Getter of a pose from position and orientation attributes
    * @return the pose as a 7d vector. Beware, quaternion coefficients are
    * returned using the (w, x, y, z) convention
    */
-  const Eigen::Matrix<double, 7, 1> get_pose() const;
+  Eigen::Matrix<double, 7, 1> get_pose() const;
 
   /**
    * @brief Getter of a pose from position and orientation attributes
    * @return the pose as a 4x4 transformation matrix
    */
-  const Eigen::Matrix4d get_transformation_matrix() const;
+  Eigen::Matrix4d get_transformation_matrix() const;
 
   /**
    * @brief Getter of the linear velocity attribute 
@@ -173,7 +173,7 @@ public:
   /**
    * @brief Getter of a twist from linear and angular velocities attribute
    */
-  const Eigen::Matrix<double, 6, 1> get_twist() const;
+  Eigen::Matrix<double, 6, 1> get_twist() const;
 
   /**
    * @brief Getter of the linear acceleration attribute 
@@ -188,7 +188,7 @@ public:
   /**
    * @brief Getter of accelerations from linear and angular accelerations attribute
    */
-  const Eigen::Matrix<double, 6, 1> get_accelerations() const;
+  Eigen::Matrix<double, 6, 1> get_accelerations() const;
 
   /**
    * @brief Getter of the force attribute
@@ -203,7 +203,7 @@ public:
   /**
    * @brief Getter of a wrench from force and torque attributes
    */
-  const Eigen::Matrix<double, 6, 1> get_wrench() const;
+  Eigen::Matrix<double, 6, 1> get_wrench() const;
 
   /**
    * @brief Setter of the position
@@ -328,7 +328,7 @@ public:
    * @brief Return a copy of the CartesianState
    * @return the copy
    */
-  const CartesianState copy() const;
+  CartesianState copy() const;
 
   /**
    * @brief Overload the *= operator with another state by deriving the equations of motions
@@ -342,7 +342,7 @@ public:
    * @param state the state to compose with corresponding to b_S_c
    * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
    */
-  const CartesianState operator*(const CartesianState& state) const;
+  CartesianState operator*(const CartesianState& state) const;
 
   /**
    * @brief Overload the *= operator with a scalar
@@ -356,7 +356,7 @@ public:
    * @param lambda the scalar to multiply with
    * @return the CartesianState multiplied by lambda
    */
-  const CartesianState operator*(double lambda) const;
+  CartesianState operator*(double lambda) const;
 
   /**
    * @brief Overload the += operator
@@ -370,7 +370,7 @@ public:
    * @param state CartesianState to add
    * @return the current CartesianState added the CartesianState given in argument
    */
-  const CartesianState operator+(const CartesianState& state) const;
+  CartesianState operator+(const CartesianState& state) const;
 
   /**
    * @brief Overload the -= operator
@@ -384,13 +384,13 @@ public:
    * @param state CartesianState to substract
    * @return the current CartesianState minus the CartesianState given in argument
    */
-  const CartesianState operator-(const CartesianState& state) const;
+  CartesianState operator-(const CartesianState& state) const;
 
   /**
    * @brief compute the inverse of the current CartesianState
    * @return the inverse corresponding to b_S_f (assuming this is f_S_b) 
    */
-  const CartesianState inverse() const;
+  CartesianState inverse() const;
 
   /**
    * @brief Compute the distance between two states as the sum of distances between each features
@@ -414,7 +414,7 @@ public:
    * @param lambda the scalar to multiply with
    * @return the CartesianState provided multiply by lambda
    */
-  friend const CartesianState operator*(double lambda, const CartesianState& state);
+  friend CartesianState operator*(double lambda, const CartesianState& state);
 
   /**
    * @brief compute the distance between two CartesianStates
@@ -430,7 +430,7 @@ public:
    * @brief Return the state as a std vector of floats
    * @return std::vector<float> the state vector as a std vector
    */
-  virtual const std::vector<double> to_std_vector() const;
+  virtual std::vector<double> to_std_vector() const;
 
   /**
    * @brief Set the value from a std vector
@@ -456,17 +456,17 @@ inline const Eigen::Quaterniond& CartesianState::get_orientation() const {
   return this->orientation;
 }
 
-inline const Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
+inline Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
   return Eigen::Vector4d(this->get_orientation().w(), this->get_orientation().x(), this->get_orientation().y(), this->get_orientation().z());
 }
 
-inline const Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {
+inline Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {
   Eigen::Matrix<double, 7, 1> pose;
   pose << this->get_position(), this->get_orientation_coefficients();
   return pose;
 }
 
-inline const Eigen::Matrix4d CartesianState::get_transformation_matrix() const {
+inline Eigen::Matrix4d CartesianState::get_transformation_matrix() const {
   Eigen::Matrix4d pose;
   pose << this->orientation.toRotationMatrix(), this->position, 0., 0., 0., 1;
   return pose;
@@ -480,7 +480,7 @@ inline const Eigen::Vector3d& CartesianState::get_angular_velocity() const {
   return this->angular_velocity;
 }
 
-inline const Eigen::Matrix<double, 6, 1> CartesianState::get_twist() const {
+inline Eigen::Matrix<double, 6, 1> CartesianState::get_twist() const {
   Eigen::Matrix<double, 6, 1> twist;
   twist << this->get_linear_velocity(), this->get_angular_velocity();
   return twist;
@@ -494,7 +494,7 @@ inline const Eigen::Vector3d& CartesianState::get_angular_acceleration() const {
   return this->angular_acceleration;
 }
 
-inline const Eigen::Matrix<double, 6, 1> CartesianState::get_accelerations() const {
+inline Eigen::Matrix<double, 6, 1> CartesianState::get_accelerations() const {
   Eigen::Matrix<double, 6, 1> accelerations;
   accelerations << this->get_linear_acceleration(), this->get_angular_acceleration();
   return accelerations;
@@ -508,13 +508,13 @@ inline const Eigen::Vector3d& CartesianState::get_torque() const {
   return this->torque;
 }
 
-inline const Eigen::Matrix<double, 6, 1> CartesianState::get_wrench() const {
+inline Eigen::Matrix<double, 6, 1> CartesianState::get_wrench() const {
   Eigen::Matrix<double, 6, 1> wrench;
   wrench << this->get_force(), this->get_torque();
   return wrench;
 }
 
-inline const Eigen::VectorXd CartesianState::get_state_variable(const CartesianStateVariable& state_variable_type) const {
+inline Eigen::VectorXd CartesianState::get_state_variable(const CartesianStateVariable& state_variable_type) const {
   switch (state_variable_type) {
     case CartesianStateVariable::POSITION:
       return this->get_position();

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -5,476 +5,517 @@
 
 #pragma once
 
-#include <vector>
+#include "state_representation/Exceptions/IncompatibleSizeException.hpp"
+#include "state_representation/Space/SpatialState.hpp"
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
 #include <iostream>
-#include "state_representation/Space/SpatialState.hpp"
-#include "state_representation/Exceptions/IncompatibleSizeException.hpp"
-
-namespace StateRepresentation
-{
-	class CartesianState;
-
-	/**
-	 * @brief compute the distance between two CartesianStates
-	 * @param s1 the first CartesianState
-	 * @param s2 the second CartesianState
-	 * @param type of the distance between position, orientation, linear_velocity, etc...
-	 * default all for full distance across all dimensions
-	 * @return the distance beteen the two states
-	 */
-	double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type="all");
-
-	/**
-	 * @class CartesianState
-	 * @brief Class to represent a state in Cartesian space
-	 */
-	class CartesianState: public SpatialState
-	{
-	private:
-		Eigen::Vector3d position; ///< position of the point
-		Eigen::Quaterniond orientation; ///< orientation of the point
-		Eigen::Vector3d linear_velocity; ///< linear_velocity of the point
-		Eigen::Vector3d angular_velocity; ///< angular_velocity of the point
-		Eigen::Vector3d linear_acceleration; ///< linear_acceleration of the point
-		Eigen::Vector3d angular_acceleration; ///< angular_acceleration of the point
-		Eigen::Vector3d force; ///< force applied at the point
-		Eigen::Vector3d torque; ///< torque applied at the point
-
-	public:
-		/**
-	 	 * @brief Empty constructor
-	     */
-		explicit CartesianState();
-		
-		/**
-	 	 * @brief Constructor with name and reference frame provided
-	 	 * @brief name the name of the state
-	 	 * @brief reference the name of the reference frame
-	     */
-		explicit CartesianState(const std::string& name, const std::string& reference="world");
-
-		/**
-	 	 * @brief Copy constructor of a CartesianState
-	     */
-		CartesianState(const CartesianState& state);
-
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param state the state with value to assign
-		 * @return reference to the current state with new values
-		 */
-		CartesianState& operator=(const CartesianState& state);
-
-		/**
-	 	 * @brief Getter of the posistion attribute
-	     */
-		const Eigen::Vector3d& get_position() const;
-
-		/**
-	 	 * @brief Getter of the orientation attribute
-	     */
-		const Eigen::Quaterniond& get_orientation() const;
-
-		/**
-	 	 * @brief Getter of the linear velocity attribute 
-	     */
-		const Eigen::Vector3d& get_linear_velocity() const;
-
-		/**
-	 	 * @brief Getter of the angular velocity attribute 
-	     */
-		const Eigen::Vector3d& get_angular_velocity() const;
-
-		/**
-	 	 * @brief Getter of the linear acceleration attribute 
-	     */
-		const Eigen::Vector3d& get_linear_acceleration() const;
-
-		/**
-	 	 * @brief Getter of the angular acceleration attribute 
-	     */
-		const Eigen::Vector3d& get_angular_acceleration() const;
-
-		/**
-	 	 * @brief Getter of the force attribute
-	     */
-		const Eigen::Vector3d& get_force() const;
-
-		/**
-	 	 * @brief Getter of the torque attribute
-	     */
-		const Eigen::Vector3d& get_torque() const;
-
-		/**
-	 	 * @brief Getter of a pose from position and orientation attributes
-	 	 * @return the pose as a 4x4 transformation matrix
-	     */
-		const Eigen::Matrix4d get_pose() const;
-
-		/**
-	 	 * @brief Getter of a twist from velocities attribute
-	     */
-		const Eigen::Matrix<double, 6, 1> get_twist() const;
-
-		/**
-	 	 * @brief Getter of a wrench from force and torque attributes
-	     */
-		const Eigen::Matrix<double, 6, 1> get_wrench() const;
-
-		/**
-	 	 * @brief Setter of the position
-	     */
-		void set_position(const Eigen::Vector3d& position);
-
-		/**
-	 	 * @brief Setter of the position from a std vector
-	     */
-		void set_position(const std::vector<double>& position);
-
-		/**
-	 	 * @brief Setter of the position from three scalar coordinates
-	     */
-		void set_position(const double& x, const double& y, const double& z);
-
-		/**
-	 	 * @brief Setter of the orientation
-	     */
-		void set_orientation(const Eigen::Quaterniond& orientation);
-
-		/**
-	 	 * @brief Setter of the orientation from a std vector
-	     */
-		void set_orientation(const std::vector<double>& orientation);
-
-		/**
-		 * @brief Setter of the pose from both position and orientation
-		 * @param position the position
-		 * @param orientation the orientation
-		 */
-		void set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation);
-
-		/**
-		 * @brief Setter of the pose from both position and orientation as Eigen 7D vector
-		 * @param pose the pose
-		 */
-		void set_pose(const Eigen::Matrix<double, 7, 1>& pose);
-
-		/**
-		 * @brief Setter of the pose from both position and orientation as std vector
-		 * @param pose the pose
-		 */
-		void set_pose(const std::vector<double>& pose);
-
-		/**
-	 	 * @brief Setter of the linear velocity attribute
-	     */
-		void set_linear_velocity(const Eigen::Vector3d& linear_velocity);
-
-		/**
-	 	 * @brief Setter of the angular velocity attribute
-	     */
-		void set_angular_velocity(const Eigen::Vector3d& angular_velocity);
-
-		/**
-	 	 * @brief Setter of the linear accelration attribute
-	     */
-		void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration);
-
-		/**
-	 	 * @brief Setter of the angular velocity attribute
-	     */
-		void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration);
-
-		/**
-	 	 * @brief Setter of the force attribute
-	     */
-		void set_force(const Eigen::Vector3d& force);
-
-		/**
-	 	 * @brief Setter of the force attribute
-	     */
-		void set_torque(const Eigen::Vector3d& torque);
-
-		/**
-	 	 * @brief Setter of the linear and angular velocities from a single twist vector
-	     */
-		void set_twist(const Eigen::Matrix<double, 6, 1>& twist);
-
-		/**
-	 	 * @brief Setter of the force and torque from a single wrench vector
-	     */
-		void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench);
-
-		/**
-	 	 * @brief Initialize the CartesianState to a zero value
-	     */
-		void initialize();
-
-		/**
-	 	 * @brief Set the State to a zero value
-	     */
-		void set_zero();
-
-		/**
-		 * @brief Return a copy of the CartesianState
-		 * @return the copy
-		 */
-		const CartesianState copy() const;
-
-		/**
-	 	 * @brief Overload the *= operator with another state by deriving the equations of motions
-	 	 * @param state the state to compose with corresponding to b_S_c
-	 	 * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
-	     */
-		CartesianState& operator*=(const CartesianState& state);
-
-		/**
-	 	 * @brief Overload the * operator with another state by deriving the equations of motions
-	 	 * @param state the state to compose with corresponding to b_S_c
-	 	 * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
-	     */
-		const CartesianState operator*(const CartesianState& state) const;
-
-		/**
-	 	 * @brief Overload the *= operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianState multiply by lambda
-	     */
-		CartesianState& operator*=(double lambda);
-
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianState multiply by lambda
-	     */
-		const CartesianState operator*(double lambda) const;
-
-		/**
-		 * @brief compute the inverse of the current CartesianState
-		 * @return the inverse corresponding to b_S_f (assuming this is f_S_b) 
-		 */
-		const CartesianState inverse() const;
-
-		/**
-		 * @brief Compute the distance between two states as the sum of distances between each features
-		 * @param state the second state
-		 * @param type of the distance between position, orientation, linear_velocity, etc...
-		 * default all for full distance across all dimensions
-		 * @return dist the distance value as a double
-		 */
-		double dist(const CartesianState& state, const std::string& distance_type="all") const;
-
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to happend the string representing the state to
-	 	 * @param state the state to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const CartesianState& state);
-		
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianState provided multiply by lambda
-	     */
-		friend const CartesianState operator*(double lambda, const CartesianState& state);
-
-		/**
-		 * @brief compute the distance between two CartesianStates
-		 * @param s1 the first CartesianState
-		 * @param s2 the second CartesianState
-		 * @param type of the distance between position, orientation, linear_velocity, etc...
-		 * default all for full distance across all dimensions
-		 * @return the distance beteen the two states
-		 */
-		friend double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type);
-
-		/**
-		 * @brief Return the state as a std vector of floats
-		 * @return std::vector<float> the state vector as a std vector
-		 */
-		virtual const std::vector<double> to_std_vector() const;
-
-		/**
-		 * @brief Set the value from a std vector
-		 * @param value the value as a std vector
-		 */
-		virtual void from_std_vector(const std::vector<double>& value);
-	};
-
-	inline CartesianState& CartesianState::operator=(const CartesianState& state)
-	{
-		SpatialState::operator=(state);
-		this->set_position(state.get_position());
-		this->set_orientation(state.get_orientation());
-		this->set_linear_velocity(state.get_linear_velocity());
-		this->set_angular_velocity(state.get_angular_velocity());
-		this->set_linear_acceleration(state.get_linear_acceleration());
-		this->set_angular_acceleration(state.get_angular_acceleration());
-		this->set_force(state.get_force());
-		this->set_torque(state.get_torque());
-		return (*this);
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_position() const
-	{ 
-		return this->position;
-	}
-
-	inline const Eigen::Quaterniond& CartesianState::get_orientation() const
-	{ 
-		return this->orientation;
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_linear_velocity() const
-	{
-		return this->linear_velocity;
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_angular_velocity() const
-	{
-		return this->angular_velocity;
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_linear_acceleration() const
-	{
-		return this->linear_acceleration;
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_angular_acceleration() const
-	{
-		return this->angular_acceleration;
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_force() const
-	{
-		return this->force;
-	}
-
-	inline const Eigen::Vector3d& CartesianState::get_torque() const
-	{
-		return this->torque;
-	}
-
-	inline const Eigen::Matrix4d CartesianState::get_pose() const
-	{
-		Eigen::Matrix4d pose;
-		pose << this->orientation.toRotationMatrix(), this->position, 0., 0., 0., 1;
-		return pose;
-	}
-
-	inline const Eigen::Matrix<double, 6, 1> CartesianState::get_twist() const
-	{
-		Eigen::Matrix<double, 6, 1> twist;
-		twist << this->linear_velocity, this->angular_velocity;
-		return twist;
-	}
-
-	inline const Eigen::Matrix<double, 6, 1> CartesianState::get_wrench() const
-	{
-		Eigen::Matrix<double, 6, 1> wrench;
-		wrench << this->force, this->torque;
-		return wrench;
-	}
-
-	inline void CartesianState::set_position(const Eigen::Vector3d& position)
-	{
-		this->set_filled();
-		this->position = position;
-	}
-
-	inline void CartesianState::set_position(const std::vector<double>& position)
-	{
-		if (position.size() != 3) throw Exceptions::IncompatibleSizeException("The input vector is not of size 3 required for position");
-		this->set_filled();
-		this->position = Eigen::Vector3d::Map(position.data(), 3);
-	}
-
-	inline void CartesianState::set_position(const double& x, const double& y, const double& z)
-	{
-		this->set_position(Eigen::Vector3d(x, y, z));
-	}
-
-	inline void CartesianState::set_orientation(const Eigen::Quaterniond& orientation)
-	{
-		this->set_filled();
-		this->orientation = orientation.normalized();
-	}
-
-	inline void CartesianState::set_orientation(const std::vector<double>& orientation)
-	{
-		if (orientation.size() != 4) throw Exceptions::IncompatibleSizeException("The input vector is not of size 4 required for orientation");
-		this->set_orientation(Eigen::Quaterniond(orientation[0], orientation[1], orientation[2], orientation[3]));
-	}
-
-	inline void CartesianState::set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation)
-	{
-		this->set_position(position);
-		this->set_orientation(orientation);
-	}
-
-	inline void CartesianState::set_pose(const Eigen::Matrix<double, 7, 1>& pose)
-	{
-		this->set_position(pose.head(3));
-		this->set_orientation(Eigen::Quaterniond(pose(3), pose(4), pose(5), pose(6)));
-	}
-
-	inline void CartesianState::set_pose(const std::vector<double>& pose)
-	{
-		if (pose.size() != 7) throw Exceptions::IncompatibleSizeException("The input vector is not of size 7 required for pose");
-		this->set_position(Eigen::Vector3d::Map(pose.data(), 3));
-		this->set_orientation(Eigen::Quaterniond(pose[3], pose[4], pose[5], pose[6]));
-	}
-
-	inline void CartesianState::set_linear_velocity(const Eigen::Vector3d& linear_velocity)
-	{
-		this->set_filled();
-		this->linear_velocity = linear_velocity;
-	}
-
-	inline void CartesianState::set_angular_velocity(const Eigen::Vector3d& angular_velocity)
-	{
-		this->set_filled();
-		this->angular_velocity = angular_velocity;
-	}
-
-	inline void CartesianState::set_linear_acceleration(const Eigen::Vector3d& linear_acceleration)
-	{
-		this->set_filled();
-		this->linear_acceleration = linear_acceleration;
-	}
-
-	inline void CartesianState::set_angular_acceleration(const Eigen::Vector3d& angular_acceleration)
-	{
-		this->set_filled();
-		this->angular_acceleration = angular_acceleration;
-	}
-
-	inline void CartesianState::set_force(const Eigen::Vector3d& force)
-	{
-		this->set_filled();
-		this->force = force;
-	}
-
-	inline void CartesianState::set_torque(const Eigen::Vector3d& torque)
-	{
-		this->set_filled();
-		this->torque = torque;
-	}
-
-	inline void CartesianState::set_twist(const Eigen::Matrix<double, 6, 1>& twist)
-	{
-		this->set_filled();
-		this->linear_velocity = twist.head(3);
-		this->angular_velocity = twist.tail(3);
-	}
-
-	inline void CartesianState::set_wrench(const Eigen::Matrix<double, 6, 1>& wrench)
-	{
-		this->set_filled();
-		this->force = wrench.head(3);
-		this->torque = wrench.tail(3);
-	}
+#include <vector>
+
+namespace StateRepresentation {
+class CartesianState;
+
+/**
+ * @brief compute the distance between two CartesianStates
+ * @param s1 the first CartesianState
+ * @param s2 the second CartesianState
+ * @param type of the distance between position, orientation, linear_velocity, etc...
+ * default all for full distance across all dimensions
+ * @return the distance beteen the two states
+ */
+double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type = "all");
+
+/**
+ * @class CartesianState
+ * @brief Class to represent a state in Cartesian space
+ */
+class CartesianState : public SpatialState {
+private:
+  Eigen::Vector3d position;            ///< position of the point
+  Eigen::Quaterniond orientation;      ///< orientation of the point
+  Eigen::Vector3d linear_velocity;     ///< linear_velocity of the point
+  Eigen::Vector3d angular_velocity;    ///< angular_velocity of the point
+  Eigen::Vector3d linear_acceleration; ///< linear_acceleration of the point
+  Eigen::Vector3d angular_acceleration;///< angular_acceleration of the point
+  Eigen::Vector3d force;               ///< force applied at the point
+  Eigen::Vector3d torque;              ///< torque applied at the point
+
+public:
+  /**
+   * @brief Empty constructor
+   */
+  explicit CartesianState();
+
+  /**
+   * @brief Constructor with name and reference frame provided
+   * @brief name the name of the state
+   * @brief reference the name of the reference frame
+   */
+  explicit CartesianState(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Copy constructor of a CartesianState
+   */
+  CartesianState(const CartesianState& state);
+
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param state the state with value to assign
+   * @return reference to the current state with new values
+   */
+  CartesianState& operator=(const CartesianState& state);
+
+  /**
+   * @brief Getter of the posistion attribute
+   */
+  const Eigen::Vector3d& get_position() const;
+
+  /**
+   * @brief Getter of the orientation attribute
+   */
+  const Eigen::Quaterniond& get_orientation() const;
+
+  /**
+   * @brief Getter of a pose from position and orientation attributes
+   * @return the pose as a 7d vector. Beware, quaternion coefficients are
+   * returned using the (w, x, y, z) convention
+   */
+  const Eigen::Matrix<double, 7, 1> get_pose() const;
+
+  /**
+   * @brief Getter of a pose from position and orientation attributes
+   * @return the pose as a 4x4 transformation matrix
+   */
+  const Eigen::Matrix4d get_transformation_matrix() const;
+
+  /**
+   * @brief Getter of the linear velocity attribute 
+   */
+  const Eigen::Vector3d& get_linear_velocity() const;
+
+  /**
+   * @brief Getter of the angular velocity attribute 
+   */
+  const Eigen::Vector3d& get_angular_velocity() const;
+
+  /**
+   * @brief Getter of a twist from linear and angular velocities attribute
+   */
+  const Eigen::Matrix<double, 6, 1> get_twist() const;
+
+  /**
+   * @brief Getter of the linear acceleration attribute 
+   */
+  const Eigen::Vector3d& get_linear_acceleration() const;
+
+  /**
+   * @brief Getter of the angular acceleration attribute 
+   */
+  const Eigen::Vector3d& get_angular_acceleration() const;
+
+  /**
+   * @brief Getter of accelerations from linear and angular accelerations attribute
+   */
+  const Eigen::Matrix<double, 6, 1> get_accelerations() const;
+
+  /**
+   * @brief Getter of the force attribute
+   */
+  const Eigen::Vector3d& get_force() const;
+
+  /**
+   * @brief Getter of the torque attribute
+   */
+  const Eigen::Vector3d& get_torque() const;
+
+  /**
+   * @brief Getter of a wrench from force and torque attributes
+   */
+  const Eigen::Matrix<double, 6, 1> get_wrench() const;
+
+  /**
+   * @brief Setter of the position
+   */
+  void set_position(const Eigen::Vector3d& position);
+
+  /**
+   * @brief Setter of the position from a std vector
+   */
+  void set_position(const std::vector<double>& position);
+
+  /**
+   * @brief Setter of the position from three scalar coordinates
+   */
+  void set_position(const double& x, const double& y, const double& z);
+
+  /**
+   * @brief Setter of the orientation
+   */
+  void set_orientation(const Eigen::Quaterniond& orientation);
+
+  /**
+   * @brief Setter of the orientation from a 4d vector
+   * @param the orientation coefficients as a 4d vector. Beware, quaternion coefficients 
+   * uses the (w, x, y, z) convention
+   */
+  void set_orientation(const Eigen::Vector4d& orientation);
+
+  /**
+   * @brief Setter of the orientation from a std vector
+   * @param the orientation coefficients as a 4d vector. Beware, quaternion coefficients 
+   * uses the (w, x, y, z) convention
+   */
+  void set_orientation(const std::vector<double>& orientation);
+
+  /**
+   * @brief Setter of the pose from both position and orientation
+   * @param position the position
+   * @param orientation the orientation
+   */
+  void set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation);
+
+  /**
+   * @brief Setter of the pose from both position and orientation as Eigen 7D vector
+   * @param pose the pose as a 7d vector. Beware, quaternion coefficients 
+   * uses the (w, x, y, z) convention
+   */
+  void set_pose(const Eigen::Matrix<double, 7, 1>& pose);
+
+  /**
+   * @brief Setter of the pose from both position and orientation as std vector
+   * @param pose the pose as a 7d vectorz. Beware, quaternion coefficients 
+   * uses the (w, x, y, z) convention
+   */
+  void set_pose(const std::vector<double>& pose);
+
+  /**
+   * @brief Setter of the linear velocity attribute
+   */
+  void set_linear_velocity(const Eigen::Vector3d& linear_velocity);
+
+  /**
+   * @brief Setter of the angular velocity attribute
+   */
+  void set_angular_velocity(const Eigen::Vector3d& angular_velocity);
+
+  /**
+   * @brief Setter of the linear and angular velocities from a single twist vector
+   */
+  void set_twist(const Eigen::Matrix<double, 6, 1>& twist);
+
+  /**
+   * @brief Setter of the linear accelration attribute
+   */
+  void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration);
+
+  /**
+   * @brief Setter of the angular velocity attribute
+   */
+  void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration);
+
+  /**
+   * @brief Setter of the linear and angular accelerations from a single acceleration vector
+   */
+  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations);
+
+  /**
+   * @brief Setter of the force attribute
+   */
+  void set_force(const Eigen::Vector3d& force);
+
+  /**
+   * @brief Setter of the force attribute
+   */
+  void set_torque(const Eigen::Vector3d& torque);
+
+  /**
+   * @brief Setter of the force and torque from a single wrench vector
+   */
+  void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench);
+
+  /**
+   * @brief Initialize the CartesianState to a zero value
+   */
+  void initialize();
+
+  /**
+   * @brief Set the State to a zero value
+   */
+  void set_zero();
+
+  /**
+   * @brief Return a copy of the CartesianState
+   * @return the copy
+   */
+  const CartesianState copy() const;
+
+  /**
+   * @brief Overload the *= operator with another state by deriving the equations of motions
+   * @param state the state to compose with corresponding to b_S_c
+   * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
+   */
+  CartesianState& operator*=(const CartesianState& state);
+
+  /**
+   * @brief Overload the * operator with another state by deriving the equations of motions
+   * @param state the state to compose with corresponding to b_S_c
+   * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
+   */
+  const CartesianState operator*(const CartesianState& state) const;
+
+  /**
+   * @brief Overload the *= operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianState multiplied by lambda
+   */
+  CartesianState& operator*=(double lambda);
+
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianState multiplied by lambda
+   */
+  const CartesianState operator*(double lambda) const;
+
+  /**
+   * @brief Overload the += operator
+   * @param state CartesianState to add
+   * @return the current CartesianState added the CartesianState given in argument
+   */
+  CartesianState& operator+=(const CartesianState& state);
+
+  /**
+   * @brief Overload the + operator
+   * @param state CartesianState to add
+   * @return the current CartesianState added the CartesianState given in argument
+   */
+  const CartesianState operator+(const CartesianState& state) const;
+
+  /**
+   * @brief Overload the -= operator
+   * @param state CartesianState to substract
+   * @return the current CartesianState minus the CartesianState given in argument
+   */
+  CartesianState& operator-=(const CartesianState& state);
+
+  /**
+   * @brief Overload the - operator
+   * @param state CartesianState to substract
+   * @return the current CartesianState minus the CartesianState given in argument
+   */
+  const CartesianState operator-(const CartesianState& state) const;
+
+  /**
+   * @brief compute the inverse of the current CartesianState
+   * @return the inverse corresponding to b_S_f (assuming this is f_S_b) 
+   */
+  const CartesianState inverse() const;
+
+  /**
+   * @brief Compute the distance between two states as the sum of distances between each features
+   * @param state the second state
+   * @param type of the distance between position, orientation, linear_velocity, etc...
+   * default all for full distance across all dimensions
+   * @return dist the distance value as a double
+   */
+  double dist(const CartesianState& state, const std::string& distance_type = "all") const;
+
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to happend the string representing the state to
+   * @param state the state to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const CartesianState& state);
+
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianState provided multiply by lambda
+   */
+  friend const CartesianState operator*(double lambda, const CartesianState& state);
+
+  /**
+   * @brief compute the distance between two CartesianStates
+   * @param s1 the first CartesianState 
+   * @param s2 the second CartesianState
+   * @param type of the distance between position, orientation, linear_velocity, etc...
+   * default all for full distance across all dimensions
+   * @return the distance beteen the two states
+   */
+  friend double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type);
+
+  /**
+   * @brief Return the state as a std vector of floats
+   * @return std::vector<float> the state vector as a std vector
+   */
+  virtual const std::vector<double> to_std_vector() const;
+
+  /**
+   * @brief Set the value from a std vector
+   * @param value the value as a std vector
+   */
+  virtual void from_std_vector(const std::vector<double>& value);
+};
+
+inline CartesianState& CartesianState::operator=(const CartesianState& state) {
+  SpatialState::operator=(state);
+  this->set_pose(state.get_pose());
+  this->set_twist(state.get_twist());
+  this->set_accelerations(state.get_accelerations());
+  this->set_wrench(state.get_wrench());
+  return (*this);
 }
+
+inline const Eigen::Vector3d& CartesianState::get_position() const {
+  return this->position;
+}
+
+inline const Eigen::Quaterniond& CartesianState::get_orientation() const {
+  return this->orientation;
+}
+
+inline const Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {
+  Eigen::Matrix<double, 7, 1> pose;
+  pose << this->get_position();
+  pose << this->get_orientation().w(), this->get_orientation().x(), this->get_orientation().y(), this->get_orientation().z();
+  return pose;
+}
+
+inline const Eigen::Matrix4d CartesianState::get_transformation_matrix() const {
+  Eigen::Matrix4d pose;
+  pose << this->orientation.toRotationMatrix(), this->position, 0., 0., 0., 1;
+  return pose;
+}
+
+inline const Eigen::Vector3d& CartesianState::get_linear_velocity() const {
+  return this->linear_velocity;
+}
+
+inline const Eigen::Vector3d& CartesianState::get_angular_velocity() const {
+  return this->angular_velocity;
+}
+
+inline const Eigen::Matrix<double, 6, 1> CartesianState::get_twist() const {
+  Eigen::Matrix<double, 6, 1> twist;
+  twist << this->get_linear_velocity(), this->get_angular_velocity();
+  return twist;
+}
+
+inline const Eigen::Vector3d& CartesianState::get_linear_acceleration() const {
+  return this->linear_acceleration;
+}
+
+inline const Eigen::Vector3d& CartesianState::get_angular_acceleration() const {
+  return this->angular_acceleration;
+}
+
+inline const Eigen::Matrix<double, 6, 1> CartesianState::get_accelerations() const {
+  Eigen::Matrix<double, 6, 1> accelerations;
+  accelerations << this->get_linear_acceleration(), this->get_angular_acceleration();
+  return accelerations;
+}
+
+inline const Eigen::Vector3d& CartesianState::get_force() const {
+  return this->force;
+}
+
+inline const Eigen::Vector3d& CartesianState::get_torque() const {
+  return this->torque;
+}
+
+inline const Eigen::Matrix<double, 6, 1> CartesianState::get_wrench() const {
+  Eigen::Matrix<double, 6, 1> wrench;
+  wrench << this->get_force(), this->get_torque();
+  return wrench;
+}
+
+inline void CartesianState::set_position(const Eigen::Vector3d& position) {
+  this->set_filled();
+  this->position = position;
+}
+
+inline void CartesianState::set_position(const std::vector<double>& position) {
+  if (position.size() != 3) throw Exceptions::IncompatibleSizeException("The input vector is not of size 3 required for position");
+  this->set_position(Eigen::Vector3d::Map(position.data(), 3));
+}
+
+inline void CartesianState::set_position(const double& x, const double& y, const double& z) {
+  this->set_position(Eigen::Vector3d(x, y, z));
+}
+
+inline void CartesianState::set_orientation(const Eigen::Quaterniond& orientation) {
+  this->set_filled();
+  this->orientation = orientation.normalized();
+}
+
+inline void CartesianState::set_orientation(const Eigen::Vector4d& orientation) {
+  this->set_orientation(Eigen::Quaterniond(orientation(0), orientation(1), orientation(2), orientation(3)));
+}
+
+inline void CartesianState::set_orientation(const std::vector<double>& orientation) {
+  if (orientation.size() != 4) throw Exceptions::IncompatibleSizeException("The input vector is not of size 4 required for orientation");
+  this->set_orientation(Eigen::Quaterniond(orientation[0], orientation[1], orientation[2], orientation[3]));
+}
+
+inline void CartesianState::set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation) {
+  this->set_position(position);
+  this->set_orientation(orientation);
+}
+
+inline void CartesianState::set_pose(const Eigen::Matrix<double, 7, 1>& pose) {
+  this->set_position(pose.head(3));
+  this->set_orientation(pose.tail(4));
+}
+
+inline void CartesianState::set_pose(const std::vector<double>& pose) {
+  if (pose.size() != 7) throw Exceptions::IncompatibleSizeException("The input vector is not of size 7 required for pose");
+  this->set_position(std::vector<double>(pose.begin(), pose.begin() + 3));
+  this->set_orientation(std::vector<double>(pose.begin() + 4, pose.end()));
+}
+
+inline void CartesianState::set_linear_velocity(const Eigen::Vector3d& linear_velocity) {
+  this->set_filled();
+  this->linear_velocity = linear_velocity;
+}
+
+inline void CartesianState::set_angular_velocity(const Eigen::Vector3d& angular_velocity) {
+  this->set_filled();
+  this->angular_velocity = angular_velocity;
+}
+
+inline void CartesianState::set_twist(const Eigen::Matrix<double, 6, 1>& twist) {
+  this->set_linear_velocity(twist.head(3));
+  this->set_angular_velocity(twist.tail(3));
+}
+
+inline void CartesianState::set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) {
+  this->set_filled();
+  this->linear_acceleration = linear_acceleration;
+}
+
+inline void CartesianState::set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) {
+  this->set_filled();
+  this->angular_acceleration = angular_acceleration;
+}
+
+inline void CartesianState::set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) {
+  this->set_linear_acceleration(accelerations.head(3));
+  this->set_angular_acceleration(accelerations.tail(3));
+}
+
+inline void CartesianState::set_force(const Eigen::Vector3d& force) {
+  this->set_filled();
+  this->force = force;
+}
+
+inline void CartesianState::set_torque(const Eigen::Vector3d& torque) {
+  this->set_filled();
+  this->torque = torque;
+}
+
+inline void CartesianState::set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) {
+  this->set_force(wrench.head(3));
+  this->set_torque(wrench.tail(3));
+}
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -567,7 +567,7 @@ inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_var
 
 inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable, const std::vector<double>& new_value) {
   this->set_state_variable(linear_state_variable, std::vector<double>(new_value.begin(), new_value.begin() + 3));
-  this->set_state_variable(angular_state_variable, std::vector<double>(new_value.begin() + 4, new_value.end()));
+  this->set_state_variable(angular_state_variable, std::vector<double>(new_value.begin() + 3, new_value.end()));
 }
 
 inline void CartesianState::set_position(const Eigen::Vector3d& position) {
@@ -609,7 +609,7 @@ inline void CartesianState::set_pose(const Eigen::Matrix<double, 7, 1>& pose) {
 inline void CartesianState::set_pose(const std::vector<double>& pose) {
   if (pose.size() != 7) throw Exceptions::IncompatibleSizeException("The input vector is not of size 7 required for pose");
   this->set_position(std::vector<double>(pose.begin(), pose.begin() + 3));
-  this->set_orientation(std::vector<double>(pose.begin() + 4, pose.end()));
+  this->set_orientation(std::vector<double>(pose.begin() + 3, pose.end()));
 }
 
 inline void CartesianState::set_linear_velocity(const Eigen::Vector3d& linear_velocity) {

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -553,7 +553,7 @@ inline const Eigen::VectorXd CartesianState::get_state_variable(const CartesianS
       return this->get_wrench();
 
     case CartesianStateVariable::ALL:
-      Eigen::MatrixXd all_fields;
+      Eigen::VectorXd all_fields(25);
       all_fields << this->get_pose(), this->get_twist(), this->get_accelerations(), this->get_wrench();
       return all_fields;
   }

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -593,7 +593,7 @@ inline void CartesianState::set_orientation(const Eigen::Vector4d& orientation) 
 
 inline void CartesianState::set_orientation(const std::vector<double>& orientation) {
   if (orientation.size() != 4) throw Exceptions::IncompatibleSizeException("The input vector is not of size 4 required for orientation");
-  this->set_orientation(Eigen::Quaterniond(orientation[0], orientation[1], orientation[2], orientation[3]));
+  this->set_orientation(Eigen::Vector4d::Map(orientation.data(), orientation.size()));
 }
 
 inline void CartesianState::set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation) {

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -553,7 +553,7 @@ inline const Eigen::VectorXd CartesianState::get_state_variable(const CartesianS
       return this->get_wrench();
 
     case CartesianStateVariable::ALL:
-      Eigen::Matrix<double, 25, 1> all_fields;
+      Eigen::MatrixXd all_fields;
       all_fields << this->get_pose(), this->get_twist(), this->get_accelerations(), this->get_wrench();
       return all_fields;
   }

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
@@ -189,25 +189,25 @@ public:
   CartesianTwist& operator*=(const Eigen::Matrix<double, 6, 6>& lambda);
 
   /**
-   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @brief Clamp inplace the magnitude of the twist to the values in argument
    * @param max_linear the maximum magnitude of the linear velocity
    * @param max_angular the maximum magnitude of the angular velocity
    * @param linear_noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
+   * the linear velocity will be set to 0
    * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
+   * the angular velocity will be set to 0
    */
   void clamp(double max_linear, double max_angular, double linear_noise_ratio = 0, double angular_noise_ratio = 0);
 
   /**
-   * @brief Return the clamped velocity
+   * @brief Return the clamped twist
    * @param max_linear the maximum magnitude of the linear velocity
    * @param max_angular the maximum magnitude of the angular velocity
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
+   * the linear velocity will be set to 0
    * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
-   * @return the clamped velocity
+   * the angular velocity will be set to 0
+   * @return the clamped twist
    */
   const CartesianTwist clamped(double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0) const;
 

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
@@ -58,6 +58,22 @@ public:
   explicit CartesianTwist(const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference = "world");
 
   /**
+   * @brief Constructor for the zero twist
+   * @param name the name of the state
+   * @param the name of the reference frame
+   * @return CartesianTwist with zero values
+   */
+  static const CartesianTwist Zero(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Constructor for a random twist
+   * @param name the name of the state
+   * @param the name of the reference frame
+   * @return CartesianTwist random twist
+   */
+  static const CartesianTwist Random(const std::string& name, const std::string& reference = "world");
+
+  /**
    * @brief Copy assignement operator that have to be defined to the custom assignement operator
    * @param twist the twist with value to assign
    * @return reference to the current twist with new values

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
@@ -5,247 +5,279 @@
 
 #pragma once
 
-#include "state_representation/Space/Cartesian/CartesianState.hpp"
 #include "state_representation/Space/Cartesian/CartesianPose.hpp"
+#include "state_representation/Space/Cartesian/CartesianState.hpp"
 
-namespace StateRepresentation
-{
-	class CartesianPose;
+namespace StateRepresentation {
+class CartesianPose;
 
-	/**
-	 * @class CartesianTwist
-	 * @brief Class to define twist in cartesian space as 3D linear and angular velocity vectors
-	 */
-	class CartesianTwist: public CartesianState
-	{
-	public:
-		/**
-		 * Empty constructor
-		 */
-		explicit CartesianTwist();
+/**
+ * @class CartesianTwist
+ * @brief Class to define twist in cartesian space as 3D linear and angular velocity vectors
+ */
+class CartesianTwist : public CartesianState {
+public:
+  /**
+   * Empty constructor
+   */
+  explicit CartesianTwist();
 
-		/**
-	 	 * @brief Empty constructor for a CartesianTwist
-	     */
-		explicit CartesianTwist(const std::string& name, const std::string& reference="world");
+  /**
+   * @brief Empty constructor for a CartesianTwist
+   */
+  explicit CartesianTwist(const std::string& name, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Copy constructor
-	     */
-		CartesianTwist(const CartesianTwist& twist);
+  /**
+   * @brief Copy constructor
+   */
+  CartesianTwist(const CartesianTwist& twist);
 
-		/**
-	 	 * @brief Copy constructor from a CartesianState
-	     */
-		CartesianTwist(const CartesianState& state);
+  /**
+   * @brief Copy constructor from a CartesianState
+   */
+  CartesianTwist(const CartesianState& state);
 
-		/**
-	 	 * @brief Copy constructor from a CartesianPose by considering that it is equivalent to dividing the pose by 1 second
-	     */
-		CartesianTwist(const CartesianPose& pose);
-		
-		/**
-	 	 * @brief Construct a CartesianTwist from a linear_velocity given as a vector of coordinates for the linear velocity.
-	     */
-		explicit CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference="world");
+  /**
+   * @brief Copy constructor from a CartesianPose by considering that it is equivalent to dividing the pose by 1 second
+   */
+  CartesianTwist(const CartesianPose& pose);
 
-		/**
-	 	 * @brief Construct a CartesianTwist from a linear_velocity given as a vector of coordinates and a quaternion.
-	     */
-		explicit CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianTwist from a linear_velocity given as a vector of coordinates for the linear velocity.
+   */
+  explicit CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Construct a CartesianTwist from a single 6d twist vector
-	     */
-		explicit CartesianTwist(const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianTwist from a linear_velocity given as a vector of coordinates and a quaternion.
+   */
+  explicit CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity, const std::string& reference = "world");
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param twist the twist with value to assign
-		 * @return reference to the current twist with new values
-		 */
-		CartesianTwist& operator=(const CartesianTwist& twist);
+  /**
+   * @brief Construct a CartesianTwist from a single 6d twist vector
+   */
+  explicit CartesianTwist(const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Overload the = operator from a CartesianState
-	 	 * @param state CartesianState to get velocity from
-	     */
-		CartesianTwist& operator=(const CartesianState& state);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param twist the twist with value to assign
+   * @return reference to the current twist with new values
+   */
+  CartesianTwist& operator=(const CartesianTwist& twist);
 
-		/**
-		 * @brief Set the values of the 6D twist from a 6D Eigen Vector
-		 * @param twist the twist as an Eigen Vector
-		 */
-		CartesianTwist& operator=(const Eigen::Matrix<double, 6, 1>& twist);
+  /**
+   * @brief Overload the = operator from a CartesianState
+   * @param state CartesianState to get velocity from
+   */
+  CartesianTwist& operator=(const CartesianState& state);
 
-		/**
-	 	 * @brief Overload the += operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the CartesianTwist added the vector given in argument
-	     */
-		CartesianTwist& operator+=(const Eigen::Matrix<double, 6, 1>& vector);
+  /**
+   * @brief Set the values of the 6D twist from a 6D Eigen Vector
+   * @param twist the twist as an Eigen Vector
+   */
+  CartesianTwist& operator=(const Eigen::Matrix<double, 6, 1>& twist);
 
-		/**
-	 	 * @brief Overload the += operator
-	 	 * @param twist CartesianTwist to add
-	 	 * @return the current CartesianTwist added the CartesianTwist given in argument
-	     */
-		CartesianTwist& operator+=(const CartesianTwist& twist);
+  /**
+   * @brief Overload the *= operator
+   * @param twist CartesianTwist to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
+   */
+  CartesianTwist& operator*=(const CartesianTwist& twist);
 
-		/**
-	 	 * @brief Overload the + operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the CartesianTwist added the vector given in argument
-	     */
-		const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector) const;
+  /**
+   * @brief Overload the * operator with a twist
+   * @param twist CartesianTwist to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
+   */
+  const CartesianTwist operator*(const CartesianTwist& twist) const;
 
-		/**
-	 	 * @brief Overload the + operator
-	 	 * @param twist CartesianTwist to add
-	 	 * @return the current CartesianTwist added the CartesianTwist given in argument
-	     */
-		const CartesianTwist operator+(const CartesianTwist& twist) const;
+  /**
+   * @brief Overload the * operator with a state
+   * @param state CartesianState to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianState given in argument
+   */
+  const CartesianState operator*(const CartesianState& state) const;
 
-		/**
-	 	 * @brief Overload the -= operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the CartesianTwist substracted the vector given in argument
-	     */
-		CartesianTwist& operator-=(const Eigen::Matrix<double, 6, 1>& vector);
+  /**
+   * @brief Overload the *= operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianTwist multiplied by lambda
+   */
+  CartesianTwist& operator*=(double lambda);
 
-		/**
-	 	 * @brief Overload the -= operator
-	 	 * @param twist CartesianTwist to substract
-	 	 * @return the current CartesianTwist minus the CartesianTwist given in argument
-	     */
-		CartesianTwist& operator-=(const CartesianTwist& twist);
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianState multiplied by lambda
+   */
+  const CartesianTwist operator*(double lambda) const;
 
-		/**
-	 	 * @brief Overload the - operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the CartesianTwist substracted the vector given in argument
-	     */
-		const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector) const;
+  /**
+   * @brief Overload the += operator
+   * @param twist CartesianTwist to add to
+   * @return the current CartesianTwist added the CartesianTwist given in argument
+   */
+  CartesianTwist& operator+=(const CartesianTwist& twist);
 
-		/**
-	 	 * @brief Overload the - operator
-	 	 * @param twist CartesianTwist to substract
-	 	 * @return the current CartesianTwist minus the CartesianTwist given in argument
-	     */
-		const CartesianTwist operator-(const CartesianTwist& twist) const;
+  /**
+   * @brief Overload the + operator with a twist
+   * @param twist CartesianTwist to add to
+   * @return the current CartesianTwist added the CartesianTwist given in argument
+   */
+  const CartesianTwist operator+(const CartesianTwist& twist) const;
 
-		/**
-	 	 * @brief Overload the *= operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianTwist multiplied by lambda
-	     */
-		CartesianTwist& operator*=(double lambda);
+  /**
+   * @brief Overload the + operator with a state
+   * @param state CartesianState to add
+   * @return the current CartesianTwist added the CartesianState given in argument
+   */
+  const CartesianState operator+(const CartesianState& state) const;
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianTwist multiplied by lambda
-	     */
-		const CartesianTwist operator*(double lambda) const;
+  /**
+   * @brief Overload the -= operator
+   * @param twist CartesianTwist to substract
+   * @return the current CartesianTwist minus the CartesianTwist given in argument
+   */
+  CartesianTwist& operator-=(const CartesianTwist& twist);
 
-		/**
-	 	 * @brief Overload the *= operator with a matrix
-	 	 * @param lambda the matrix to multiply with
-	 	 * @return the CartesianTwist multiplied by lambda
-	     */
-		CartesianTwist& operator*=(const Eigen::Matrix<double, 6, 6>& lambda);
+  /**
+   * @brief Overload the - operator with a twist
+   * @param twist CartesianTwist to substract
+   * @return the current CartesianTwist minus the CartesianTwist given in argument
+   */
+  const CartesianTwist operator-(const CartesianTwist& twist) const;
 
-		/**
-		 * @brief Clamp inplace the magnitude of the velocity to the values in argument
-		 * @param max_linear the maximum magnitude of the linear velocity
-		 * @param max_angular the maximum magnitude of the angular velocity
-		 * @param linear_noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocity will be set to 0
-		 * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocity will be set to 0
-		 */
-		void clamp(double max_linear, double max_angular, double linear_noise_ratio=0, double angular_noise_ratio=0);
+  /**
+   * @brief Overload the - operator with a state
+   * @param state CartesianState to substract
+   * @return the current CartesianTwist minus the CartesianState given in argument
+   */
+  const CartesianState operator-(const CartesianState& state) const;
 
-		/**
-		 * @brief Return the clamped velocity
-		 * @param max_linear the maximum magnitude of the linear velocity
-		 * @param max_angular the maximum magnitude of the angular velocity
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocity will be set to 0
-		 * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocity will be set to 0
-		 * @return the clamped velocity
-		 */
-		const CartesianTwist clamped(double max_linear, double max_angular, double noise_ratio=0, double angular_noise_ratio=0) const;
+  /**
+   * @brief Overload the += operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the CartesianTwist added the vector given in argument
+   */
+  CartesianTwist& operator+=(const Eigen::Matrix<double, 6, 1>& vector);
 
-		/**
-		 * @brief Return a copy of the CartesianTwist
-		 * @return the copy
-		 */
-		const CartesianTwist copy() const;
+  /**
+   * @brief Overload the + operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the CartesianTwist added the vector given in argument
+   */
+  const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector) const;
 
-		/**
-		 * @brief Return the value of the 6D twist as Eigen array
-		 * @retrun the Eigen array representing the twist
-		 */
-		const Eigen::Array<double, 6, 1> array() const;
+  /**
+   * @brief Overload the -= operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the CartesianTwist substracted the vector given in argument
+   */
+  CartesianTwist& operator-=(const Eigen::Matrix<double, 6, 1>& vector);
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to happend the string representing the CartesianTwist to
-	 	 * @param CartesianTwist the CartesianTwist to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist);
+  /**
+   * @brief Overload the - operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the CartesianTwist substracted the vector given in argument
+   */
+  const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector) const;
 
-		/**
-	 	 * @brief Overload the + operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @param twist CartesianTwist to add
-	 	 * @return the Eigen Vector plus the CartesianTwist represented as a CartesianTwist
-	     */
-		friend const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist);
+  /**
+   * @brief Overload the *= operator with a matrix
+   * @param lambda the matrix to multiply with
+   * @return the CartesianTwist multiplied by lambda
+   */
+  CartesianTwist& operator*=(const Eigen::Matrix<double, 6, 6>& lambda);
 
-		/**
-	 	 * @brief Overload the - operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector
-	 	 * @param twist CartesianTwist to substract
-	 	 * @return the Eigen Vector minus the CartesianTwist represented as a CartesianTwist
-	     */
-		friend const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist);
+  /**
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_linear the maximum magnitude of the linear velocity
+   * @param max_angular the maximum magnitude of the angular velocity
+   * @param linear_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   */
+  void clamp(double max_linear, double max_angular, double linear_noise_ratio = 0, double angular_noise_ratio = 0);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianTwist provided multiplied by lambda
-	     */
-		friend const CartesianTwist operator*(double lambda, const CartesianTwist& twist);
+  /**
+   * @brief Return the clamped velocity
+   * @param max_linear the maximum magnitude of the linear velocity
+   * @param max_angular the maximum magnitude of the angular velocity
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   * @return the clamped velocity
+   */
+  const CartesianTwist clamped(double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0) const;
 
-		/**
-	 	 * @brief Overload the * operator with a matrix
-	 	 * @param lambda the matrix to multiply with
-	 	 * @return the CartesianTwist provided multiplied by lambda
-	     */
-		friend const CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist);
+  /**
+   * @brief Return a copy of the CartesianTwist
+   * @return the copy
+   */
+  const CartesianTwist copy() const;
 
-		/**
-	 	 * @brief Overload the * operator with a time period
-	 	 * @param dt the time period to multiply with
-	 	 * @return the CartesianPose corresponding to the displacement over the time period
-	     */
-		friend const CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist);
+  /**
+   * @brief Return the value of the 6D twist as Eigen array
+   * @retrun the Eigen array representing the twist
+   */
+  const Eigen::Array<double, 6, 1> array() const;
 
-		/**
-	 	 * @brief Overload the * operator with a time period
-	 	 * @param dt the time period to multiply with
-	 	 * @return the CartesianPose corresponding to the displacement over the time period
-	     */
-		friend const CartesianPose operator*(const CartesianTwist& twist, const std::chrono::nanoseconds& dt);
-	};
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to happend the string representing the CartesianTwist to
+   * @param CartesianTwist the CartesianTwist to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist);
 
-	inline CartesianTwist& CartesianTwist::operator=(const CartesianTwist& twist)
-	{
-		CartesianState::operator=(twist);
-		return (*this);
-	}
+  /**
+   * @brief Overload the + operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to add
+   * @param twist CartesianTwist to add
+   * @return the Eigen Vector plus the CartesianTwist represented as a CartesianTwist
+   */
+  friend const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the - operator with a 6D Eigen Vector
+   * @param vector Eigen Vector
+   * @param twist CartesianTwist to substract
+   * @return the Eigen Vector minus the CartesianTwist represented as a CartesianTwist
+   */
+  friend const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianTwist provided multiplied by lambda
+   */
+  friend const CartesianTwist operator*(double lambda, const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the * operator with a matrix
+   * @param lambda the matrix to multiply with
+   * @return the CartesianTwist provided multiplied by lambda
+   */
+  friend const CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the CartesianPose corresponding to the displacement over the time period
+   */
+  friend const CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the CartesianPose corresponding to the displacement over the time period
+   */
+  friend const CartesianPose operator*(const CartesianTwist& twist, const std::chrono::nanoseconds& dt);
+};
+
+inline CartesianTwist& CartesianTwist::operator=(const CartesianTwist& twist) {
+  CartesianState::operator=(twist);
+  return (*this);
 }
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
@@ -63,7 +63,7 @@ public:
    * @param the name of the reference frame
    * @return CartesianTwist with zero values
    */
-  static const CartesianTwist Zero(const std::string& name, const std::string& reference = "world");
+  static CartesianTwist Zero(const std::string& name, const std::string& reference = "world");
 
   /**
    * @brief Constructor for a random twist
@@ -71,7 +71,7 @@ public:
    * @param the name of the reference frame
    * @return CartesianTwist random twist
    */
-  static const CartesianTwist Random(const std::string& name, const std::string& reference = "world");
+  static CartesianTwist Random(const std::string& name, const std::string& reference = "world");
 
   /**
    * @brief Copy assignement operator that have to be defined to the custom assignement operator
@@ -87,12 +87,6 @@ public:
   CartesianTwist& operator=(const CartesianState& state);
 
   /**
-   * @brief Set the values of the 6D twist from a 6D Eigen Vector
-   * @param twist the twist as an Eigen Vector
-   */
-  CartesianTwist& operator=(const Eigen::Matrix<double, 6, 1>& twist);
-
-  /**
    * @brief Overload the *= operator
    * @param twist CartesianTwist to multiply with
    * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
@@ -104,28 +98,7 @@ public:
    * @param twist CartesianTwist to multiply with
    * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
    */
-  const CartesianTwist operator*(const CartesianTwist& twist) const;
-
-  /**
-   * @brief Overload the * operator with a state
-   * @param state CartesianState to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianState given in argument
-   */
-  const CartesianState operator*(const CartesianState& state) const;
-
-  /**
-   * @brief Overload the *= operator with a scalar
-   * @param lambda the scalar to multiply with
-   * @return the CartesianTwist multiplied by lambda
-   */
-  CartesianTwist& operator*=(double lambda);
-
-  /**
-   * @brief Overload the * operator with a scalar
-   * @param lambda the scalar to multiply with
-   * @return the CartesianState multiplied by lambda
-   */
-  const CartesianTwist operator*(double lambda) const;
+  CartesianTwist operator*(const CartesianTwist& twist) const;
 
   /**
    * @brief Overload the += operator
@@ -139,14 +112,7 @@ public:
    * @param twist CartesianTwist to add to
    * @return the current CartesianTwist added the CartesianTwist given in argument
    */
-  const CartesianTwist operator+(const CartesianTwist& twist) const;
-
-  /**
-   * @brief Overload the + operator with a state
-   * @param state CartesianState to add
-   * @return the current CartesianTwist added the CartesianState given in argument
-   */
-  const CartesianState operator+(const CartesianState& state) const;
+  CartesianTwist operator+(const CartesianTwist& twist) const;
 
   /**
    * @brief Overload the -= operator
@@ -160,49 +126,35 @@ public:
    * @param twist CartesianTwist to substract
    * @return the current CartesianTwist minus the CartesianTwist given in argument
    */
-  const CartesianTwist operator-(const CartesianTwist& twist) const;
+  CartesianTwist operator-(const CartesianTwist& twist) const;
 
   /**
-   * @brief Overload the - operator with a state
-   * @param state CartesianState to substract
-   * @return the current CartesianTwist minus the CartesianState given in argument
+   * @brief Overload the *= operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianTwist multiplied by lambda
    */
-  const CartesianState operator-(const CartesianState& state) const;
+  CartesianTwist& operator*=(double lambda);
 
   /**
-   * @brief Overload the += operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the CartesianTwist added the vector given in argument
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianState multiplied by lambda
    */
-  CartesianTwist& operator+=(const Eigen::Matrix<double, 6, 1>& vector);
+  CartesianTwist operator*(double lambda) const;
 
   /**
-   * @brief Overload the + operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the CartesianTwist added the vector given in argument
-   */
-  const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector) const;
-
-  /**
-   * @brief Overload the -= operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the CartesianTwist substracted the vector given in argument
-   */
-  CartesianTwist& operator-=(const Eigen::Matrix<double, 6, 1>& vector);
-
-  /**
-   * @brief Overload the - operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the CartesianTwist substracted the vector given in argument
-   */
-  const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector) const;
-
-  /**
-   * @brief Overload the *= operator with a matrix
+   * @brief Overload the *= operator with a gain matrix
    * @param lambda the matrix to multiply with
    * @return the CartesianTwist multiplied by lambda
    */
   CartesianTwist& operator*=(const Eigen::Matrix<double, 6, 6>& lambda);
+
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the CartesianPose corresponding to the displacement over the time period
+   */
+  CartesianPose operator*(const std::chrono::nanoseconds& dt) const;
 
   /**
    * @brief Clamp inplace the magnitude of the twist to the values in argument
@@ -225,19 +177,19 @@ public:
    * the angular velocity will be set to 0
    * @return the clamped twist
    */
-  const CartesianTwist clamped(double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0) const;
+  CartesianTwist clamped(double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0) const;
 
   /**
    * @brief Return a copy of the CartesianTwist
    * @return the copy
    */
-  const CartesianTwist copy() const;
+  CartesianTwist copy() const;
 
   /**
    * @brief Return the value of the 6D twist as Eigen array
    * @retrun the Eigen array representing the twist
    */
-  const Eigen::Array<double, 6, 1> array() const;
+  Eigen::Array<double, 6, 1> array() const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -248,48 +200,25 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist);
 
   /**
-   * @brief Overload the + operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to add
-   * @param twist CartesianTwist to add
-   * @return the Eigen Vector plus the CartesianTwist represented as a CartesianTwist
-   */
-  friend const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist);
-
-  /**
-   * @brief Overload the - operator with a 6D Eigen Vector
-   * @param vector Eigen Vector
-   * @param twist CartesianTwist to substract
-   * @return the Eigen Vector minus the CartesianTwist represented as a CartesianTwist
-   */
-  friend const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist);
-
-  /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
    * @return the CartesianTwist provided multiplied by lambda
    */
-  friend const CartesianTwist operator*(double lambda, const CartesianTwist& twist);
+  friend CartesianTwist operator*(double lambda, const CartesianTwist& twist);
 
   /**
-   * @brief Overload the * operator with a matrix
+   * @brief Overload the * operator with a gain matrix
    * @param lambda the matrix to multiply with
    * @return the CartesianTwist provided multiplied by lambda
    */
-  friend const CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist);
+  friend CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist);
 
   /**
    * @brief Overload the * operator with a time period
    * @param dt the time period to multiply with
    * @return the CartesianPose corresponding to the displacement over the time period
    */
-  friend const CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist);
-
-  /**
-   * @brief Overload the * operator with a time period
-   * @param dt the time period to multiply with
-   * @return the CartesianPose corresponding to the displacement over the time period
-   */
-  friend const CartesianPose operator*(const CartesianTwist& twist, const std::chrono::nanoseconds& dt);
+  friend CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist);
 };
 
 inline CartesianTwist& CartesianTwist::operator=(const CartesianTwist& twist) {

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
@@ -7,205 +7,223 @@
 
 #include "state_representation/Space/Cartesian/CartesianState.hpp"
 
-namespace StateRepresentation 
-{
-	/**
-	 * @class CartesianWrench
-	 * @brief Class to define wrench in cartesian space as 3D force and torque vectors
-	 */
-	class CartesianWrench: public CartesianState
-	{
-	public:
-		/**
-		 * Empty constructor
-		 */
-		explicit CartesianWrench();
+namespace StateRepresentation {
+/**
+ * @class CartesianWrench
+ * @brief Class to define wrench in cartesian space as 3D force and torque vectors
+ */
+class CartesianWrench : public CartesianState {
+public:
+  /**
+   * Empty constructor
+   */
+  explicit CartesianWrench();
 
-		/**
-	 	 * @brief Empty constructor for a CartesianWrench
-	     */
-		explicit CartesianWrench(const std::string& name, const std::string& reference="world");
+  /**
+   * @brief Empty constructor for a CartesianWrench
+   */
+  explicit CartesianWrench(const std::string& name, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Copy constructor
-	     */
-		CartesianWrench(const CartesianWrench& wrench);
+  /**
+   * @brief Copy constructor
+   */
+  CartesianWrench(const CartesianWrench& wrench);
 
-		/**
-	 	 * @brief Copy constructor from a CartesianState
-	     */
-		CartesianWrench(const CartesianState& state);
-		
-		/**
-	 	 * @brief Construct a CartesianWrench from a force given as a vector of coordinates.
-	     */
-		explicit CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const std::string& reference="world");
+  /**
+   * @brief Copy constructor from a CartesianState
+   */
+  CartesianWrench(const CartesianState& state);
 
-		/**
-	 	 * @brief Construct a CartesianWrench from a force given as a vector of coordinates and a quaternion.
-	     */
-		explicit CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianWrench from a force given as a vector of coordinates.
+   */
+  explicit CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const std::string& reference = "world");
 
-		/**
-	 	 * @brief Construct a CartesianWrench from a single 6d wrench vector
-	     */
-		explicit CartesianWrench(const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference="world");
+  /**
+   * @brief Construct a CartesianWrench from a force given as a vector of coordinates and a quaternion.
+   */
+  explicit CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque, const std::string& reference = "world");
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param pose the pose with value to assign
-		 * @return reference to the current pose with new values
-		 */
-		CartesianWrench& operator=(const CartesianWrench& pose);
+  /**
+   * @brief Construct a CartesianWrench from a single 6d wrench vector
+   */
+  explicit CartesianWrench(const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference = "world");
 
-		/**
-		 * @brief Set the values of the 6D wrench from a 6D Eigen Vector
-		 * @param wrench the wrench as an Eigen Vector
-		 */
-		CartesianWrench& operator=(const Eigen::Matrix<double, 6, 1>& wrench);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param pose the pose with value to assign
+   * @return reference to the current pose with new values
+   */
+  CartesianWrench& operator=(const CartesianWrench& pose);
 
-		/**
-	 	 * @brief Overload the += operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the CartesianWrench added the vector given in argument
-	     */
-		CartesianWrench& operator+=(const Eigen::Matrix<double, 6, 1>& vector);
+  /**
+   * @brief Overload the = operator from a CartesianState
+   * @param state CartesianState to get the wrench from
+   */
+  CartesianWrench& operator=(const CartesianState& state);
 
-		/**
-	 	 * @brief Overload the += operator
-	 	 * @param wrench CartesianWrench to add
-	 	 * @return the current CartesianWrench added the CartesianWrench given in argument
-	     */
-		CartesianWrench& operator+=(const CartesianWrench& wrench);
+  /**
+   * @brief Set the values of the 6D wrench from a 6D Eigen Vector
+   * @param wrench the wrench as an Eigen Vector
+   */
+  CartesianWrench& operator=(const Eigen::Matrix<double, 6, 1>& wrench);
 
-		/**
-	 	 * @brief Overload the + operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the CartesianWrench added the vector given in argument
-	     */
-		const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector) const;
+  /**
+   * @brief Overload the *= operator
+   * @param wrench CartesianWrench to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
+   */
+  CartesianWrench& operator*=(const CartesianWrench& twist);
 
-		/**
-	 	 * @brief Overload the + operator
-	 	 * @param wrench CartesianWrench to add
-	 	 * @return the current CartesianWrench added the CartesianWrench given in argument
-	     */
-		const CartesianWrench operator+(const CartesianWrench& wrench) const;
+  /**
+   * @brief Overload the * operator with a wrench
+   * @param wrench CartesianWrench to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
+   */
+  const CartesianWrench operator*(const CartesianWrench& twist) const;
 
-		/**
-	 	 * @brief Overload the -= operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the CartesianWrench substracted the vector given in argument
-	     */
-		CartesianWrench& operator-=(const Eigen::Matrix<double, 6, 1>& vector);
+  /**
+   * @brief Overload the * operator with a state
+   * @param state CartesianState to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianState given in argument
+   */
+  const CartesianState operator*(const CartesianState& state) const;
 
-		/**
-	 	 * @brief Overload the -= operator
-	 	 * @param wrench CartesianWrench to substract
-	 	 * @return the current CartesianWrench minus the CartesianWrench given in argument
-	     */
-		CartesianWrench& operator-=(const CartesianWrench& wrench);
+  /**
+   * @brief Overload the += operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the CartesianWrench added the vector given in argument
+   */
+  CartesianWrench& operator+=(const Eigen::Matrix<double, 6, 1>& vector);
 
-		/**
-	 	 * @brief Overload the - operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the CartesianWrench substracted the vector given in argument
-	     */
-		const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector) const;
+  /**
+   * @brief Overload the += operator
+   * @param wrench CartesianWrench to add
+   * @return the current CartesianWrench added the CartesianWrench given in argument
+   */
+  CartesianWrench& operator+=(const CartesianWrench& wrench);
 
-		/**
-	 	 * @brief Overload the - operator
-	 	 * @param wrench CartesianWrench to substract
-	 	 * @return the current CartesianWrench minus the CartesianWrench given in argument
-	     */
-		const CartesianWrench operator-(const CartesianWrench& wrench) const;
+  /**
+   * @brief Overload the + operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the CartesianWrench added the vector given in argument
+   */
+  const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector) const;
 
-		/**
-	 	 * @brief Overload the = operator from a CartesianState
-	 	 * @param state CartesianState to get the wrench from
-	     */
-		void operator=(const CartesianState& state);
+  /**
+   * @brief Overload the + operator
+   * @param wrench CartesianWrench to add
+   * @return the current CartesianWrench added the CartesianWrench given in argument
+   */
+  const CartesianWrench operator+(const CartesianWrench& wrench) const;
 
-		/**
-	 	 * @brief Overload the *= operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianWrench multiply by lambda
-	     */
-		CartesianWrench& operator*=(double lambda);
+  /**
+   * @brief Overload the -= operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the CartesianWrench substracted the vector given in argument
+   */
+  CartesianWrench& operator-=(const Eigen::Matrix<double, 6, 1>& vector);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianWrench multiply by lambda
-	     */
-		const CartesianWrench operator*(double lambda) const;
+  /**
+   * @brief Overload the -= operator
+   * @param wrench CartesianWrench to substract
+   * @return the current CartesianWrench minus the CartesianWrench given in argument
+   */
+  CartesianWrench& operator-=(const CartesianWrench& wrench);
 
-		/**
-		 * @brief Clamp inplace the magnitude of the force to the values in argument
-		 * @param max_force the maximum magnitude of the force
-		 * @param max_torque the maximum magnitude of the torque
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the signal will be set to 0
-		 */
-		void clamp(double max_force, double max_torque, double noise_ratio=0);
+  /**
+   * @brief Overload the - operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the CartesianWrench substracted the vector given in argument
+   */
+  const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector) const;
 
-		/**
-		 * @brief Return the clamped velocity
-		 * @param max_force the maximum magnitude of the force
-		 * @param max_torque the maximum magnitude of the torque
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the signal will be set to 0
-		 * @return the clamped velocity
-		 */
-		const CartesianWrench clamped(double max_force, double max_torque, double noise_ratio=0) const;
+  /**
+   * @brief Overload the - operator
+   * @param wrench CartesianWrench to substract
+   * @return the current CartesianWrench minus the CartesianWrench given in argument
+   */
+  const CartesianWrench operator-(const CartesianWrench& wrench) const;
 
-		/**
-		 * @brief Return a copy of the CartesianWrench
-		 * @return the copy
-		 */
-		const CartesianWrench copy() const;
+  /**
+   * @brief Overload the *= operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianWrench multiply by lambda
+   */
+  CartesianWrench& operator*=(double lambda);
 
-		/**
-		 * @brief Return the value of the 6D wrench as Eigen array
-		 * @retrun the Eigen array representing the wrench
-		 */
-		const Eigen::Array<double, 6, 1> array() const;
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianWrench multiply by lambda
+   */
+  const CartesianWrench operator*(double lambda) const;
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to happend the string representing the CartesianWrench to
-	 	 * @param CartesianWrench the CartesianWrench to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench);
+  /**
+   * @brief Clamp inplace the magnitude of the force to the values in argument
+   * @param max_force the maximum magnitude of the force
+   * @param max_torque the maximum magnitude of the torque
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the signal will be set to 0
+   */
+  void clamp(double max_force, double max_torque, double noise_ratio = 0);
 
-		/**
-	 	 * @brief Overload the + operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @param wrench CartesianWrench to add
-	 	 * @return the Eigen Vector plus the CartesianWrench represented as a CartesianWrench
-	     */
-		friend const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench);
+  /**
+   * @brief Return the clamped velocity
+   * @param max_force the maximum magnitude of the force
+   * @param max_torque the maximum magnitude of the torque
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the signal will be set to 0
+   * @return the clamped velocity
+   */
+  const CartesianWrench clamped(double max_force, double max_torque, double noise_ratio = 0) const;
 
-		/**
-	 	 * @brief Overload the - operator with a 6D Eigen Vector
-	 	 * @param vector Eigen Vector
-	 	 * @param wrench CartesianWrench to substract
-	 	 * @return the Eigen Vector minus the CartesianWrench represented as a CartesianWrench
-	     */
-		friend const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench);
+  /**
+   * @brief Return a copy of the CartesianWrench
+   * @return the copy
+   */
+  const CartesianWrench copy() const;
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the CartesianWrench provided multiply by lambda
-	     */
-		friend const CartesianWrench operator*(double lambda, const CartesianWrench& wrench);
-	};
+  /**
+   * @brief Return the value of the 6D wrench as Eigen array
+   * @retrun the Eigen array representing the wrench
+   */
+  const Eigen::Array<double, 6, 1> array() const;
 
-	inline CartesianWrench& CartesianWrench::operator=(const CartesianWrench& wrench)
-	{
-		CartesianState::operator=(wrench);
-		return (*this);
-	}
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to happend the string representing the CartesianWrench to
+   * @param CartesianWrench the CartesianWrench to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench);
+
+  /**
+   * @brief Overload the + operator with a 6D Eigen Vector
+   * @param vector Eigen Vector to add
+   * @param wrench CartesianWrench to add
+   * @return the Eigen Vector plus the CartesianWrench represented as a CartesianWrench
+   */
+  friend const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench);
+
+  /**
+   * @brief Overload the - operator with a 6D Eigen Vector
+   * @param vector Eigen Vector
+   * @param wrench CartesianWrench to substract
+   * @return the Eigen Vector minus the CartesianWrench represented as a CartesianWrench
+   */
+  friend const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench);
+
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianWrench provided multiply by lambda
+   */
+  friend const CartesianWrench operator*(double lambda, const CartesianWrench& wrench);
+};
+
+inline CartesianWrench& CartesianWrench::operator=(const CartesianWrench& wrench) {
+  CartesianState::operator=(wrench);
+  return (*this);
 }
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
@@ -55,7 +55,7 @@ public:
    * @param the name of the reference frame
    * @return CartesianWrench with zero values
    */
-  static const CartesianWrench Zero(const std::string& name, const std::string& reference = "world");
+  static CartesianWrench Zero(const std::string& name, const std::string& reference = "world");
 
   /**
    * @brief Constructor for a random wrench
@@ -63,7 +63,7 @@ public:
    * @param the name of the reference frame
    * @return CartesianWrench random wrench
    */
-  static const CartesianWrench Random(const std::string& name, const std::string& reference = "world");
+  static CartesianWrench Random(const std::string& name, const std::string& reference = "world");
 
   /**
    * @brief Copy assignement operator that have to be defined to the custom assignement operator
@@ -79,12 +79,6 @@ public:
   CartesianWrench& operator=(const CartesianState& state);
 
   /**
-   * @brief Set the values of the 6D wrench from a 6D Eigen Vector
-   * @param wrench the wrench as an Eigen Vector
-   */
-  CartesianWrench& operator=(const Eigen::Matrix<double, 6, 1>& wrench);
-
-  /**
    * @brief Overload the *= operator
    * @param wrench CartesianWrench to multiply with
    * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
@@ -96,21 +90,7 @@ public:
    * @param wrench CartesianWrench to multiply with
    * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
    */
-  const CartesianWrench operator*(const CartesianWrench& twist) const;
-
-  /**
-   * @brief Overload the * operator with a state
-   * @param state CartesianState to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianState given in argument
-   */
-  const CartesianState operator*(const CartesianState& state) const;
-
-  /**
-   * @brief Overload the += operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the CartesianWrench added the vector given in argument
-   */
-  CartesianWrench& operator+=(const Eigen::Matrix<double, 6, 1>& vector);
+  CartesianWrench operator*(const CartesianWrench& twist) const;
 
   /**
    * @brief Overload the += operator
@@ -120,25 +100,11 @@ public:
   CartesianWrench& operator+=(const CartesianWrench& wrench);
 
   /**
-   * @brief Overload the + operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the CartesianWrench added the vector given in argument
-   */
-  const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector) const;
-
-  /**
    * @brief Overload the + operator
    * @param wrench CartesianWrench to add
    * @return the current CartesianWrench added the CartesianWrench given in argument
    */
-  const CartesianWrench operator+(const CartesianWrench& wrench) const;
-
-  /**
-   * @brief Overload the -= operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the CartesianWrench substracted the vector given in argument
-   */
-  CartesianWrench& operator-=(const Eigen::Matrix<double, 6, 1>& vector);
+  CartesianWrench operator+(const CartesianWrench& wrench) const;
 
   /**
    * @brief Overload the -= operator
@@ -148,18 +114,11 @@ public:
   CartesianWrench& operator-=(const CartesianWrench& wrench);
 
   /**
-   * @brief Overload the - operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the CartesianWrench substracted the vector given in argument
-   */
-  const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector) const;
-
-  /**
    * @brief Overload the - operator
    * @param wrench CartesianWrench to substract
    * @return the current CartesianWrench minus the CartesianWrench given in argument
    */
-  const CartesianWrench operator-(const CartesianWrench& wrench) const;
+  CartesianWrench operator-(const CartesianWrench& wrench) const;
 
   /**
    * @brief Overload the *= operator with a scalar
@@ -173,7 +132,7 @@ public:
    * @param lambda the scalar to multiply with
    * @return the CartesianWrench multiply by lambda
    */
-  const CartesianWrench operator*(double lambda) const;
+  CartesianWrench operator*(double lambda) const;
 
   /**
    * @brief Clamp inplace the magnitude of the wrench to the values in argument
@@ -196,19 +155,19 @@ public:
    * the torque will be set to 0
    * @return the clamped wrench
    */
-  const CartesianWrench clamped(double max_force, double max_torque, double force_noise_ratio = 0, double torque_noise_ratio = 0) const;
+  CartesianWrench clamped(double max_force, double max_torque, double force_noise_ratio = 0, double torque_noise_ratio = 0) const;
 
   /**
    * @brief Return a copy of the CartesianWrench
    * @return the copy
    */
-  const CartesianWrench copy() const;
+  CartesianWrench copy() const;
 
   /**
    * @brief Return the value of the 6D wrench as Eigen array
    * @retrun the Eigen array representing the wrench
    */
-  const Eigen::Array<double, 6, 1> array() const;
+  Eigen::Array<double, 6, 1> array() const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -219,27 +178,11 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench);
 
   /**
-   * @brief Overload the + operator with a 6D Eigen Vector
-   * @param vector Eigen Vector to add
-   * @param wrench CartesianWrench to add
-   * @return the Eigen Vector plus the CartesianWrench represented as a CartesianWrench
-   */
-  friend const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench);
-
-  /**
-   * @brief Overload the - operator with a 6D Eigen Vector
-   * @param vector Eigen Vector
-   * @param wrench CartesianWrench to substract
-   * @return the Eigen Vector minus the CartesianWrench represented as a CartesianWrench
-   */
-  friend const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench);
-
-  /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
    * @return the CartesianWrench provided multiply by lambda
    */
-  friend const CartesianWrench operator*(double lambda, const CartesianWrench& wrench);
+  friend CartesianWrench operator*(double lambda, const CartesianWrench& wrench);
 };
 
 inline CartesianWrench& CartesianWrench::operator=(const CartesianWrench& wrench) {

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
@@ -160,23 +160,27 @@ public:
   const CartesianWrench operator*(double lambda) const;
 
   /**
-   * @brief Clamp inplace the magnitude of the force to the values in argument
+   * @brief Clamp inplace the magnitude of the wrench to the values in argument
    * @param max_force the maximum magnitude of the force
    * @param max_torque the maximum magnitude of the torque
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the signal will be set to 0
+   * @param force_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the force will be set to 0
+   * @param torque_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
    */
-  void clamp(double max_force, double max_torque, double noise_ratio = 0);
+  void clamp(double max_force, double max_torque, double force_noise_ratio = 0, double torque_noise_ratio = 0);
 
   /**
-   * @brief Return the clamped velocity
+   * @brief Return the clamped wrench
    * @param max_force the maximum magnitude of the force
    * @param max_torque the maximum magnitude of the torque
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the signal will be set to 0
-   * @return the clamped velocity
+   * @param force_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the force will be set to 0
+   * @param torque_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
+   * @return the clamped wrench
    */
-  const CartesianWrench clamped(double max_force, double max_torque, double noise_ratio = 0) const;
+  const CartesianWrench clamped(double max_force, double max_torque, double force_noise_ratio = 0, double torque_noise_ratio = 0) const;
 
   /**
    * @brief Return a copy of the CartesianWrench

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
@@ -50,6 +50,22 @@ public:
   explicit CartesianWrench(const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference = "world");
 
   /**
+   * @brief Constructor for the zero wrench
+   * @param name the name of the state
+   * @param the name of the reference frame
+   * @return CartesianWrench with zero values
+   */
+  static const CartesianWrench Zero(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Constructor for a random wrench
+   * @param name the name of the state
+   * @param the name of the reference frame
+   * @return CartesianWrench random wrench
+   */
+  static const CartesianWrench Random(const std::string& name, const std::string& reference = "world");
+
+  /**
    * @brief Copy assignement operator that have to be defined to the custom assignement operator
    * @param pose the pose with value to assign
    * @return reference to the current pose with new values

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -5,216 +5,201 @@
 
 #pragma once
 
+#include "state_representation/MathTools.hpp"
+#include <assert.h>
+#include <chrono>
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
 #include <iostream>
-#include <chrono>
 #include <typeinfo>
-#include <assert.h>
-#include "state_representation/MathTools.hpp"
 
-namespace StateRepresentation 
-{
-	enum class StateType
-	{
-		STATE,
-		CARTESIANSTATE,
-		DUALQUATERNIONSTATE,
-		JOINTSTATE,
-		JACOBIANMATRIX,
-		TRAJECTORY,
-		GEOMETRY_SHAPE,
-		GEOMETRY_ELLIPSOID,
-		PARAMETER_DOUBLE,
-		PARAMETER_DOUBLE_ARRAY,
-		PARAMETER_BOOL,
-		PARAMETER_BOOL_ARRAY,
-		PARAMETER_STRING,
-		PARAMETER_STRING_ARRAY,
-		PARAMETER_CARTESIANSTATE,
-		PARAMETER_CARTESIANPOSE,
-		PARAMETER_JOINTSTATE,
-		PARAMETER_JOINTPOSITIONS,
-		PARAMETER_ELLIPSOID,
-		PARAMETER_MATRIX
-	};
+namespace StateRepresentation {
+enum class StateType {
+  STATE,
+  CARTESIANSTATE,
+  DUALQUATERNIONSTATE,
+  JOINTSTATE,
+  JACOBIANMATRIX,
+  TRAJECTORY,
+  GEOMETRY_SHAPE,
+  GEOMETRY_ELLIPSOID,
+  PARAMETER_DOUBLE,
+  PARAMETER_DOUBLE_ARRAY,
+  PARAMETER_BOOL,
+  PARAMETER_BOOL_ARRAY,
+  PARAMETER_STRING,
+  PARAMETER_STRING_ARRAY,
+  PARAMETER_CARTESIANSTATE,
+  PARAMETER_CARTESIANPOSE,
+  PARAMETER_JOINTSTATE,
+  PARAMETER_JOINTPOSITIONS,
+  PARAMETER_ELLIPSOID,
+  PARAMETER_MATRIX
+};
 
-	/**
-	 * @class State
-	 * @brief Abstract class to represent a state
-	 */
-	class State
-	{
-	private:
-		StateType type_; ///< type of the State
-		std::string name_; ///< name of the state
-		bool empty_;  ///< indicate if the state is empty
-		std::chrono::time_point<std::chrono::steady_clock> timestamp_;  ///< time since last modification made to the state
-	
-	public:
-		/**
-		 * @brief Empty constructor
-		 */
-		explicit State();
+/**
+ * @class State
+ * @brief Abstract class to represent a state
+ */
+class State {
+private:
+  StateType type_;                                              ///< type of the State
+  std::string name_;                                            ///< name of the state
+  bool empty_;                                                  ///< indicate if the state is empty
+  std::chrono::time_point<std::chrono::steady_clock> timestamp_;///< time since last modification made to the state
 
-		/**
-	 	 * @brief Constructor only specifying the type of the state from the StateType enumeration
-	 	 * @param type the type of State 
-	     */
-		explicit State(const StateType& type);
-		
-		/**
-	 	 * @brief Constructor with name and reference frame specification
-	 	 * @param type the type of State
-	 	 * @param name the name of the State
-	 	 * @param empty specify if the state is initialized as empty, default true
-	     */
-		explicit State(const StateType& type, const std::string& name, const bool& empty=true);
+public:
+  /**
+   * @brief Empty constructor
+   */
+  explicit State();
 
-		/**
-	 	 * @brief Copy constructor from another State
-	     */
-		State(const State& state);
+  /**
+   * @brief Constructor only specifying the type of the state from the StateType enumeration
+   * @param type the type of State 
+   */
+  explicit State(const StateType& type);
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param state the state with value to assign
-		 * @return reference to the current state with new values
-		 */
-		State& operator=(const State& state);
+  /**
+   * @brief Constructor with name and reference frame specification
+   * @param type the type of State
+   * @param name the name of the State
+   * @param empty specify if the state is initialized as empty, default true
+   */
+  explicit State(const StateType& type, const std::string& name, const bool& empty = true);
 
-		/**
-	 	 * @brief Getter of the type attribute
-	 	 * @return the type of the State
-	     */
-		const StateType& get_type() const;
+  /**
+   * @brief Copy constructor from another State
+   */
+  State(const State& state);
 
-		/**
-	 	 * @brief Getter of the empty attribute
-	     */
-		bool is_empty() const;
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param state the state with value to assign
+   * @return reference to the current state with new values
+   */
+  State& operator=(const State& state);
 
-		/**
-	 	 * @brief Setter of the empty attribute to true
-	     */
-		void set_empty();
+  /**
+   * @brief Getter of the type attribute
+   * @return the type of the State
+   */
+  const StateType& get_type() const;
 
-		/**
-	 	 * @brief Setter of the empty attribute to false and also reset the timestamp
-	     */
-		void set_filled();
+  /**
+   * @brief Getter of the empty attribute
+   */
+  bool is_empty() const;
 
-		/**
-	 	 * @brief Getter of the timestamp attribute
-	     */
-		const std::chrono::time_point<std::chrono::steady_clock>& get_timestamp() const;
+  /**
+   * @brief Setter of the empty attribute to true
+   */
+  void set_empty();
 
-		/**
-	 	 * @brief Reset the timestramp attribute to now
-	     */
-		void reset_timestamp();
+  /**
+   * @brief Setter of the empty attribute to false and also reset the timestamp
+   */
+  void set_filled();
 
-		/**
-	 	 * @brief Getter of the name as const reference
-	     */
-		const std::string& get_name() const;
+  /**
+   * @brief Getter of the timestamp attribute
+   */
+  const std::chrono::time_point<std::chrono::steady_clock>& get_timestamp() const;
 
-		/**
-	 	 * @brief Setter of the name
-	     */
-		virtual void set_name(const std::string& name);
+  /**
+   * @brief Reset the timestramp attribute to now
+   */
+  void reset_timestamp();
 
-		/**
-	 	 * @brief Check if the state is deprecated given a certain time delay
-	 	 * @param time_delay the time after which to consider the state as deprecated
-	     */
-	    template <typename DurationT>
-		bool is_deprecated(const std::chrono::duration<int64_t, DurationT>& time_delay);
+  /**
+   * @brief Getter of the name as const reference
+   */
+  const std::string& get_name() const;
 
-		/**
-	 	 * @brief Check if the state is compatible for operations with the state given as argument
-	 	 * @param state the state to check compatibility with
-	     */
-		virtual bool is_compatible(const State& state) const;
+  /**
+   * @brief Setter of the name
+   */
+  virtual void set_name(const std::string& name);
 
-		/**
-	 	 * @brief Initialize the State to a zero value
-	     */
-		virtual void initialize();
+  /**
+   * @brief Check if the state is deprecated given a certain time delay
+   * @param time_delay the time after which to consider the state as deprecated
+   */
+  template <typename DurationT>
+  bool is_deprecated(const std::chrono::duration<int64_t, DurationT>& time_delay);
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to happend the string representing the State to
-	 	 * @param state the State to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const State& state);
-	};
+  /**
+   * @brief Check if the state is compatible for operations with the state given as argument
+   * @param state the state to check compatibility with
+   */
+  virtual bool is_compatible(const State& state) const;
 
-	inline State& State::operator=(const State& state)
-	{
-		this->type_ = state.type_;
-		this->name_ = state.name_;
-		this->empty_ = state.empty_;
-		this->timestamp_ = std::chrono::steady_clock::now();
-		return (*this);
-	}
+  /**
+   * @brief Initialize the State to a zero value
+   */
+  virtual void initialize();
 
-	inline const StateType& State::get_type() const
-	{
-		return this->type_;
-	}
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to happend the string representing the State to
+   * @param state the State to print
+   * @return the appended ostream 
+   */
+  friend std::ostream& operator<<(std::ostream& os, const State& state);
+};
 
-	inline bool State::is_empty() const
-	{
-		return this->empty_;
-	}
-
-	inline void State::set_empty()
-	{
-		this->empty_ = true;
-	}
-
-	inline void State::set_filled()
-	{
-		this->empty_ = false;
-		this->reset_timestamp();
-	}
-
-	inline const std::chrono::time_point<std::chrono::steady_clock>& State::get_timestamp() const
-	{
-		return this->timestamp_;
-	}
-
-	inline void State::reset_timestamp()
-	{
-		this->timestamp_ = std::chrono::steady_clock::now();
-	}
-
-	template <typename DurationT>
-	inline bool State::is_deprecated(const std::chrono::duration<int64_t, DurationT>& time_delay)
-	{
-		return ((std::chrono::steady_clock::now() - this->timestamp_) > time_delay);
-	}
-
-	inline const std::string& State::get_name() const
-	{ 
-		return this->name_;
-	}
-
-	inline void State::set_name(const std::string& name)
-	{
-		this->name_ = name;
-	}
-
-	inline bool State::is_compatible(const State& state) const
-	{
-		bool compatible = (this->name_ == state.name_);
-		return compatible;
-	}
-
-	inline void State::initialize()
-	{
-		this->empty_ = true;
-	}
+inline State& State::operator=(const State& state) {
+  this->type_ = state.type_;
+  this->name_ = state.name_;
+  this->empty_ = state.empty_;
+  this->timestamp_ = std::chrono::steady_clock::now();
+  return (*this);
 }
+
+inline const StateType& State::get_type() const {
+  return this->type_;
+}
+
+inline bool State::is_empty() const {
+  return this->empty_;
+}
+
+inline void State::set_empty() {
+  this->empty_ = true;
+}
+
+inline void State::set_filled() {
+  this->empty_ = false;
+  this->reset_timestamp();
+}
+
+inline const std::chrono::time_point<std::chrono::steady_clock>& State::get_timestamp() const {
+  return this->timestamp_;
+}
+
+inline void State::reset_timestamp() {
+  this->timestamp_ = std::chrono::steady_clock::now();
+}
+
+template <typename DurationT>
+inline bool State::is_deprecated(const std::chrono::duration<int64_t, DurationT>& time_delay) {
+  return ((std::chrono::steady_clock::now() - this->timestamp_) > time_delay);
+}
+
+inline const std::string& State::get_name() const {
+  return this->name_;
+}
+
+inline void State::set_name(const std::string& name) {
+  this->name_ = name;
+}
+
+inline bool State::is_compatible(const State& state) const {
+  bool compatible = (this->name_ == state.name_);
+  return compatible;
+}
+
+inline void State::initialize() {
+  this->empty_ = true;
+}
+}// namespace StateRepresentation

--- a/source/state_representation/install.sh
+++ b/source/state_representation/install.sh
@@ -7,7 +7,7 @@ apt-get update && apt-get install -y \
 
 # install googletest
 mkdir ${SOURCE_PATH}/lib
-cd ${SOURCE_PATH}/lib && git clone https://github.com/google/googletest.git
+cd ${SOURCE_PATH}/lib && git clone --depth 1 --branch v1.10.x https://github.com/google/googletest.git
 
 # install state_representation
 cd ${SOURCE_PATH} && mkdir -p build && cd build && cmake -Druntests="OFF" .. && make -j && make install

--- a/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
@@ -131,6 +131,10 @@ std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
   return os;
 }
 
+const CartesianPose operator*(double lambda, const CartesianPose& pose) {
+  return pose * lambda;
+}
+
 const CartesianTwist operator/(const CartesianPose& pose, const std::chrono::nanoseconds& dt) {
   // sanity check
   if (pose.is_empty()) throw EmptyStateException(pose.get_name() + " state is empty");

--- a/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
@@ -1,238 +1,172 @@
 #include "state_representation/Space/Cartesian/CartesianPose.hpp"
-#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/Exceptions/IncompatibleSizeException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation 
-{
-	CartesianPose::CartesianPose()
-	{}
+namespace StateRepresentation {
+CartesianPose::CartesianPose() {}
 
-	CartesianPose::CartesianPose(const std::string& name, const std::string& reference):
-	CartesianState(name, reference)
-	{}
+CartesianPose::CartesianPose(const std::string& name, const std::string& reference) : CartesianState(name, reference) {}
 
-	CartesianPose::CartesianPose(const std::string& name, const Eigen::Vector3d& position, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_position(position);
-	}
-
-	CartesianPose::CartesianPose(const std::string& name, const double& x, const double& y, const double& z, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_position(x,y,z);
-	}
-
-	CartesianPose::CartesianPose(const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_position(position);
-		this->set_orientation(orientation);
-	}
-
-	CartesianPose::CartesianPose(const CartesianPose& pose):
-	CartesianState(pose)
-	{}
-
-	CartesianPose::CartesianPose(const CartesianState& state):
-	CartesianState(state)
-	{}
-
-	CartesianPose::CartesianPose(const CartesianTwist& twist):
-	CartesianState(std::chrono::seconds(1) * twist)
-	{}
-
-	const CartesianPose CartesianPose::Identity(const std::string& name, const std::string& reference)
-	{
-		return CartesianPose(name, Eigen::Vector3d::Zero(), Eigen::Quaterniond::Identity(), reference);
-	}
-
-	const CartesianPose CartesianPose::Random(const std::string& name, const std::string& reference)
-	{
-		return CartesianPose(name, Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom(), reference);
-	}
-
-	CartesianPose& CartesianPose::operator=(const Eigen::Matrix<double, 7, 1>& pose)
-	{
-		this->set_pose(pose);
-		return (*this);
-	}
-
-	CartesianPose& CartesianPose::operator=(const std::vector<double>& pose)
-	{
-		this->set_pose(pose);
-		return (*this);
-	}
-
-	CartesianPose& CartesianPose::operator*=(const CartesianPose& pose)
-	{
-		this->CartesianState::operator*=(pose);
-		return (*this);
-	}
-
-	const CartesianPose CartesianPose::operator*(const CartesianPose& pose) const
-	{
-		return this->CartesianState::operator*(pose);
-	}
-
-	const CartesianState CartesianPose::operator*(const CartesianState& state) const
-	{
-		return this->CartesianState::operator*(state);	
-	}
-
-	const Eigen::Vector3d CartesianPose::operator*(const Eigen::Vector3d& vector) const
-	{
-        return this->get_orientation() * vector + this->get_position();
-	}
-
-	CartesianPose& CartesianPose::operator+=(const CartesianPose& pose)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(pose.is_empty()) throw EmptyStateException(pose.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == pose.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// operation
-		this->set_position(this->get_position() + pose.get_position());
-		Eigen::Quaterniond orientation = (this->get_orientation().dot(pose.get_orientation()) > 0) ? pose.get_orientation() : Eigen::Quaterniond(-pose.get_orientation().coeffs());
-		this->set_orientation(this->get_orientation() * orientation);
-		return (*this);
-	}
-
-	const CartesianPose CartesianPose::operator+(const CartesianPose& pose) const
-	{
-		CartesianPose result(*this);
-		result += pose;
-		return result;
-	}
-
-	CartesianPose& CartesianPose::operator-=(const CartesianPose& pose)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(pose.is_empty()) throw EmptyStateException(pose.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == pose.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// operation
-		this->set_position(this->get_position() - pose.get_position());
-		Eigen::Quaterniond orientation = (this->get_orientation().dot(pose.get_orientation()) > 0) ? pose.get_orientation() : Eigen::Quaterniond(-pose.get_orientation().coeffs());
-		this->set_orientation(this->get_orientation() * orientation.conjugate());
-		return (*this);
-	}
-
-	const CartesianPose CartesianPose::operator-(const CartesianPose& pose) const
-	{
-		CartesianPose result(*this);
-		result -= pose;
-		return result;
-	}
-
-	CartesianPose& CartesianPose::operator*=(double lambda)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		// operation
-		this->set_position(lambda * this->get_position());
-		// calculate the scaled rotation as a displacement from identity
-		Eigen::Quaterniond w = MathTools::log(this->get_orientation());
-		// calculate the orientation corresponding to the scaled velocity
-		Eigen::Quaterniond qres = MathTools::exp(w, lambda / 2.);
-		if(this->get_orientation().dot(qres) < 0) qres = Eigen::Quaterniond(-qres.coeffs());
-		this->set_orientation(qres);
-		return (*this);
-	}
-
-	const CartesianPose CartesianPose::operator*(double lambda) const
-	{
-		CartesianPose result(*this);
-		result *= lambda;
-		return result;
-	}
-
-	const CartesianPose CartesianPose::copy() const
-	{
-		CartesianPose result(*this);
-		return result;
-	}
-
-	std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) 
-	{
-		if(pose.is_empty())
-		{
-			os << "Empty CartesianPose";
-		}
-		else
-		{
-			os << pose.get_name() << " CartesianPose expressed in " << pose.get_reference_frame() << " frame" << std::endl;
-	  		os << "position: (" << pose.get_position()(0) << ", ";
-	  		os << pose.get_position()(1) << ", ";
-	  		os << pose.get_position()(2) << ")" << std::endl;
-	  		os << "orientation: (" <<pose.get_orientation().w() << ", ";
-	  		os << pose.get_orientation().x() << ", ";
-	  		os << pose.get_orientation().y() << ", ";
-	  		os << pose.get_orientation().z() << ")";
-	  		Eigen::AngleAxisd axis_angle(pose.get_orientation());
-	  		os << " <=> theta: " << axis_angle.angle() << ", ";
-	  		os << "axis: (" << axis_angle.axis()(0) << ", ";
-	  		os << axis_angle.axis()(1) << ", ";
-	  		os << axis_angle.axis()(2) << ")";
-	  	}
-  		return os;
-	}
-
-	const CartesianPose operator*(double lambda, const CartesianPose& pose)
-	{
-		return pose * lambda;
-	}
-
-	const CartesianTwist operator/(const CartesianPose& pose, const std::chrono::nanoseconds& dt)
-	{
-		// sanity check
-		if(pose.is_empty()) throw EmptyStateException(pose.get_name() + " state is empty");
-		// operations
-		CartesianTwist twist(pose.get_name(), pose.get_reference_frame());
-		// convert the period to a double with the second as reference
-		double period = dt.count();
-		period /= 1e9;
-		// set linear velocity
-		twist.set_linear_velocity(pose.get_position() / period);
-		// set angular velocity from the log of the quaternion error
-		Eigen::Quaterniond log_q = MathTools::log(pose.get_orientation());
-		if(pose.get_orientation().dot(log_q) < 0) log_q = Eigen::Quaterniond(-log_q.coeffs());
-		twist.set_angular_velocity(2 * log_q.vec() / period);
-		return twist;
-	}
-
-	const std::vector<double> CartesianPose::to_std_vector() const
-	{
-		std::vector<double> pose = std::vector<double>(this->get_position().data(), this->get_position().data() + 3);
-		pose.resize(7);
-		pose[3] = this->get_orientation().w();
-		pose[4] = this->get_orientation().x();
-		pose[5] = this->get_orientation().y();
-		pose[6] = this->get_orientation().z();
-		return pose;
-	}
-
-	void CartesianPose::from_std_vector(const std::vector<double>& value)
-	{
-		if (value.size() == 3)
-		{
-			this->set_position(value);
-		}
-		else if (value.size() == 4)
-		{
-			this->set_orientation(value);
-		}
-		else if (value.size() == 7)
-		{
-			this->set_pose(value);
-		}
-		else
-		{
-			throw IncompatibleSizeException("The input vector is of incorrect size");
-		}
-	}
+CartesianPose::CartesianPose(const std::string& name, const Eigen::Vector3d& position, const std::string& reference) : CartesianState(name, reference) {
+  this->set_position(position);
 }
+
+CartesianPose::CartesianPose(const std::string& name, const double& x, const double& y, const double& z, const std::string& reference) : CartesianState(name, reference) {
+  this->set_position(x, y, z);
+}
+
+CartesianPose::CartesianPose(const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation, const std::string& reference) : CartesianState(name, reference) {
+  this->set_position(position);
+  this->set_orientation(orientation);
+}
+
+CartesianPose::CartesianPose(const CartesianPose& pose) : CartesianState(pose) {}
+
+CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state) {}
+
+CartesianPose::CartesianPose(const CartesianTwist& twist) : CartesianState(std::chrono::seconds(1) * twist) {}
+
+const CartesianPose CartesianPose::Identity(const std::string& name, const std::string& reference) {
+  return CartesianPose(name, Eigen::Vector3d::Zero(), Eigen::Quaterniond::Identity(), reference);
+}
+
+const CartesianPose CartesianPose::Random(const std::string& name, const std::string& reference) {
+  return CartesianPose(name, Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom(), reference);
+}
+
+CartesianPose& CartesianPose::operator=(const CartesianState& state) {
+  this->CartesianState::operator=(state);
+  return (*this);
+}
+
+CartesianPose& CartesianPose::operator=(const Eigen::Matrix<double, 7, 1>& pose) {
+  this->set_pose(pose);
+  return (*this);
+}
+
+CartesianPose& CartesianPose::operator=(const std::vector<double>& pose) {
+  this->set_pose(pose);
+  return (*this);
+}
+
+const Eigen::Vector3d CartesianPose::operator*(const Eigen::Vector3d& vector) const {
+  return this->get_orientation() * vector + this->get_position();
+}
+
+CartesianPose& CartesianPose::operator*=(const CartesianPose& pose) {
+  this->CartesianState::operator*=(pose);
+  return (*this);
+}
+
+const CartesianPose CartesianPose::operator*(const CartesianPose& pose) const {
+  return this->CartesianState::operator*(pose);
+}
+
+const CartesianState CartesianPose::operator*(const CartesianState& state) const {
+  return this->CartesianState::operator*(state);
+}
+
+CartesianPose& CartesianPose::operator*=(double lambda) {
+  this->CartesianState::operator*=(lambda);
+  return (*this);
+}
+
+const CartesianPose CartesianPose::operator*(double lambda) const {
+  return this->CartesianState::operator*(lambda);
+}
+
+CartesianPose& CartesianPose::operator+=(const CartesianPose& pose) {
+  this->CartesianState::operator+=(pose);
+  return (*this);
+}
+
+const CartesianPose CartesianPose::operator+(const CartesianPose& pose) const {
+  return this->CartesianState::operator+(pose);
+}
+
+const CartesianState CartesianPose::operator+(const CartesianState& state) const {
+  return this->CartesianState::operator+(state);
+}
+
+CartesianPose& CartesianPose::operator-=(const CartesianPose& pose) {
+  this->CartesianState::operator-=(pose);
+  return (*this);
+}
+
+const CartesianPose CartesianPose::operator-(const CartesianPose& pose) const {
+  return this->CartesianState::operator-(pose);
+}
+
+const CartesianState CartesianPose::operator-(const CartesianState& state) const {
+  return this->CartesianState::operator-(state);
+}
+
+const CartesianPose CartesianPose::copy() const {
+  CartesianPose result(*this);
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
+  if (pose.is_empty()) {
+    os << "Empty CartesianPose";
+  } else {
+    os << pose.get_name() << " CartesianPose expressed in " << pose.get_reference_frame() << " frame" << std::endl;
+    os << "position: (" << pose.get_position()(0) << ", ";
+    os << pose.get_position()(1) << ", ";
+    os << pose.get_position()(2) << ")" << std::endl;
+    os << "orientation: (" << pose.get_orientation().w() << ", ";
+    os << pose.get_orientation().x() << ", ";
+    os << pose.get_orientation().y() << ", ";
+    os << pose.get_orientation().z() << ")";
+    Eigen::AngleAxisd axis_angle(pose.get_orientation());
+    os << " <=> theta: " << axis_angle.angle() << ", ";
+    os << "axis: (" << axis_angle.axis()(0) << ", ";
+    os << axis_angle.axis()(1) << ", ";
+    os << axis_angle.axis()(2) << ")";
+  }
+  return os;
+}
+
+const CartesianTwist operator/(const CartesianPose& pose, const std::chrono::nanoseconds& dt) {
+  // sanity check
+  if (pose.is_empty()) throw EmptyStateException(pose.get_name() + " state is empty");
+  // operations
+  CartesianTwist twist(pose.get_name(), pose.get_reference_frame());
+  // convert the period to a double with the second as reference
+  double period = dt.count();
+  period /= 1e9;
+  // set linear velocity
+  twist.set_linear_velocity(pose.get_position() / period);
+  // set angular velocity from the log of the quaternion error
+  Eigen::Quaterniond log_q = MathTools::log(pose.get_orientation());
+  if (pose.get_orientation().dot(log_q) < 0) log_q = Eigen::Quaterniond(-log_q.coeffs());
+  twist.set_angular_velocity(2 * log_q.vec() / period);
+  return twist;
+}
+
+const std::vector<double> CartesianPose::to_std_vector() const {
+  std::vector<double> pose = std::vector<double>(this->get_position().data(), this->get_position().data() + 3);
+  pose.resize(7);
+  pose[3] = this->get_orientation().w();
+  pose[4] = this->get_orientation().x();
+  pose[5] = this->get_orientation().y();
+  pose[6] = this->get_orientation().z();
+  return pose;
+}
+
+void CartesianPose::from_std_vector(const std::vector<double>& value) {
+  if (value.size() == 3) {
+    this->set_position(value);
+  } else if (value.size() == 4) {
+    this->set_orientation(value);
+  } else if (value.size() == 7) {
+    this->set_pose(value);
+  } else {
+    throw IncompatibleSizeException("The input vector is of incorrect size");
+  }
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -186,49 +186,49 @@ const CartesianState CartesianState::inverse() const {
   return result;
 }
 
-void CartesianState::clamp_field(double max_value, const CartesianStateFields& field_name, double noise_ratio) {
-  Eigen::VectorXd field_value = this->get_field(field_name);
+void CartesianState::clamp_state_variable(double max_value, const CartesianStateVariable& state_variable_type, double noise_ratio) {
+  Eigen::VectorXd state_variable_value = this->get_state_variable(state_variable_type);
   if (noise_ratio != 0) {
-    field_value -= noise_ratio * field_value.normalized();
+    state_variable_value -= noise_ratio * state_variable_value.normalized();
     // apply a deadzone
-    if (field_value.norm() < noise_ratio) field_value.setZero();
+    if (state_variable_value.norm() < noise_ratio) state_variable_value.setZero();
   }
   // clamp the values to their maximum amplitude provided
-  if (field_value.norm() > max_value) field_value = max_value * field_value.normalized();
-  this->set_field(field_value, field_name);
+  if (state_variable_value.norm() > max_value) state_variable_value = max_value * state_variable_value.normalized();
+  this->set_state_variable(state_variable_value, state_variable_type);
 }
 
-double CartesianState::dist(const CartesianState& state, const CartesianStateFields& field_name) const {
+double CartesianState::dist(const CartesianState& state, const CartesianStateVariable& state_variable_type) const {
   // sanity check
   if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
   if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
   if (!(this->get_reference_frame() == state.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
   // calculation
   double result = 0;
-  if (field_name == CartesianStateFields::POSITION || field_name == CartesianStateFields::POSE || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::POSITION || state_variable_type == CartesianStateVariable::POSE || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_position() - state.get_position()).norm();
   }
-  if (field_name == CartesianStateFields::ORIENTATION || field_name == CartesianStateFields::POSE || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::ORIENTATION || state_variable_type == CartesianStateVariable::POSE || state_variable_type == CartesianStateVariable::ALL) {
     // https://math.stackexchange.com/questions/90081/quaternion-distance for orientation
     double inner_product = this->get_orientation().dot(state.get_orientation());
     result += acos(2 * inner_product * inner_product - 1);
   }
-  if (field_name == CartesianStateFields::LINEAR_VELOCITY || field_name == CartesianStateFields::TWIST || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::LINEAR_VELOCITY || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_linear_velocity() - state.get_linear_velocity()).norm();
   }
-  if (field_name == CartesianStateFields::ANGULAR_VELOCITY || field_name == CartesianStateFields::TWIST || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::ANGULAR_VELOCITY || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_angular_velocity() - state.get_angular_velocity()).norm();
   }
-  if (field_name == CartesianStateFields::LINEAR_ACCELERATION || field_name == CartesianStateFields::ACCELERATIONS || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION || state_variable_type == CartesianStateVariable::ACCELERATIONS || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_linear_acceleration() - state.get_linear_acceleration()).norm();
   }
-  if (field_name == CartesianStateFields::ANGULAR_ACCELERATION || field_name == CartesianStateFields::ACCELERATIONS || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION || state_variable_type == CartesianStateVariable::ACCELERATIONS || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_angular_acceleration() - state.get_angular_acceleration()).norm();
   }
-  if (field_name == CartesianStateFields::FORCE || field_name == CartesianStateFields::WRENCH || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::FORCE || state_variable_type == CartesianStateVariable::WRENCH || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_force() - state.get_force()).norm();
   }
-  if (field_name == CartesianStateFields::TORQUE || field_name == CartesianStateFields::WRENCH || field_name == CartesianStateFields::ALL) {
+  if (state_variable_type == CartesianStateVariable::TORQUE || state_variable_type == CartesianStateVariable::WRENCH || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_torque() - state.get_torque()).norm();
   }
   return result;
@@ -277,8 +277,8 @@ const CartesianState operator*(double lambda, const CartesianState& state) {
   return state * lambda;
 }
 
-double dist(const CartesianState& s1, const CartesianState& s2, const CartesianStateFields& field_name) {
-  return s1.dist(s2, field_name);
+double dist(const CartesianState& s1, const CartesianState& s2, const CartesianStateVariable& state_variable_type) {
+  return s1.dist(s2, state_variable_type);
 }
 
 const std::vector<double> CartesianState::to_std_vector() const {

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -52,13 +52,13 @@ CartesianState& CartesianState::operator*=(double lambda) {
   return (*this);
 }
 
-const CartesianState CartesianState::operator*(double lambda) const {
+CartesianState CartesianState::operator*(double lambda) const {
   CartesianState result(*this);
   result *= lambda;
   return result;
 }
 
-const CartesianState CartesianState::copy() const {
+CartesianState CartesianState::copy() const {
   CartesianState result(*this);
   return result;
 }
@@ -97,7 +97,7 @@ CartesianState& CartesianState::operator*=(const CartesianState& state) {
   return (*this);
 }
 
-const CartesianState CartesianState::operator*(const CartesianState& state) const {
+CartesianState CartesianState::operator*(const CartesianState& state) const {
   CartesianState result(*this);
   result *= state;
   return result;
@@ -122,7 +122,7 @@ CartesianState& CartesianState::operator+=(const CartesianState& state) {
   return (*this);
 }
 
-const CartesianState CartesianState::operator+(const CartesianState& state) const {
+CartesianState CartesianState::operator+(const CartesianState& state) const {
   CartesianState result(*this);
   result += state;
   return result;
@@ -147,13 +147,13 @@ CartesianState& CartesianState::operator-=(const CartesianState& state) {
   return (*this);
 }
 
-const CartesianState CartesianState::operator-(const CartesianState& state) const {
+CartesianState CartesianState::operator-(const CartesianState& state) const {
   CartesianState result(*this);
   result -= state;
   return result;
 }
 
-const CartesianState CartesianState::inverse() const {
+CartesianState CartesianState::inverse() const {
   CartesianState result(*this);
   // inverse name and reference frame
   std::string ref = result.get_reference_frame();
@@ -273,7 +273,7 @@ std::ostream& operator<<(std::ostream& os, const CartesianState& state) {
   return os;
 }
 
-const CartesianState operator*(double lambda, const CartesianState& state) {
+CartesianState operator*(double lambda, const CartesianState& state) {
   return state * lambda;
 }
 
@@ -281,7 +281,7 @@ double dist(const CartesianState& s1, const CartesianState& s2, const CartesianS
   return s1.dist(s2, state_variable_type);
 }
 
-const std::vector<double> CartesianState::to_std_vector() const {
+std::vector<double> CartesianState::to_std_vector() const {
   throw(NotImplementedException("to_std_vector() is not implemented for the base CartesianState class"));
   return std::vector<double>();
 }

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -5,261 +5,276 @@
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation 
-{
-	CartesianState::CartesianState():
-	SpatialState(StateType::CARTESIANSTATE)
-	{
-		this->initialize();
-	}
-
-	CartesianState::CartesianState(const std::string& robot_name, const std::string& reference):
-	SpatialState(StateType::CARTESIANSTATE, robot_name, reference)
-	{
-		this->initialize();
-	}
-
-	CartesianState::CartesianState(const CartesianState& state):
-	SpatialState(state),
-	position(state.position), orientation(state.orientation),
-	linear_velocity(state.linear_velocity), angular_velocity(state.angular_velocity),
-	linear_acceleration(state.linear_acceleration), angular_acceleration(state.angular_acceleration),
-	force(state.force), torque(state.torque)
-	{}
-
-	void CartesianState::initialize()
-	{
-		this->State::initialize();
-		this->set_zero();
-	}
-
-	void CartesianState::set_zero()
-	{
-		this->position.setZero();
-		this->orientation.setIdentity();
-		this->linear_velocity.setZero();
-		this->angular_velocity.setZero();
-		this->linear_acceleration.setZero();
-		this->angular_acceleration.setZero();
-		this->force.setZero();
-		this->torque.setZero();
-	}
-
-	CartesianState& CartesianState::operator*=(double lambda)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		// operation
-		this->set_position(lambda * this->get_position());
-		// calculate the scaled rotation as a displacement from identity
-		Eigen::Quaterniond w = MathTools::log(this->get_orientation());
-		// calculate the orientation corresponding to the scaled velocity
-		this->set_orientation(MathTools::exp(w, lambda / 2.));
-		// calculate the other vectors normally
-		this->set_linear_velocity(lambda * this->get_linear_velocity());
-		this->set_angular_velocity(lambda * this->get_angular_velocity());
-		this->set_linear_acceleration(lambda * this->get_linear_acceleration());
-		this->set_angular_acceleration(lambda * this->get_angular_acceleration());
-		this->set_force(lambda * this->get_force());
-		this->set_torque(lambda * this->get_torque());
-		return (*this);
-	}
-
-	const CartesianState CartesianState::operator*(double lambda) const
-	{
-		CartesianState result(*this);
-		result *= lambda;
-		return result;
-	}
-
-	const CartesianState CartesianState::copy() const
-	{
-		CartesianState result(*this);
-		return result;
-	}
-
-	CartesianState& CartesianState::operator*=(const CartesianState& state)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		if(this->get_name() != state.get_reference_frame()) throw IncompatibleReferenceFramesException("Expected " + this->get_name() + ", got " + state.get_reference_frame());
-		this->set_name(state.get_name());
-		// intermediate variables for f_S_b
-		Eigen::Vector3d f_P_b = this->get_position();
-		Eigen::Quaterniond f_R_b = this->get_orientation();
-		Eigen::Vector3d f_v_b = this->get_linear_velocity();
-		Eigen::Vector3d f_omega_b = this->get_angular_velocity();
-		Eigen::Vector3d f_a_b = this->get_linear_acceleration();
-		Eigen::Vector3d f_alpha_b = this->get_angular_acceleration();
-		// intermediate variables for b_S_c
-		Eigen::Vector3d b_P_c = state.get_position();
-		Eigen::Quaterniond b_R_c = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(-state.get_orientation().coeffs());
-		Eigen::Vector3d b_v_c = state.get_linear_velocity();
-		Eigen::Vector3d b_omega_c = state.get_angular_velocity();
-		Eigen::Vector3d b_a_c = state.get_linear_acceleration();
-		Eigen::Vector3d b_alpha_c = state.get_angular_acceleration();
-		// pose
-		this->set_position(f_P_b + f_R_b * b_P_c);
-		this->set_orientation(f_R_b * b_R_c);
-		// twist
-		this->set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
-		this->set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
-		// acceleration
-		this->set_linear_acceleration(f_a_b + f_R_b * b_a_c + f_alpha_b.cross(f_R_b * b_P_c) + 2 * f_omega_b.cross(f_R_b * b_v_c) + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
-		this->set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
-		// wrench
-		//TODO
-		return (*this);
-	}
-
-	const CartesianState CartesianState::operator*(const CartesianState& state) const
-	{
-		CartesianState result(*this);
-		result *= state;
-		return result;
-	}
-
-	const CartesianState CartesianState::inverse() const
-	{
-		CartesianState result(*this);
-		// inverse name and reference frame
-		std::string ref = result.get_reference_frame();
-		std::string name = result.get_name();
-		result.set_reference_frame(name);
-		result.set_name(ref);
-		// intermediate variables for f_S_b
-		Eigen::Vector3d f_P_b = this->get_position();
-		Eigen::Quaterniond f_R_b = this->get_orientation();
-		Eigen::Vector3d f_v_b = this->get_linear_velocity();
-		Eigen::Vector3d f_omega_b = this->get_angular_velocity();
-		Eigen::Vector3d f_a_b = this->get_linear_acceleration();
-		Eigen::Vector3d f_alpha_b = this->get_angular_acceleration();
-		// computation for b_S_f
-		Eigen::Quaterniond b_R_f = f_R_b.conjugate();
-		Eigen::Vector3d b_P_f = b_R_f * (-f_P_b);
-		Eigen::Vector3d b_v_f = b_R_f * (-f_v_b);
-		Eigen::Vector3d b_omega_f = b_R_f * (-f_omega_b);
-		Eigen::Vector3d b_a_f = b_R_f * f_a_b; // not sure if minus is needed
-		Eigen::Vector3d b_alpha_f = b_R_f * f_alpha_b; // no minus for sure
-		// wrench
-		//TODO
-		// collect the results
-		result.set_position(b_P_f);
-		result.set_orientation(b_R_f);
-		result.set_linear_velocity(b_v_f);
-		result.set_angular_velocity(b_omega_f);
-		result.set_linear_acceleration(b_a_f);
-		result.set_angular_acceleration(b_alpha_f);
-		return result;
-	}
-
-	double CartesianState::dist(const CartesianState& state, const std::string& distance_type) const
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == state.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// calculation
-		double result = 0;
-		if (distance_type == "position" || distance_type == "pose" || distance_type == "all")
-		{
-			result += (this->get_position() - state.get_position()).norm();
-		}
-		if (distance_type == "orientation" || distance_type == "pose" || distance_type == "all")
-		{
-			// https://math.stackexchange.com/questions/90081/quaternion-distance for orientation
-			double inner_product = this->get_orientation().dot(state.get_orientation());
-			result += acos(2 * inner_product * inner_product - 1);
-		}
-		if (distance_type == "linear_velocity" || distance_type == "twist" || distance_type == "all")
-		{
-			result += (this->get_linear_velocity() - state.get_linear_velocity()).norm();
-		}
-		if (distance_type == "angular_velocity" || distance_type == "twist" || distance_type == "all")
-		{
-			result += (this->get_angular_velocity() - state.get_angular_velocity()).norm();
-		}
-		if (distance_type == "linear_acceleration" || distance_type == "acceleration" || distance_type == "all")
-		{
-			result += (this->get_linear_acceleration() - state.get_linear_acceleration()).norm();
-		}
-		if (distance_type == "angular_acceleration" || distance_type == "acceleration" || distance_type == "all")
-		{
-			result += (this->get_angular_acceleration() - state.get_angular_acceleration()).norm();
-		}
-		if (distance_type == "force" || distance_type == "wrench" || distance_type == "all")
-		{
-			result += (this->get_force() - state.get_force()).norm();
-		}
-		if (distance_type == "torque" || distance_type == "wrench" || distance_type == "all")
-		{
-			result += (this->get_torque() - state.get_torque()).norm();
-		}
-		return result;
-	}
-
-	std::ostream& operator<<(std::ostream& os, const CartesianState& state) 
-	{ 
-		if(state.is_empty())
-		{
-			os << "Empty CartesianState";
-		}
-		else
-		{
-			os << state.get_name() << " CartesianState expressed in " << state.get_reference_frame() << " frame" << std::endl;
-	  		os << "position: (" << state.position(0) << ", ";
-	  		os << state.position(1) << ", ";
-	  		os << state.position(2) << ")" << std::endl;
-	  		os << "orientation: (" <<state.orientation.w() << ", ";
-	  		os << state.orientation.x() << ", ";
-	  		os << state.orientation.y() << ", ";
-	  		os << state.orientation.z() << ")";
-	  		Eigen::AngleAxisd axis_angle(state.orientation);
-	  		os << " <=> theta: " << axis_angle.angle() << ", ";
-	  		os << "axis: (" << axis_angle.axis()(0) << ", ";
-	  		os << axis_angle.axis()(1) << ", ";
-	  		os << axis_angle.axis()(2) << ")" << std::endl;
-	  		os << "linear velocity: (" << state.linear_velocity(0) << ", ";
-	  		os << state.linear_velocity(1) << ", ";
-	  		os << state.linear_velocity(2) << ")" << std::endl;
-	  		os << "angular velocity: (" << state.angular_velocity(0) << ", ";
-	  		os << state.angular_velocity(1) << ", ";
-	  		os << state.angular_velocity(2) << ")" << std::endl;
-	  		os << "linear acceleration: (" << state.linear_acceleration(0) << ", ";
-	  		os << state.linear_acceleration(1) << ", ";
-	  		os << state.linear_acceleration(2) << ")" << std::endl;
-	  		os << "angular acceleration: (" << state.angular_acceleration(0) << ", ";
-	  		os << state.angular_acceleration(1) << ", ";
-	  		os << state.angular_acceleration(2) << ")" << std::endl;
-	  		os << "force: (" << state.force(0) << ", ";
-	  		os << state.force(1) << ", ";
-	  		os << state.force(2) << ")" << std::endl;
-	  		os << "torque: (" << state.torque(0) << ", ";
-	  		os << state.torque(1) << ", ";
-	  		os << state.torque(2) << ")";
-	  	}
-  		return os;
-	}
-
-	const CartesianState operator*(double lambda, const CartesianState& state)
-	{
-		return state * lambda;
-	}
-
-	double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type)
-	{
-		return s1.dist(s2, distance_type);
-	}
-
-	const std::vector<double> CartesianState::to_std_vector() const
-	{
-		throw(NotImplementedException("to_std_vector() is not implemented for the base CartesianState class"));
-		return std::vector<double>();
-	}
-
-	void CartesianState::from_std_vector(const std::vector<double>&)
-	{
-		throw(NotImplementedException("from_std_vector() is not implemented for the base CartesianState class"));
-	}
+namespace StateRepresentation {
+CartesianState::CartesianState() : SpatialState(StateType::CARTESIANSTATE) {
+  this->initialize();
 }
+
+CartesianState::CartesianState(const std::string& robot_name, const std::string& reference) : SpatialState(StateType::CARTESIANSTATE, robot_name, reference) {
+  this->initialize();
+}
+
+CartesianState::CartesianState(const CartesianState& state) : SpatialState(state),
+                                                              position(state.position), orientation(state.orientation),
+                                                              linear_velocity(state.linear_velocity), angular_velocity(state.angular_velocity),
+                                                              linear_acceleration(state.linear_acceleration), angular_acceleration(state.angular_acceleration),
+                                                              force(state.force), torque(state.torque) {}
+
+void CartesianState::initialize() {
+  this->State::initialize();
+  this->set_zero();
+}
+
+void CartesianState::set_zero() {
+  this->position.setZero();
+  this->orientation.setIdentity();
+  this->linear_velocity.setZero();
+  this->angular_velocity.setZero();
+  this->linear_acceleration.setZero();
+  this->angular_acceleration.setZero();
+  this->force.setZero();
+  this->torque.setZero();
+}
+
+CartesianState& CartesianState::operator*=(double lambda) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  // operation
+  this->set_position(lambda * this->get_position());
+  // calculate the scaled rotation as a displacement from identity
+  Eigen::Quaterniond w = MathTools::log(this->get_orientation());
+  // calculate the orientation corresponding to the scaled velocity
+  this->set_orientation(MathTools::exp(w, lambda / 2.));
+  // calculate the other vectors normally
+  this->set_twist(lambda * this->get_twist());
+  this->set_accelerations(lambda * this->get_accelerations());
+  this->set_wrench(lambda * this->get_wrench());
+  return (*this);
+}
+
+const CartesianState CartesianState::operator*(double lambda) const {
+  CartesianState result(*this);
+  result *= lambda;
+  return result;
+}
+
+const CartesianState CartesianState::copy() const {
+  CartesianState result(*this);
+  return result;
+}
+
+CartesianState& CartesianState::operator*=(const CartesianState& state) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (this->get_name() != state.get_reference_frame()) throw IncompatibleReferenceFramesException("Expected " + this->get_name() + ", got " + state.get_reference_frame());
+  this->set_name(state.get_name());
+  // intermediate variables for f_S_b
+  Eigen::Vector3d f_P_b = this->get_position();
+  Eigen::Quaterniond f_R_b = this->get_orientation();
+  Eigen::Vector3d f_v_b = this->get_linear_velocity();
+  Eigen::Vector3d f_omega_b = this->get_angular_velocity();
+  Eigen::Vector3d f_a_b = this->get_linear_acceleration();
+  Eigen::Vector3d f_alpha_b = this->get_angular_acceleration();
+  // intermediate variables for b_S_c
+  Eigen::Vector3d b_P_c = state.get_position();
+  Eigen::Quaterniond b_R_c = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(-state.get_orientation().coeffs());
+  Eigen::Vector3d b_v_c = state.get_linear_velocity();
+  Eigen::Vector3d b_omega_c = state.get_angular_velocity();
+  Eigen::Vector3d b_a_c = state.get_linear_acceleration();
+  Eigen::Vector3d b_alpha_c = state.get_angular_acceleration();
+  // pose
+  this->set_position(f_P_b + f_R_b * b_P_c);
+  this->set_orientation(f_R_b * b_R_c);
+  // twist
+  this->set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
+  this->set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
+  // acceleration
+  this->set_linear_acceleration(f_a_b + f_R_b * b_a_c + f_alpha_b.cross(f_R_b * b_P_c) + 2 * f_omega_b.cross(f_R_b * b_v_c) + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
+  this->set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
+  // wrench
+  //TODO
+  return (*this);
+}
+
+const CartesianState CartesianState::operator*(const CartesianState& state) const {
+  CartesianState result(*this);
+  result *= state;
+  return result;
+}
+
+CartesianState& CartesianState::operator+=(const CartesianState& state) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (!(this->get_reference_frame() == state.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
+  // operation on pose
+  this->set_position(this->get_position() + state.get_position());
+  // specific operation on quaternion using Hamilton product
+  Eigen::Quaterniond orientation = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(-state.get_orientation().coeffs());
+  this->set_orientation(this->get_orientation() * orientation);
+  // operation on twist
+  this->set_twist(this->get_twist() + state.get_twist());
+  // operation on accelerations
+  this->set_accelerations(this->get_accelerations() + state.get_accelerations());
+  // operation on wrench
+  this->set_wrench(this->get_wrench() + state.get_wrench());
+  return (*this);
+}
+
+const CartesianState CartesianState::operator+(const CartesianState& state) const {
+  CartesianState result(*this);
+  result += state;
+  return result;
+}
+
+CartesianState& CartesianState::operator-=(const CartesianState& state) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (!(this->get_reference_frame() == state.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
+  // operation on pose
+  this->set_position(this->get_position() - state.get_position());
+  // specific operation on quaternion using Hamilton product
+  Eigen::Quaterniond orientation = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(-state.get_orientation().coeffs());
+  this->set_orientation(this->get_orientation() * orientation.conjugate());
+  // operation on twist
+  this->set_twist(this->get_twist() - state.get_twist());
+  // operation on accelerations
+  this->set_accelerations(this->get_accelerations() - state.get_accelerations());
+  // operation on wrench
+  this->set_wrench(this->get_wrench() - state.get_wrench());
+  return (*this);
+}
+
+const CartesianState CartesianState::operator-(const CartesianState& state) const {
+  CartesianState result(*this);
+  result -= state;
+  return result;
+}
+
+const CartesianState CartesianState::inverse() const {
+  CartesianState result(*this);
+  // inverse name and reference frame
+  std::string ref = result.get_reference_frame();
+  std::string name = result.get_name();
+  result.set_reference_frame(name);
+  result.set_name(ref);
+  // intermediate variables for f_S_b
+  Eigen::Vector3d f_P_b = this->get_position();
+  Eigen::Quaterniond f_R_b = this->get_orientation();
+  Eigen::Vector3d f_v_b = this->get_linear_velocity();
+  Eigen::Vector3d f_omega_b = this->get_angular_velocity();
+  Eigen::Vector3d f_a_b = this->get_linear_acceleration();
+  Eigen::Vector3d f_alpha_b = this->get_angular_acceleration();
+  // computation for b_S_f
+  Eigen::Quaterniond b_R_f = f_R_b.conjugate();
+  Eigen::Vector3d b_P_f = b_R_f * (-f_P_b);
+  Eigen::Vector3d b_v_f = b_R_f * (-f_v_b);
+  Eigen::Vector3d b_omega_f = b_R_f * (-f_omega_b);
+  Eigen::Vector3d b_a_f = b_R_f * f_a_b;        // not sure if minus is needed
+  Eigen::Vector3d b_alpha_f = b_R_f * f_alpha_b;// no minus for sure
+  // wrench
+  //TODO
+  // collect the results
+  result.set_position(b_P_f);
+  result.set_orientation(b_R_f);
+  result.set_linear_velocity(b_v_f);
+  result.set_angular_velocity(b_omega_f);
+  result.set_linear_acceleration(b_a_f);
+  result.set_angular_acceleration(b_alpha_f);
+  return result;
+}
+
+double CartesianState::dist(const CartesianState& state, const std::string& distance_type) const {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (!(this->get_reference_frame() == state.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
+  // calculation
+  double result = 0;
+  if (distance_type == "position" || distance_type == "pose" || distance_type == "all") {
+    result += (this->get_position() - state.get_position()).norm();
+  }
+  if (distance_type == "orientation" || distance_type == "pose" || distance_type == "all") {
+    // https://math.stackexchange.com/questions/90081/quaternion-distance for orientation
+    double inner_product = this->get_orientation().dot(state.get_orientation());
+    result += acos(2 * inner_product * inner_product - 1);
+  }
+  if (distance_type == "linear_velocity" || distance_type == "twist" || distance_type == "all") {
+    result += (this->get_linear_velocity() - state.get_linear_velocity()).norm();
+  }
+  if (distance_type == "angular_velocity" || distance_type == "twist" || distance_type == "all") {
+    result += (this->get_angular_velocity() - state.get_angular_velocity()).norm();
+  }
+  if (distance_type == "linear_acceleration" || distance_type == "acceleration" || distance_type == "all") {
+    result += (this->get_linear_acceleration() - state.get_linear_acceleration()).norm();
+  }
+  if (distance_type == "angular_acceleration" || distance_type == "acceleration" || distance_type == "all") {
+    result += (this->get_angular_acceleration() - state.get_angular_acceleration()).norm();
+  }
+  if (distance_type == "force" || distance_type == "wrench" || distance_type == "all") {
+    result += (this->get_force() - state.get_force()).norm();
+  }
+  if (distance_type == "torque" || distance_type == "wrench" || distance_type == "all") {
+    result += (this->get_torque() - state.get_torque()).norm();
+  }
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const CartesianState& state) {
+  if (state.is_empty()) {
+    os << "Empty CartesianState";
+  } else {
+    os << state.get_name() << " CartesianState expressed in " << state.get_reference_frame() << " frame" << std::endl;
+    os << "position: (" << state.position(0) << ", ";
+    os << state.position(1) << ", ";
+    os << state.position(2) << ")" << std::endl;
+    os << "orientation: (" << state.orientation.w() << ", ";
+    os << state.orientation.x() << ", ";
+    os << state.orientation.y() << ", ";
+    os << state.orientation.z() << ")";
+    Eigen::AngleAxisd axis_angle(state.orientation);
+    os << " <=> theta: " << axis_angle.angle() << ", ";
+    os << "axis: (" << axis_angle.axis()(0) << ", ";
+    os << axis_angle.axis()(1) << ", ";
+    os << axis_angle.axis()(2) << ")" << std::endl;
+    os << "linear velocity: (" << state.linear_velocity(0) << ", ";
+    os << state.linear_velocity(1) << ", ";
+    os << state.linear_velocity(2) << ")" << std::endl;
+    os << "angular velocity: (" << state.angular_velocity(0) << ", ";
+    os << state.angular_velocity(1) << ", ";
+    os << state.angular_velocity(2) << ")" << std::endl;
+    os << "linear acceleration: (" << state.linear_acceleration(0) << ", ";
+    os << state.linear_acceleration(1) << ", ";
+    os << state.linear_acceleration(2) << ")" << std::endl;
+    os << "angular acceleration: (" << state.angular_acceleration(0) << ", ";
+    os << state.angular_acceleration(1) << ", ";
+    os << state.angular_acceleration(2) << ")" << std::endl;
+    os << "force: (" << state.force(0) << ", ";
+    os << state.force(1) << ", ";
+    os << state.force(2) << ")" << std::endl;
+    os << "torque: (" << state.torque(0) << ", ";
+    os << state.torque(1) << ", ";
+    os << state.torque(2) << ")";
+  }
+  return os;
+}
+
+const CartesianState operator*(double lambda, const CartesianState& state) {
+  return state * lambda;
+}
+
+double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type) {
+  return s1.dist(s2, distance_type);
+}
+
+const std::vector<double> CartesianState::to_std_vector() const {
+  throw(NotImplementedException("to_std_vector() is not implemented for the base CartesianState class"));
+  return std::vector<double>();
+}
+
+void CartesianState::from_std_vector(const std::vector<double>&) {
+  throw(NotImplementedException("from_std_vector() is not implemented for the base CartesianState class"));
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -186,37 +186,49 @@ const CartesianState CartesianState::inverse() const {
   return result;
 }
 
-double CartesianState::dist(const CartesianState& state, const std::string& distance_type) const {
+void CartesianState::clamp_field(double max_value, const CartesianStateFields& field_name, double noise_ratio) {
+  Eigen::VectorXd field_value = this->get_field(field_name);
+  if (noise_ratio != 0) {
+    field_value -= noise_ratio * field_value.normalized();
+    // apply a deadzone
+    if (field_value.norm() < noise_ratio) field_value.setZero();
+  }
+  // clamp the values to their maximum amplitude provided
+  if (field_value.norm() > max_value) field_value = max_value * field_value.normalized();
+  this->set_field(field_value, field_name);
+}
+
+double CartesianState::dist(const CartesianState& state, const CartesianStateFields& field_name) const {
   // sanity check
   if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
   if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
   if (!(this->get_reference_frame() == state.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
   // calculation
   double result = 0;
-  if (distance_type == "position" || distance_type == "pose" || distance_type == "all") {
+  if (field_name == CartesianStateFields::POSITION || field_name == CartesianStateFields::POSE || field_name == CartesianStateFields::ALL) {
     result += (this->get_position() - state.get_position()).norm();
   }
-  if (distance_type == "orientation" || distance_type == "pose" || distance_type == "all") {
+  if (field_name == CartesianStateFields::ORIENTATION || field_name == CartesianStateFields::POSE || field_name == CartesianStateFields::ALL) {
     // https://math.stackexchange.com/questions/90081/quaternion-distance for orientation
     double inner_product = this->get_orientation().dot(state.get_orientation());
     result += acos(2 * inner_product * inner_product - 1);
   }
-  if (distance_type == "linear_velocity" || distance_type == "twist" || distance_type == "all") {
+  if (field_name == CartesianStateFields::LINEAR_VELOCITY || field_name == CartesianStateFields::TWIST || field_name == CartesianStateFields::ALL) {
     result += (this->get_linear_velocity() - state.get_linear_velocity()).norm();
   }
-  if (distance_type == "angular_velocity" || distance_type == "twist" || distance_type == "all") {
+  if (field_name == CartesianStateFields::ANGULAR_VELOCITY || field_name == CartesianStateFields::TWIST || field_name == CartesianStateFields::ALL) {
     result += (this->get_angular_velocity() - state.get_angular_velocity()).norm();
   }
-  if (distance_type == "linear_acceleration" || distance_type == "acceleration" || distance_type == "all") {
+  if (field_name == CartesianStateFields::LINEAR_ACCELERATION || field_name == CartesianStateFields::ACCELERATIONS || field_name == CartesianStateFields::ALL) {
     result += (this->get_linear_acceleration() - state.get_linear_acceleration()).norm();
   }
-  if (distance_type == "angular_acceleration" || distance_type == "acceleration" || distance_type == "all") {
+  if (field_name == CartesianStateFields::ANGULAR_ACCELERATION || field_name == CartesianStateFields::ACCELERATIONS || field_name == CartesianStateFields::ALL) {
     result += (this->get_angular_acceleration() - state.get_angular_acceleration()).norm();
   }
-  if (distance_type == "force" || distance_type == "wrench" || distance_type == "all") {
+  if (field_name == CartesianStateFields::FORCE || field_name == CartesianStateFields::WRENCH || field_name == CartesianStateFields::ALL) {
     result += (this->get_force() - state.get_force()).norm();
   }
-  if (distance_type == "torque" || distance_type == "wrench" || distance_type == "all") {
+  if (field_name == CartesianStateFields::TORQUE || field_name == CartesianStateFields::WRENCH || field_name == CartesianStateFields::ALL) {
     result += (this->get_torque() - state.get_torque()).norm();
   }
   return result;
@@ -265,8 +277,8 @@ const CartesianState operator*(double lambda, const CartesianState& state) {
   return state * lambda;
 }
 
-double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type) {
-  return s1.dist(s2, distance_type);
+double dist(const CartesianState& s1, const CartesianState& s2, const CartesianStateFields& field_name) {
+  return s1.dist(s2, field_name);
 }
 
 const std::vector<double> CartesianState::to_std_vector() const {

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -29,13 +29,13 @@ CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(sta
 
 CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianState(pose / std::chrono::seconds(1)) {}
 
-const CartesianTwist CartesianTwist::Zero(const std::string& name, const std::string& reference) {
+CartesianTwist CartesianTwist::Zero(const std::string& name, const std::string& reference) {
   // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
   Eigen::Matrix<double, 6, 1> zero = Eigen::Matrix<double, 6, 1>::Zero();
   return CartesianTwist(name, zero, reference);
 }
 
-const CartesianTwist CartesianTwist::Random(const std::string& name, const std::string& reference) {
+CartesianTwist CartesianTwist::Random(const std::string& name, const std::string& reference) {
   // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
   Eigen::Matrix<double, 6, 1> random = Eigen::Matrix<double, 6, 1>::Random();
   return CartesianTwist(name, random, reference);
@@ -46,31 +46,13 @@ CartesianTwist& CartesianTwist::operator=(const CartesianState& state) {
   return (*this);
 }
 
-CartesianTwist& CartesianTwist::operator=(const Eigen::Matrix<double, 6, 1>& twist) {
-  this->set_twist(twist);
-  return (*this);
-}
-
 CartesianTwist& CartesianTwist::operator*=(const CartesianTwist& twist) {
   this->CartesianState::operator*=(twist);
   return (*this);
 }
 
-const CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
+CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
   return this->CartesianState::operator*(twist);
-}
-
-const CartesianState CartesianTwist::operator*(const CartesianState& state) const {
-  return this->CartesianState::operator*(state);
-}
-
-CartesianTwist& CartesianTwist::operator*=(double lambda) {
-  this->CartesianState::operator*=(lambda);
-  return (*this);
-}
-
-const CartesianTwist CartesianTwist::operator*(double lambda) const {
-  return this->CartesianState::operator*(lambda);
 }
 
 CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
@@ -78,12 +60,8 @@ CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
   return (*this);
 }
 
-const CartesianTwist CartesianTwist::operator+(const CartesianTwist& twist) const {
+CartesianTwist CartesianTwist::operator+(const CartesianTwist& twist) const {
   return this->CartesianState::operator+(twist);
-}
-
-const CartesianState CartesianTwist::operator+(const CartesianState& state) const {
-  return this->CartesianState::operator+(state);
 }
 
 CartesianTwist& CartesianTwist::operator-=(const CartesianTwist& twist) {
@@ -91,36 +69,17 @@ CartesianTwist& CartesianTwist::operator-=(const CartesianTwist& twist) {
   return (*this);
 }
 
-const CartesianTwist CartesianTwist::operator-(const CartesianTwist& twist) const {
+CartesianTwist CartesianTwist::operator-(const CartesianTwist& twist) const {
   return this->CartesianState::operator-(twist);
 }
 
-const CartesianState CartesianTwist::operator-(const CartesianState& state) const {
-  return this->CartesianState::operator-(state);
-}
-
-CartesianTwist& CartesianTwist::operator+=(const Eigen::Matrix<double, 6, 1>& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  this->set_twist(this->get_twist() + vector);
+CartesianTwist& CartesianTwist::operator*=(double lambda) {
+  this->CartesianState::operator*=(lambda);
   return (*this);
 }
 
-const CartesianTwist CartesianTwist::operator+(const Eigen::Matrix<double, 6, 1>& vector) const {
-  CartesianTwist result(*this);
-  result += vector;
-  return result;
-}
-
-CartesianTwist& CartesianTwist::operator-=(const Eigen::Matrix<double, 6, 1>& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  this->set_twist(this->get_twist() - vector);
-  return (*this);
-}
-
-const CartesianTwist CartesianTwist::operator-(const Eigen::Matrix<double, 6, 1>& vector) const {
-  CartesianTwist result(*this);
-  result -= vector;
-  return result;
+CartesianTwist CartesianTwist::operator*(double lambda) const {
+  return this->CartesianState::operator*(lambda);
 }
 
 CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& lambda) {
@@ -132,6 +91,27 @@ CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& la
   return (*this);
 }
 
+CartesianPose CartesianTwist::operator*(const std::chrono::nanoseconds& dt) const {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  // operations
+  CartesianPose displacement(this->get_name(), this->get_reference_frame());
+  // convert the period to a double with the second as reference
+  double period = dt.count();
+  period /= 1e9;
+  // convert the velocities into a displacement
+  displacement.set_position(period * this->get_linear_velocity());
+  Eigen::Quaterniond angular_displacement = Eigen::Quaterniond::Identity();
+  double angular_norm = this->get_angular_velocity().norm();
+  if (angular_norm > 1e-4) {
+    double theta = angular_norm * period * 0.5;
+    angular_displacement.w() = cos(theta);
+    angular_displacement.vec() = this->get_angular_velocity() / angular_norm * sin(theta);
+  }
+  displacement.set_orientation(angular_displacement);
+  return displacement;
+}
+
 void CartesianTwist::clamp(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) {
   // clamp linear
   this->clamp_state_variable(max_linear, CartesianStateVariable::LINEAR_VELOCITY, linear_noise_ratio);
@@ -139,18 +119,18 @@ void CartesianTwist::clamp(double max_linear, double max_angular, double linear_
   this->clamp_state_variable(max_angular, CartesianStateVariable::ANGULAR_VELOCITY, angular_noise_ratio);
 }
 
-const CartesianTwist CartesianTwist::clamped(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) const {
+CartesianTwist CartesianTwist::clamped(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) const {
   CartesianTwist result(*this);
   result.clamp(max_linear, max_angular, linear_noise_ratio, angular_noise_ratio);
   return result;
 }
 
-const CartesianTwist CartesianTwist::copy() const {
+CartesianTwist CartesianTwist::copy() const {
   CartesianTwist result(*this);
   return result;
 }
 
-const Eigen::Array<double, 6, 1> CartesianTwist::array() const {
+Eigen::Array<double, 6, 1> CartesianTwist::array() const {
   return this->get_twist().array();
 }
 
@@ -169,46 +149,17 @@ std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {
   return os;
 }
 
-const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist) {
-  return twist + vector;
-}
-
-const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist) {
-  return vector + (-1) * twist;
-}
-
-const CartesianTwist operator*(double lambda, const CartesianTwist& twist) {
+CartesianTwist operator*(double lambda, const CartesianTwist& twist) {
   return twist * lambda;
 }
 
-const CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist) {
+CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist) {
   CartesianTwist result(twist);
   result *= lambda;
   return result;
 }
 
-const CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist) {
-  // sanity check
-  if (twist.is_empty()) throw EmptyStateException(twist.get_name() + " state is empty");
-  // operations
-  CartesianPose displacement(twist.get_name(), twist.get_reference_frame());
-  // convert the period to a double with the second as reference
-  double period = dt.count();
-  period /= 1e9;
-  // convert the velocities into a displacement
-  displacement.set_position(period * twist.get_linear_velocity());
-  Eigen::Quaterniond angular_displacement = Eigen::Quaterniond::Identity();
-  double angular_norm = twist.get_angular_velocity().norm();
-  if (angular_norm > 1e-4) {
-    double theta = angular_norm * period * 0.5;
-    angular_displacement.w() = cos(theta);
-    angular_displacement.vec() = twist.get_angular_velocity() / angular_norm * sin(theta);
-  }
-  displacement.set_orientation(angular_displacement);
-  return displacement;
-}
-
-const CartesianPose operator*(const CartesianTwist& twist, const std::chrono::nanoseconds& dt) {
-  return dt * twist;
+CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist) {
+  return twist * dt;
 }
 }// namespace StateRepresentation

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -134,9 +134,9 @@ CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& la
 
 void CartesianTwist::clamp(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) {
   // clamp linear
-  this->clamp_field(max_linear, CartesianStateFields::LINEAR_VELOCITY, linear_noise_ratio);
+  this->clamp_state_variable(max_linear, CartesianStateVariable::LINEAR_VELOCITY, linear_noise_ratio);
   // clamp angular
-  this->clamp_field(max_angular, CartesianStateFields::ANGULAR_VELOCITY, angular_noise_ratio);
+  this->clamp_state_variable(max_angular, CartesianStateVariable::ANGULAR_VELOCITY, angular_noise_ratio);
 }
 
 const CartesianTwist CartesianTwist::clamped(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) const {

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -1,261 +1,209 @@
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
-#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation 
-{
-	CartesianTwist::CartesianTwist()
-	{}
+namespace StateRepresentation {
+CartesianTwist::CartesianTwist() {}
 
-	CartesianTwist::CartesianTwist(const std::string& name, const std::string& reference):
-	CartesianState(name, reference)
-	{}
+CartesianTwist::CartesianTwist(const std::string& name, const std::string& reference) : CartesianState(name, reference) {}
 
-	CartesianTwist::CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_linear_velocity(linear_velocity);
-	}
-
-	CartesianTwist::CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_linear_velocity(linear_velocity);
-		this->set_angular_velocity(angular_velocity);
-	}
-
-	CartesianTwist::CartesianTwist(const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_twist(twist);
-	}
-
-	CartesianTwist::CartesianTwist(const CartesianTwist& twist):
-	CartesianState(twist)
-	{}
-
-	CartesianTwist::CartesianTwist(const CartesianState& state):
-	CartesianState(state)
-	{}
-
-	CartesianTwist::CartesianTwist(const CartesianPose& pose):
-	CartesianState(pose / std::chrono::seconds(1))
-	{}
-
-	CartesianTwist& CartesianTwist::operator=(const CartesianState& state)
-	{
-		// sanity check
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		// operation
-		this->set_name(state.get_name());
-		this->set_reference_frame(state.get_reference_frame());
-		this->set_linear_velocity(state.get_linear_velocity());
-		this->set_angular_velocity(state.get_angular_velocity());
-		return (*this);
-	}
-
-	CartesianTwist& CartesianTwist::operator=(const Eigen::Matrix<double, 6, 1>& twist)
-	{
-		this->set_twist(twist);
-		return (*this);
-	}
-
-	CartesianTwist& CartesianTwist::operator+=(const Eigen::Matrix<double, 6, 1>& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		this->set_twist(this->get_twist() + vector);
-		return (*this);
-	}
-
-	CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(twist.is_empty()) throw EmptyStateException(twist.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == twist.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// operation
-		this->set_linear_velocity(this->get_linear_velocity() + twist.get_linear_velocity());
-		this->set_angular_velocity(this->get_angular_velocity() + twist.get_angular_velocity());
-		return (*this);
-	}
-
-	const CartesianTwist CartesianTwist::operator+(const Eigen::Matrix<double, 6, 1>& vector) const
-	{
-		CartesianTwist result(*this);
-		result += vector;
-		return result;
-	}
-
-	const CartesianTwist CartesianTwist::operator+(const CartesianTwist& twist) const
-	{
-		CartesianTwist result(*this);
-		result += twist;
-		return result;
-	}
-
-	CartesianTwist& CartesianTwist::operator-=(const Eigen::Matrix<double, 6, 1>& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		this->set_twist(this->get_twist() - vector);
-		return (*this);
-	}
-
-	CartesianTwist& CartesianTwist::operator-=(const CartesianTwist& twist)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(twist.is_empty()) throw EmptyStateException(twist.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == twist.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// operation
-		this->set_linear_velocity(this->get_linear_velocity() - twist.get_linear_velocity());
-		this->set_angular_velocity(this->get_angular_velocity() - twist.get_angular_velocity());
-		return (*this);
-	}
-
-	const CartesianTwist CartesianTwist::operator-(const Eigen::Matrix<double, 6, 1>& vector) const
-	{
-		CartesianTwist result(*this);
-		result -= vector;
-		return result;
-	}
-
-	const CartesianTwist CartesianTwist::operator-(const CartesianTwist& twist) const
-	{
-		CartesianTwist result(*this);
-		result -= twist;
-		return result;
-	}
-
-	CartesianTwist& CartesianTwist::operator*=(double lambda)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		// operation
-		this->set_linear_velocity(lambda * this->get_linear_velocity());
-		this->set_angular_velocity(lambda * this->get_angular_velocity());
-		return (*this);
-	}
-
-	const CartesianTwist CartesianTwist::operator*(double lambda) const
-	{
-		CartesianTwist result(*this);
-		result *= lambda;
-		return result;
-	}
-
-	CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& lambda)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		// operation
-		this->set_linear_velocity(lambda.block<3,3>(0, 0) * this->get_linear_velocity());
-		this->set_angular_velocity(lambda.block<3,3>(3, 3) * this->get_angular_velocity());
-		return (*this);
-	}
-
-	void CartesianTwist::clamp(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio)
-	{	
-		if(linear_noise_ratio != 0 || angular_noise_ratio != 0)
-		{	
-			// substract the noise ratio to both velocities
-			this->set_linear_velocity(this->get_linear_velocity() - linear_noise_ratio * this->get_linear_velocity().normalized());
-			this->set_angular_velocity(this->get_angular_velocity() - angular_noise_ratio * this->get_angular_velocity().normalized());
-			// apply a deadzone
-			if(this->get_linear_velocity().norm() < linear_noise_ratio) this->set_linear_velocity(Eigen::Vector3d::Zero());
-			if(this->get_angular_velocity().norm() < angular_noise_ratio) this->set_angular_velocity(Eigen::Vector3d::Zero()); 	
-		} 
-		// clamp the velocities to their maximum amplitude provided
-		if(this->get_linear_velocity().norm() > max_linear) this->set_linear_velocity(max_linear * this->get_linear_velocity().normalized());
-		if(this->get_angular_velocity().norm() > max_angular) this->set_angular_velocity(max_angular * this->get_angular_velocity().normalized());
-	}
-
-	const CartesianTwist CartesianTwist::clamped(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) const
-	{
-		CartesianTwist result(*this);
-		result.clamp(max_linear, max_angular, linear_noise_ratio, angular_noise_ratio);
-		return result;
-	}
-
-	const CartesianTwist CartesianTwist::copy() const
-	{
-		CartesianTwist result(*this);
-		return result;
-	}
-
-	const Eigen::Array<double, 6, 1> CartesianTwist::array() const
-	{
-		return this->get_twist().array();
-	}
-
-	std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) 
-	{
-		if(twist.is_empty())
-		{
-			os << "Empty CartesianTwist";
-		}
-		else
-		{
-			os << twist.get_name() << " CartesianTwist expressed in " << twist.get_reference_frame() << " frame" << std::endl;
-	  		os << "linear_velocity: (" << twist.get_linear_velocity()(0) << ", ";
-	  		os << twist.get_linear_velocity()(1) << ", ";
-	  		os << twist.get_linear_velocity()(2) << ")" << std::endl;
-	  		os << "angular_velocity: (" << twist.get_angular_velocity()(0) << ", ";
-	  		os << twist.get_angular_velocity()(1) << ", ";
-	  		os << twist.get_angular_velocity()(2) << ")";
-	  	}
-  		return os;
-	}
-
-	const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist)
-	{
-		return twist + vector;
-	}
-
-	const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist)
-	{
-		return vector + (-1) * twist;
-	}
-
-	const CartesianTwist operator*(double lambda, const CartesianTwist& twist)
-	{
-		return twist * lambda;
-	}
-
-	const CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist)
-	{
-		CartesianTwist result(twist);
-		result *= lambda;
-		return result;
-	}
-
-	const CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist)
-	{
-		// sanity check
-		if(twist.is_empty()) throw EmptyStateException(twist.get_name() + " state is empty");
-		// operations
-		CartesianPose displacement(twist.get_name(), twist.get_reference_frame());
-		// convert the period to a double with the second as reference
-		double period = dt.count();
-		period /= 1e9;
-		// convert the velocities into a displacement
-		displacement.set_position(period * twist.get_linear_velocity());
-		Eigen::Quaterniond angular_displacement = Eigen::Quaterniond::Identity();
-		double angular_norm = twist.get_angular_velocity().norm();
-		if (angular_norm > 1e-4)
-		{
-			double theta = angular_norm * period * 0.5;
-			angular_displacement.w() = cos(theta);
-			angular_displacement.vec() = twist.get_angular_velocity() / angular_norm * sin(theta);
-		}
-		displacement.set_orientation(angular_displacement);
-		return displacement;
-	}
-
-	const CartesianPose operator*(const CartesianTwist& twist, const std::chrono::nanoseconds& dt)
-	{
-		return dt * twist;
-	}
+CartesianTwist::CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference) : CartesianState(name, reference) {
+  this->set_linear_velocity(linear_velocity);
 }
+
+CartesianTwist::CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity, const std::string& reference) : CartesianState(name, reference) {
+  this->set_linear_velocity(linear_velocity);
+  this->set_angular_velocity(angular_velocity);
+}
+
+CartesianTwist::CartesianTwist(const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference) : CartesianState(name, reference) {
+  this->set_twist(twist);
+}
+
+CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianState(twist) {}
+
+CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(state) {}
+
+CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianState(pose / std::chrono::seconds(1)) {}
+
+CartesianTwist& CartesianTwist::operator=(const CartesianState& state) {
+  this->CartesianState::operator=(state);
+  return (*this);
+}
+
+CartesianTwist& CartesianTwist::operator=(const Eigen::Matrix<double, 6, 1>& twist) {
+  this->set_twist(twist);
+  return (*this);
+}
+
+CartesianTwist& CartesianTwist::operator*=(const CartesianTwist& twist) {
+  this->CartesianState::operator*=(twist);
+  return (*this);
+}
+
+const CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
+  return this->CartesianState::operator*(twist);
+}
+
+const CartesianState CartesianTwist::operator*(const CartesianState& state) const {
+  return this->CartesianState::operator*(state);
+}
+
+CartesianTwist& CartesianTwist::operator*=(double lambda) {
+  this->CartesianState::operator*=(lambda);
+  return (*this);
+}
+
+const CartesianTwist CartesianTwist::operator*(double lambda) const {
+  return this->CartesianState::operator*(lambda);
+}
+
+CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
+  this->CartesianState::operator+=(twist);
+  return (*this);
+}
+
+const CartesianTwist CartesianTwist::operator+(const CartesianTwist& twist) const {
+  return this->CartesianState::operator+(twist);
+}
+
+const CartesianState CartesianTwist::operator+(const CartesianState& state) const {
+  return this->CartesianState::operator+(state);
+}
+
+CartesianTwist& CartesianTwist::operator-=(const CartesianTwist& twist) {
+  this->CartesianState::operator-=(twist);
+  return (*this);
+}
+
+const CartesianTwist CartesianTwist::operator-(const CartesianTwist& twist) const {
+  return this->CartesianState::operator-(twist);
+}
+
+const CartesianState CartesianTwist::operator-(const CartesianState& state) const {
+  return this->CartesianState::operator-(state);
+}
+
+CartesianTwist& CartesianTwist::operator+=(const Eigen::Matrix<double, 6, 1>& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  this->set_twist(this->get_twist() + vector);
+  return (*this);
+}
+
+const CartesianTwist CartesianTwist::operator+(const Eigen::Matrix<double, 6, 1>& vector) const {
+  CartesianTwist result(*this);
+  result += vector;
+  return result;
+}
+
+CartesianTwist& CartesianTwist::operator-=(const Eigen::Matrix<double, 6, 1>& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  this->set_twist(this->get_twist() - vector);
+  return (*this);
+}
+
+const CartesianTwist CartesianTwist::operator-(const Eigen::Matrix<double, 6, 1>& vector) const {
+  CartesianTwist result(*this);
+  result -= vector;
+  return result;
+}
+
+CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& lambda) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  // operation
+  this->set_linear_velocity(lambda.block<3, 3>(0, 0) * this->get_linear_velocity());
+  this->set_angular_velocity(lambda.block<3, 3>(3, 3) * this->get_angular_velocity());
+  return (*this);
+}
+
+void CartesianTwist::clamp(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) {
+  if (linear_noise_ratio != 0 || angular_noise_ratio != 0) {
+    // substract the noise ratio to both velocities
+    this->set_linear_velocity(this->get_linear_velocity() - linear_noise_ratio * this->get_linear_velocity().normalized());
+    this->set_angular_velocity(this->get_angular_velocity() - angular_noise_ratio * this->get_angular_velocity().normalized());
+    // apply a deadzone
+    if (this->get_linear_velocity().norm() < linear_noise_ratio) this->set_linear_velocity(Eigen::Vector3d::Zero());
+    if (this->get_angular_velocity().norm() < angular_noise_ratio) this->set_angular_velocity(Eigen::Vector3d::Zero());
+  }
+  // clamp the velocities to their maximum amplitude provided
+  if (this->get_linear_velocity().norm() > max_linear) this->set_linear_velocity(max_linear * this->get_linear_velocity().normalized());
+  if (this->get_angular_velocity().norm() > max_angular) this->set_angular_velocity(max_angular * this->get_angular_velocity().normalized());
+}
+
+const CartesianTwist CartesianTwist::clamped(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) const {
+  CartesianTwist result(*this);
+  result.clamp(max_linear, max_angular, linear_noise_ratio, angular_noise_ratio);
+  return result;
+}
+
+const CartesianTwist CartesianTwist::copy() const {
+  CartesianTwist result(*this);
+  return result;
+}
+
+const Eigen::Array<double, 6, 1> CartesianTwist::array() const {
+  return this->get_twist().array();
+}
+
+std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {
+  if (twist.is_empty()) {
+    os << "Empty CartesianTwist";
+  } else {
+    os << twist.get_name() << " CartesianTwist expressed in " << twist.get_reference_frame() << " frame" << std::endl;
+    os << "linear_velocity: (" << twist.get_linear_velocity()(0) << ", ";
+    os << twist.get_linear_velocity()(1) << ", ";
+    os << twist.get_linear_velocity()(2) << ")" << std::endl;
+    os << "angular_velocity: (" << twist.get_angular_velocity()(0) << ", ";
+    os << twist.get_angular_velocity()(1) << ", ";
+    os << twist.get_angular_velocity()(2) << ")";
+  }
+  return os;
+}
+
+const CartesianTwist operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist) {
+  return twist + vector;
+}
+
+const CartesianTwist operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianTwist& twist) {
+  return vector + (-1) * twist;
+}
+
+const CartesianTwist operator*(double lambda, const CartesianTwist& twist) {
+  return twist * lambda;
+}
+
+const CartesianTwist operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianTwist& twist) {
+  CartesianTwist result(twist);
+  result *= lambda;
+  return result;
+}
+
+const CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist) {
+  // sanity check
+  if (twist.is_empty()) throw EmptyStateException(twist.get_name() + " state is empty");
+  // operations
+  CartesianPose displacement(twist.get_name(), twist.get_reference_frame());
+  // convert the period to a double with the second as reference
+  double period = dt.count();
+  period /= 1e9;
+  // convert the velocities into a displacement
+  displacement.set_position(period * twist.get_linear_velocity());
+  Eigen::Quaterniond angular_displacement = Eigen::Quaterniond::Identity();
+  double angular_norm = twist.get_angular_velocity().norm();
+  if (angular_norm > 1e-4) {
+    double theta = angular_norm * period * 0.5;
+    angular_displacement.w() = cos(theta);
+    angular_displacement.vec() = twist.get_angular_velocity() / angular_norm * sin(theta);
+  }
+  displacement.set_orientation(angular_displacement);
+  return displacement;
+}
+
+const CartesianPose operator*(const CartesianTwist& twist, const std::chrono::nanoseconds& dt) {
+  return dt * twist;
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -29,6 +29,18 @@ CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(sta
 
 CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianState(pose / std::chrono::seconds(1)) {}
 
+const CartesianTwist CartesianTwist::Zero(const std::string& name, const std::string& reference) {
+  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
+  Eigen::Matrix<double, 6, 1> zero = Eigen::Matrix<double, 6, 1>::Zero();
+  return CartesianTwist(name, zero, reference);
+}
+
+const CartesianTwist CartesianTwist::Random(const std::string& name, const std::string& reference) {
+  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
+  Eigen::Matrix<double, 6, 1> random = Eigen::Matrix<double, 6, 1>::Random();
+  return CartesianTwist(name, random, reference);
+}
+
 CartesianTwist& CartesianTwist::operator=(const CartesianState& state) {
   this->CartesianState::operator=(state);
   return (*this);

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -121,17 +121,10 @@ CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& la
 }
 
 void CartesianTwist::clamp(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) {
-  if (linear_noise_ratio != 0 || angular_noise_ratio != 0) {
-    // substract the noise ratio to both velocities
-    this->set_linear_velocity(this->get_linear_velocity() - linear_noise_ratio * this->get_linear_velocity().normalized());
-    this->set_angular_velocity(this->get_angular_velocity() - angular_noise_ratio * this->get_angular_velocity().normalized());
-    // apply a deadzone
-    if (this->get_linear_velocity().norm() < linear_noise_ratio) this->set_linear_velocity(Eigen::Vector3d::Zero());
-    if (this->get_angular_velocity().norm() < angular_noise_ratio) this->set_angular_velocity(Eigen::Vector3d::Zero());
-  }
-  // clamp the velocities to their maximum amplitude provided
-  if (this->get_linear_velocity().norm() > max_linear) this->set_linear_velocity(max_linear * this->get_linear_velocity().normalized());
-  if (this->get_angular_velocity().norm() > max_angular) this->set_angular_velocity(max_angular * this->get_angular_velocity().normalized());
+  // clamp linear
+  this->clamp_field(max_linear, CartesianStateFields::LINEAR_VELOCITY, linear_noise_ratio);
+  // clamp angular
+  this->clamp_field(max_angular, CartesianStateFields::ANGULAR_VELOCITY, angular_noise_ratio);
 }
 
 const CartesianTwist CartesianTwist::clamped(double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio) const {

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -27,6 +27,18 @@ CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianState
 
 CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(state) {}
 
+const CartesianWrench CartesianWrench::Zero(const std::string& name, const std::string& reference) {
+  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
+  Eigen::Matrix<double, 6, 1> zero = Eigen::Matrix<double, 6, 1>::Zero();
+  return CartesianWrench(name, zero, reference);
+}
+
+const CartesianWrench CartesianWrench::Random(const std::string& name, const std::string& reference) {
+  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
+  Eigen::Matrix<double, 6, 1> random = Eigen::Matrix<double, 6, 1>::Random();
+  return CartesianWrench(name, random, reference);
+}
+
 CartesianWrench& CartesianWrench::operator=(const CartesianState& state) {
   this->CartesianState::operator=(state);
   return (*this);

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -101,23 +101,16 @@ const CartesianWrench CartesianWrench::operator*(double lambda) const {
   return this->CartesianState::operator*(lambda);
 }
 
-void CartesianWrench::clamp(double max_force, double max_torque, double noise_ratio) {
-  if (noise_ratio != 0) {
-    // substract the noise ratio to both velocities
-    this->set_force(this->get_force() - noise_ratio * this->get_force().normalized());
-    this->set_torque(this->get_torque() - noise_ratio * this->get_torque().normalized());
-    // apply a deadzone
-    if (this->get_force().norm() < noise_ratio) this->set_force(Eigen::Vector3d::Zero());
-    if (this->get_torque().norm() < noise_ratio) this->set_torque(Eigen::Vector3d::Zero());
-  }
-  // clamp the velocities to their maximum amplitude provided
-  if (this->get_force().norm() > max_force) this->set_force(max_force * this->get_force().normalized());
-  if (this->get_torque().norm() > max_torque) this->set_torque(max_torque * this->get_torque().normalized());
+void CartesianWrench::clamp(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) {
+  // clamp force
+  this->clamp_field(max_force, CartesianStateFields::FORCE, force_noise_ratio);
+  // clamp torque
+  this->clamp_field(max_torque, CartesianStateFields::TORQUE, torque_noise_ratio);
 }
 
-const CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double noise_ratio) const {
+const CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) const {
   CartesianWrench result(*this);
-  result.clamp(max_force, max_torque, noise_ratio);
+  result.clamp(max_force, max_torque, force_noise_ratio, torque_noise_ratio);
   return result;
 }
 

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -1,211 +1,159 @@
 #include "state_representation/Space/Cartesian/CartesianWrench.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
-#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation 
-{
-	CartesianWrench::CartesianWrench()
-	{}
+namespace StateRepresentation {
+CartesianWrench::CartesianWrench() {}
 
-	CartesianWrench::CartesianWrench(const std::string& name, const std::string& reference):
-	CartesianState(name, reference)
-	{}
+CartesianWrench::CartesianWrench(const std::string& name, const std::string& reference) : CartesianState(name, reference) {}
 
-	CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_force(force);
-	}
-
-	CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_force(force);
-		this->set_torque(torque);
-	}
-
-	CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference):
-	CartesianState(name, reference)
-	{
-		this->set_wrench(wrench);
-	}
-
-	CartesianWrench::CartesianWrench(const CartesianWrench& wrench):
-	CartesianState(wrench)
-	{}
-
-	CartesianWrench::CartesianWrench(const CartesianState& state):
-	CartesianState(state)
-	{}
-
-	CartesianWrench& CartesianWrench::operator=(const Eigen::Matrix<double, 6, 1>& wrench)
-	{
-		this->set_wrench(wrench);
-		return (*this);
-	}
-
-	CartesianWrench& CartesianWrench::operator+=(const Eigen::Matrix<double, 6, 1>& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		this->set_wrench(this->get_wrench() + vector);
-		return (*this);
-	}
-
-	CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(wrench.is_empty()) throw EmptyStateException(wrench.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == wrench.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// operation
-		this->set_force(this->get_force() + wrench.get_force());
-		this->set_torque(this->get_torque() + wrench.get_torque());
-		return (*this);
-	}
-
-	const CartesianWrench CartesianWrench::operator+(const Eigen::Matrix<double, 6, 1>& vector) const
-	{
-		CartesianWrench result(*this);
-		result += vector;
-		return result;
-	}
-
-	const CartesianWrench CartesianWrench::operator+(const CartesianWrench& wrench) const
-	{
-		CartesianWrench result(*this);
-		result += wrench;
-		return result;
-	}
-
-	CartesianWrench& CartesianWrench::operator-=(const Eigen::Matrix<double, 6, 1>& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		this->set_wrench(this->get_wrench() - vector);
-		return (*this);
-	}
-
-	CartesianWrench& CartesianWrench::operator-=(const CartesianWrench& wrench)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(wrench.is_empty()) throw EmptyStateException(wrench.get_name() + " state is empty");
-		if(!(this->get_reference_frame() == wrench.get_reference_frame())) throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
-		// operation
-		this->set_force(this->get_force() - wrench.get_force());
-		this->set_torque(this->get_torque() - wrench.get_torque());
-		return (*this);
-	}
-
-	const CartesianWrench CartesianWrench::operator-(const Eigen::Matrix<double, 6, 1>& vector) const
-	{
-		CartesianWrench result(*this);
-		result -= vector;
-		return result;
-	}
-
-	const CartesianWrench CartesianWrench::operator-(const CartesianWrench& wrench) const
-	{
-		CartesianWrench result(*this);
-		result -= wrench;
-		return result;
-	}
-
-	void CartesianWrench::operator=(const CartesianState& state)
-	{
-		// sanity check
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		// operation
-		this->set_name(state.get_name());
-		this->set_reference_frame(state.get_reference_frame());
-		this->set_force(state.get_force());
-		this->set_torque(state.get_torque());
-	}
-
-	CartesianWrench& CartesianWrench::operator*=(double lambda)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		// operation
-		this->set_force(lambda * this->get_force());
-		this->set_torque(lambda * this->get_torque());
-		return (*this);
-	}
-
-	const CartesianWrench CartesianWrench::operator*(double lambda) const
-	{
-		CartesianWrench result(*this);
-		result *= lambda;
-		return result;
-	}
-
-	void CartesianWrench::clamp(double max_force, double max_torque, double noise_ratio)
-	{	
-		if(noise_ratio != 0)
-		{	
-			// substract the noise ratio to both velocities
-			this->set_force(this->get_force() - noise_ratio * this->get_force().normalized());
-			this->set_torque(this->get_torque() - noise_ratio * this->get_torque().normalized());
-			// apply a deadzone
-			if(this->get_force().norm() < noise_ratio) this->set_force(Eigen::Vector3d::Zero());
-			if(this->get_torque().norm() < noise_ratio) this->set_torque(Eigen::Vector3d::Zero()); 	
-		} 
-		// clamp the velocities to their maximum amplitude provided
-		if(this->get_force().norm() > max_force) this->set_force(max_force * this->get_force().normalized());
-		if(this->get_torque().norm() > max_torque) this->set_torque(max_torque * this->get_torque().normalized());
-	}
-
-	const CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double noise_ratio) const
-	{
-		CartesianWrench result(*this);
-		result.clamp(max_force, max_torque, noise_ratio);
-		return result;
-	}
-
-	const CartesianWrench CartesianWrench::copy() const
-	{
-		CartesianWrench result(*this);
-		return result;
-	}
-
-	const Eigen::Array<double, 6, 1> CartesianWrench::array() const
-	{
-		return this->get_wrench().array();
-	}
-
-	std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) 
-	{
-		if(wrench.is_empty())
-		{
-			os << "Empty CartesianWrench";
-		}
-		else
-		{
-			os << wrench.get_name() << " CartesianWrench expressed in " << wrench.get_reference_frame() << " frame" << std::endl;
-	  		os << "force: (" << wrench.get_force()(0) << ", ";
-	  		os << wrench.get_force()(1) << ", ";
-	  		os << wrench.get_force()(2) << ")" << std::endl;
-	  		os << "torque: (" << wrench.get_torque()(0) << ", ";
-	  		os << wrench.get_torque()(1) << ", ";
-	  		os << wrench.get_torque()(2) << ")";
-	  	}
-  		return os;
-	}
-
-	const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench)
-	{
-		return wrench + vector;
-	}
-
-	const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench)
-	{
-		return vector + (-1) * wrench;
-	}
-
-	const CartesianWrench operator*(double lambda, const CartesianWrench& wrench)
-	{
-		return wrench * lambda;
-	}
+CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const std::string& reference) : CartesianState(name, reference) {
+  this->set_force(force);
 }
+
+CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque, const std::string& reference) : CartesianState(name, reference) {
+  this->set_force(force);
+  this->set_torque(torque);
+}
+
+CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference) : CartesianState(name, reference) {
+  this->set_wrench(wrench);
+}
+
+CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianState(wrench) {}
+
+CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(state) {}
+
+CartesianWrench& CartesianWrench::operator=(const CartesianState& state) {
+  this->CartesianState::operator=(state);
+  return (*this);
+}
+
+CartesianWrench& CartesianWrench::operator=(const Eigen::Matrix<double, 6, 1>& wrench) {
+  this->set_wrench(wrench);
+  return (*this);
+}
+
+CartesianWrench& CartesianWrench::operator*=(const CartesianWrench& wrench) {
+  this->CartesianState::operator*=(wrench);
+  return (*this);
+}
+
+const CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const {
+  return this->CartesianState::operator*(wrench);
+}
+
+const CartesianState CartesianWrench::operator*(const CartesianState& state) const {
+  return this->CartesianState::operator*(state);
+}
+
+CartesianWrench& CartesianWrench::operator+=(const Eigen::Matrix<double, 6, 1>& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  this->set_wrench(this->get_wrench() + vector);
+  return (*this);
+}
+
+CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
+  this->CartesianState::operator+=(wrench);
+  return (*this);
+}
+
+const CartesianWrench CartesianWrench::operator+(const Eigen::Matrix<double, 6, 1>& vector) const {
+  CartesianWrench result(*this);
+  result += vector;
+  return result;
+}
+
+const CartesianWrench CartesianWrench::operator+(const CartesianWrench& wrench) const {
+  return this->CartesianState::operator+(wrench);
+}
+
+CartesianWrench& CartesianWrench::operator-=(const Eigen::Matrix<double, 6, 1>& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  this->set_wrench(this->get_wrench() - vector);
+  return (*this);
+}
+
+CartesianWrench& CartesianWrench::operator-=(const CartesianWrench& wrench) {
+  this->CartesianState::operator-=(wrench);
+  return (*this);
+}
+
+const CartesianWrench CartesianWrench::operator-(const Eigen::Matrix<double, 6, 1>& vector) const {
+  CartesianWrench result(*this);
+  result -= vector;
+  return result;
+}
+
+const CartesianWrench CartesianWrench::operator-(const CartesianWrench& wrench) const {
+  return this->CartesianState::operator-(wrench);
+}
+
+CartesianWrench& CartesianWrench::operator*=(double lambda) {
+  this->CartesianState::operator*=(lambda);
+  return (*this);
+}
+
+const CartesianWrench CartesianWrench::operator*(double lambda) const {
+  return this->CartesianState::operator*(lambda);
+}
+
+void CartesianWrench::clamp(double max_force, double max_torque, double noise_ratio) {
+  if (noise_ratio != 0) {
+    // substract the noise ratio to both velocities
+    this->set_force(this->get_force() - noise_ratio * this->get_force().normalized());
+    this->set_torque(this->get_torque() - noise_ratio * this->get_torque().normalized());
+    // apply a deadzone
+    if (this->get_force().norm() < noise_ratio) this->set_force(Eigen::Vector3d::Zero());
+    if (this->get_torque().norm() < noise_ratio) this->set_torque(Eigen::Vector3d::Zero());
+  }
+  // clamp the velocities to their maximum amplitude provided
+  if (this->get_force().norm() > max_force) this->set_force(max_force * this->get_force().normalized());
+  if (this->get_torque().norm() > max_torque) this->set_torque(max_torque * this->get_torque().normalized());
+}
+
+const CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double noise_ratio) const {
+  CartesianWrench result(*this);
+  result.clamp(max_force, max_torque, noise_ratio);
+  return result;
+}
+
+const CartesianWrench CartesianWrench::copy() const {
+  CartesianWrench result(*this);
+  return result;
+}
+
+const Eigen::Array<double, 6, 1> CartesianWrench::array() const {
+  return this->get_wrench().array();
+}
+
+std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {
+  if (wrench.is_empty()) {
+    os << "Empty CartesianWrench";
+  } else {
+    os << wrench.get_name() << " CartesianWrench expressed in " << wrench.get_reference_frame() << " frame" << std::endl;
+    os << "force: (" << wrench.get_force()(0) << ", ";
+    os << wrench.get_force()(1) << ", ";
+    os << wrench.get_force()(2) << ")" << std::endl;
+    os << "torque: (" << wrench.get_torque()(0) << ", ";
+    os << wrench.get_torque()(1) << ", ";
+    os << wrench.get_torque()(2) << ")";
+  }
+  return os;
+}
+
+const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench) {
+  return wrench + vector;
+}
+
+const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench) {
+  return vector + (-1) * wrench;
+}
+
+const CartesianWrench operator*(double lambda, const CartesianWrench& wrench) {
+  return wrench * lambda;
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -27,13 +27,13 @@ CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianState
 
 CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(state) {}
 
-const CartesianWrench CartesianWrench::Zero(const std::string& name, const std::string& reference) {
+CartesianWrench CartesianWrench::Zero(const std::string& name, const std::string& reference) {
   // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
   Eigen::Matrix<double, 6, 1> zero = Eigen::Matrix<double, 6, 1>::Zero();
   return CartesianWrench(name, zero, reference);
 }
 
-const CartesianWrench CartesianWrench::Random(const std::string& name, const std::string& reference) {
+CartesianWrench CartesianWrench::Random(const std::string& name, const std::string& reference) {
   // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
   Eigen::Matrix<double, 6, 1> random = Eigen::Matrix<double, 6, 1>::Random();
   return CartesianWrench(name, random, reference);
@@ -44,28 +44,13 @@ CartesianWrench& CartesianWrench::operator=(const CartesianState& state) {
   return (*this);
 }
 
-CartesianWrench& CartesianWrench::operator=(const Eigen::Matrix<double, 6, 1>& wrench) {
-  this->set_wrench(wrench);
-  return (*this);
-}
-
 CartesianWrench& CartesianWrench::operator*=(const CartesianWrench& wrench) {
   this->CartesianState::operator*=(wrench);
   return (*this);
 }
 
-const CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const {
+CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const {
   return this->CartesianState::operator*(wrench);
-}
-
-const CartesianState CartesianWrench::operator*(const CartesianState& state) const {
-  return this->CartesianState::operator*(state);
-}
-
-CartesianWrench& CartesianWrench::operator+=(const Eigen::Matrix<double, 6, 1>& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  this->set_wrench(this->get_wrench() + vector);
-  return (*this);
 }
 
 CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
@@ -73,20 +58,8 @@ CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
   return (*this);
 }
 
-const CartesianWrench CartesianWrench::operator+(const Eigen::Matrix<double, 6, 1>& vector) const {
-  CartesianWrench result(*this);
-  result += vector;
-  return result;
-}
-
-const CartesianWrench CartesianWrench::operator+(const CartesianWrench& wrench) const {
+CartesianWrench CartesianWrench::operator+(const CartesianWrench& wrench) const {
   return this->CartesianState::operator+(wrench);
-}
-
-CartesianWrench& CartesianWrench::operator-=(const Eigen::Matrix<double, 6, 1>& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  this->set_wrench(this->get_wrench() - vector);
-  return (*this);
 }
 
 CartesianWrench& CartesianWrench::operator-=(const CartesianWrench& wrench) {
@@ -94,13 +67,7 @@ CartesianWrench& CartesianWrench::operator-=(const CartesianWrench& wrench) {
   return (*this);
 }
 
-const CartesianWrench CartesianWrench::operator-(const Eigen::Matrix<double, 6, 1>& vector) const {
-  CartesianWrench result(*this);
-  result -= vector;
-  return result;
-}
-
-const CartesianWrench CartesianWrench::operator-(const CartesianWrench& wrench) const {
+CartesianWrench CartesianWrench::operator-(const CartesianWrench& wrench) const {
   return this->CartesianState::operator-(wrench);
 }
 
@@ -109,7 +76,7 @@ CartesianWrench& CartesianWrench::operator*=(double lambda) {
   return (*this);
 }
 
-const CartesianWrench CartesianWrench::operator*(double lambda) const {
+CartesianWrench CartesianWrench::operator*(double lambda) const {
   return this->CartesianState::operator*(lambda);
 }
 
@@ -120,18 +87,18 @@ void CartesianWrench::clamp(double max_force, double max_torque, double force_no
   this->clamp_state_variable(max_torque, CartesianStateVariable::TORQUE, torque_noise_ratio);
 }
 
-const CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) const {
+CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) const {
   CartesianWrench result(*this);
   result.clamp(max_force, max_torque, force_noise_ratio, torque_noise_ratio);
   return result;
 }
 
-const CartesianWrench CartesianWrench::copy() const {
+CartesianWrench CartesianWrench::copy() const {
   CartesianWrench result(*this);
   return result;
 }
 
-const Eigen::Array<double, 6, 1> CartesianWrench::array() const {
+Eigen::Array<double, 6, 1> CartesianWrench::array() const {
   return this->get_wrench().array();
 }
 
@@ -150,15 +117,7 @@ std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {
   return os;
 }
 
-const CartesianWrench operator+(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench) {
-  return wrench + vector;
-}
-
-const CartesianWrench operator-(const Eigen::Matrix<double, 6, 1>& vector, const CartesianWrench& wrench) {
-  return vector + (-1) * wrench;
-}
-
-const CartesianWrench operator*(double lambda, const CartesianWrench& wrench) {
+CartesianWrench operator*(double lambda, const CartesianWrench& wrench) {
   return wrench * lambda;
 }
 }// namespace StateRepresentation

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -115,9 +115,9 @@ const CartesianWrench CartesianWrench::operator*(double lambda) const {
 
 void CartesianWrench::clamp(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) {
   // clamp force
-  this->clamp_field(max_force, CartesianStateFields::FORCE, force_noise_ratio);
+  this->clamp_state_variable(max_force, CartesianStateVariable::FORCE, force_noise_ratio);
   // clamp torque
-  this->clamp_field(max_torque, CartesianStateFields::TORQUE, torque_noise_ratio);
+  this->clamp_state_variable(max_torque, CartesianStateVariable::TORQUE, torque_noise_ratio);
 }
 
 const CartesianWrench CartesianWrench::clamped(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) const {

--- a/source/state_representation/tests/testCartesianState.cpp
+++ b/source/state_representation/tests/testCartesianState.cpp
@@ -1,347 +1,274 @@
 #include "state_representation/Space/Cartesian/CartesianPose.hpp"
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 #include "state_representation/Space/Cartesian/CartesianWrench.hpp"
-#include <gtest/gtest.h>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <unistd.h>
 
 using namespace StateRepresentation;
 
-TEST(NegateQuaternion, PositiveNos)
-{
-	Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
-	Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());
+TEST(NegateQuaternion, PositiveNos) {
+  Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
+  Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());
 
-	EXPECT_TRUE(q.w() == -q2.w());
-	for (int i = 0; i < 3; ++i) EXPECT_TRUE(q.vec()(i) == -q2.vec()(i));
+  EXPECT_TRUE(q.w() == -q2.w());
+  for (int i = 0; i < 3; ++i) EXPECT_TRUE(q.vec()(i) == -q2.vec()(i));
 }
 
-TEST(MultiplyTransformsBothOperators, PositiveNos)
-{
-	Eigen::Vector3d pos1(1,2,3);
-	Eigen::Quaterniond rot1(1,0,0,0);
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(MultiplyTransformsBothOperators, PositiveNos) {
+  Eigen::Vector3d pos1(1, 2, 3);
+  Eigen::Quaterniond rot1(1, 0, 0, 0);
+  CartesianPose tf1("t1", pos1, rot1);
 
-	Eigen::Vector3d pos2(4,5,6);
-	Eigen::Quaterniond rot2(1,0,0,0);
-	CartesianPose tf2("t2", pos2, rot2, "t1");
+  Eigen::Vector3d pos2(4, 5, 6);
+  Eigen::Quaterniond rot2(1, 0, 0, 0);
+  CartesianPose tf2("t2", pos2, rot2, "t1");
 
-	CartesianPose tf3 = tf1 * tf2;
-	tf1 *= tf2;
-	
-	EXPECT_EQ(tf3.get_name(), "t2");
-	for(int i=0; i<tf1.get_position().size(); ++i) EXPECT_NEAR(tf1.get_position()(i), tf3.get_position()(i), 0.00001);
+  CartesianPose tf3 = tf1 * tf2;
+  tf1 *= tf2;
+
+  EXPECT_EQ(tf3.get_name(), "t2");
+  for (int i = 0; i < tf1.get_position().size(); ++i) EXPECT_NEAR(tf1.get_position()(i), tf3.get_position()(i), 0.00001);
 }
 
+TEST(MultiplyTransformsSameOrientation, PositiveNos) {
+  Eigen::Vector3d pos1(1, 2, 3);
+  Eigen::Quaterniond rot1(1, 0, 0, 0);
+  CartesianPose tf1("t1", pos1, rot1);
 
-TEST(MultiplyTransformsSameOrientation, PositiveNos)
-{
-	Eigen::Vector3d pos1(1,2,3);
-	Eigen::Quaterniond rot1(1,0,0,0);
-	CartesianPose tf1("t1", pos1, rot1);
+  Eigen::Vector3d pos2(4, 5, 6);
+  Eigen::Quaterniond rot2(1, 0, 0, 0);
+  CartesianPose tf2("t2", pos2, rot2, "t1");
 
-	Eigen::Vector3d pos2(4,5,6);
-	Eigen::Quaterniond rot2(1,0,0,0);
-	CartesianPose tf2("t2", pos2, rot2, "t1");
+  tf1 *= tf2;
 
-	tf1 *= tf2;
-	
-	Eigen::Vector3d pos_truth(5,7,9);
-	for(int i=0; i<pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  Eigen::Vector3d pos_truth(5, 7, 9);
+  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
 }
 
-TEST(MultiplyTransformsDifferentOrientation, PositiveNos)
-{
-	Eigen::Vector3d pos1(1,2,3);
-	Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(MultiplyTransformsDifferentOrientation, PositiveNos) {
+  Eigen::Vector3d pos1(1, 2, 3);
+  Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
+  CartesianPose tf1("t1", pos1, rot1);
 
-	Eigen::Vector3d pos2(4,5,6);
-	Eigen::Quaterniond rot2(0., 0., 0.70710678, 0.70710678);
-	CartesianPose tf2("t2", pos2, rot2, "t1");
+  Eigen::Vector3d pos2(4, 5, 6);
+  Eigen::Quaterniond rot2(0., 0., 0.70710678, 0.70710678);
+  CartesianPose tf2("t2", pos2, rot2, "t1");
 
-	tf1 *= tf2;
-	
-	Eigen::Vector3d pos_truth(5,-4,8);
-	Eigen::Quaterniond rot_truth(0.,0.,0.,1.);
+  tf1 *= tf2;
 
-	std::cerr << "position" << std::endl;
-	std::cerr << tf1.get_position() << std::endl;
-	std::cerr << "orientation" << std::endl;
-	std::cerr << tf1.get_orientation().coeffs() << std::endl;
+  Eigen::Vector3d pos_truth(5, -4, 8);
+  Eigen::Quaterniond rot_truth(0., 0., 0., 1.);
 
-	for(int i=0; i<pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-    EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1-10E-4);
+  std::cerr << "position" << std::endl;
+  std::cerr << tf1.get_position() << std::endl;
+  std::cerr << "orientation" << std::endl;
+  std::cerr << tf1.get_orientation().coeffs() << std::endl;
+
+  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
 
-TEST(TestInverseNullOrientation, PositiveNos)
-{
-	Eigen::Vector3d pos1(1,2,3);
-	Eigen::Quaterniond rot1(1., 0., 0., 0.);
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestInverseNullOrientation, PositiveNos) {
+  Eigen::Vector3d pos1(1, 2, 3);
+  Eigen::Quaterniond rot1(1., 0., 0., 0.);
+  CartesianPose tf1("t1", pos1, rot1);
 
-	tf1 = tf1.inverse();
-	
-	Eigen::Vector3d pos_truth(-1,-2,-3);
-	Eigen::Quaterniond rot_truth(1.,0.,0.,0.);
+  tf1 = tf1.inverse();
 
-	std::cerr << "position" << std::endl;
-	std::cerr << tf1.get_position() << std::endl;
-	std::cerr << "orientation" << std::endl;
-	std::cerr << tf1.get_orientation().coeffs() << std::endl;
+  Eigen::Vector3d pos_truth(-1, -2, -3);
+  Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
 
-	EXPECT_EQ(tf1.get_name(), "world");
-	EXPECT_EQ(tf1.get_reference_frame(), "t1");
-	for(int i=0; i<pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-    EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1-10E-4);
+  std::cerr << "position" << std::endl;
+  std::cerr << tf1.get_position() << std::endl;
+  std::cerr << "orientation" << std::endl;
+  std::cerr << tf1.get_orientation().coeffs() << std::endl;
+
+  EXPECT_EQ(tf1.get_name(), "world");
+  EXPECT_EQ(tf1.get_reference_frame(), "t1");
+  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
 
-TEST(TestInverseNonNullOrientation, PositiveNos)
-{
-	Eigen::Vector3d pos1(1,2,3);
-	Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestInverseNonNullOrientation, PositiveNos) {
+  Eigen::Vector3d pos1(1, 2, 3);
+  Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
+  CartesianPose tf1("t1", pos1, rot1);
 
-	tf1 = tf1.inverse();
-	
-	Eigen::Vector3d pos_truth(-1,-3,2);
-	Eigen::Quaterniond rot_truth(0.70710678, -0.70710678, 0., 0.);
+  tf1 = tf1.inverse();
 
-	std::cerr << "position" << std::endl;
-	std::cerr << tf1.get_position() << std::endl;
-	std::cerr << "orientation" << std::endl;
-	std::cerr << tf1.get_orientation().coeffs() << std::endl;
+  Eigen::Vector3d pos_truth(-1, -3, 2);
+  Eigen::Quaterniond rot_truth(0.70710678, -0.70710678, 0., 0.);
 
-	for(int i=0; i<pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-    EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1-10E-4);
+  std::cerr << "position" << std::endl;
+  std::cerr << tf1.get_position() << std::endl;
+  std::cerr << "orientation" << std::endl;
+  std::cerr << tf1.get_orientation().coeffs() << std::endl;
+
+  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
 
-TEST(TestMultiplyInverseNonNullOrientation, PositiveNos)
-{
-	Eigen::Vector3d pos1(1,2,3);
-	Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestMultiplyInverseNonNullOrientation, PositiveNos) {
+  Eigen::Vector3d pos1(1, 2, 3);
+  Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
+  CartesianPose tf1("t1", pos1, rot1);
 
-	tf1 *= tf1.inverse();
-	
-	Eigen::Vector3d pos_truth(0,0,0);
-	Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
+  tf1 *= tf1.inverse();
 
-	std::cerr << "position" << std::endl;
-	std::cerr << tf1.get_position() << std::endl;
-	std::cerr << "orientation" << std::endl;
-	std::cerr << tf1.get_orientation().coeffs() << std::endl;
+  Eigen::Vector3d pos_truth(0, 0, 0);
+  Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
 
-	for(int i=0; i<pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-    EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1-10E-4);
+  std::cerr << "position" << std::endl;
+  std::cerr << tf1.get_position() << std::endl;
+  std::cerr << "orientation" << std::endl;
+  std::cerr << tf1.get_orientation().coeffs() << std::endl;
+
+  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
 
-TEST(MultiplyPoseAndState, PositiveNos)
-{
-	CartesianPose p = CartesianPose::Random("test");
-	CartesianState s = CartesianPose::Random("test2", "test");
+TEST(MultiplyPoseAndState, PositiveNos) {
+  CartesianPose p = CartesianPose::Random("test");
+  CartesianState s = CartesianPose::Random("test2", "test");
 
-	CartesianState res = p * s;
-	CartesianPose res2 = p * static_cast<CartesianPose>(s);
+  CartesianState res = p * s;
+  CartesianPose res2 = p * static_cast<CartesianPose>(s);
 
-	for(int i=0; i<res.get_position().size(); ++i) EXPECT_NEAR(res.get_position()(i), res2.get_position()(i), 0.00001);
-    EXPECT_TRUE(abs(res.get_orientation().dot(res2.get_orientation())) > 1-10E-4);
+  for (int i = 0; i < res.get_position().size(); ++i) EXPECT_NEAR(res.get_position()(i), res2.get_position()(i), 0.00001);
+  EXPECT_TRUE(abs(res.get_orientation().dot(res2.get_orientation())) > 1 - 10E-4);
 }
 
-TEST(TestAddTwoPoses, PositiveNos)
-{
-	Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
-	Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity(); 
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestAddTwoPoses, PositiveNos) {
+  Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
+  Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
+  CartesianPose tf1("t1", pos1, rot1);
 
-	Eigen::Vector3d pos2(1,0,0);
-	Eigen::Quaterniond rot2(0,1,0,0); 
-	CartesianPose tf2("t1", pos2, rot2);
+  Eigen::Vector3d pos2(1, 0, 0);
+  Eigen::Quaterniond rot2(0, 1, 0, 0);
+  CartesianPose tf2("t1", pos2, rot2);
 
-	std::cout << tf1 + tf2 << std::endl;
-	std::cout << tf1 - tf2 << std::endl;
+  std::cout << tf1 + tf2 << std::endl;
+  std::cout << tf1 - tf2 << std::endl;
 }
 
-TEST(TestAddDisplacement, PositiveNos)
-{
-	Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
-	Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity(); 
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestAddDisplacement, PositiveNos) {
+  Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
+  Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
+  CartesianPose tf1("t1", pos1, rot1);
 
-	CartesianTwist vel("t1");
-	vel.set_linear_velocity(Eigen::Vector3d(0.1,0.1,0.1));
-	vel.set_angular_velocity(Eigen::Vector3d(0.1,0.1,0));
+  CartesianTwist vel("t1");
+  vel.set_linear_velocity(Eigen::Vector3d(0.1, 0.1, 0.1));
+  vel.set_angular_velocity(Eigen::Vector3d(0.1, 0.1, 0));
 
-	std::chrono::milliseconds dt1(10);
-	std::cout << tf1 + dt1 * vel << std::endl;
+  std::chrono::milliseconds dt1(10);
+  std::cout << tf1 + dt1 * vel << std::endl;
 
-	std::chrono::milliseconds dt2(1000);
-	std::cout << tf1 + dt2 * vel << std::endl;
+  std::chrono::milliseconds dt2(1000);
+  std::cout << tf1 + dt2 * vel << std::endl;
 
-	std::chrono::seconds dt3(1);
-	std::cout << tf1 + dt3 * vel << std::endl;
+  std::chrono::seconds dt3(1);
+  std::cout << tf1 + dt3 * vel << std::endl;
 }
 
-TEST(TestPoseToVelocity, PositiveNos)
-{
-	Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
-	Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity(); 
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestPoseToVelocity, PositiveNos) {
+  Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
+  Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
+  CartesianPose tf1("t1", pos1, rot1);
 
-	Eigen::Vector3d pos2(1,0,0);
-	Eigen::Quaterniond rot2(0,1,0,0); 
-	CartesianPose tf2("t1", pos2, rot2);
+  Eigen::Vector3d pos2(1, 0, 0);
+  Eigen::Quaterniond rot2(0, 1, 0, 0);
+  CartesianPose tf2("t1", pos2, rot2);
 
-	std::chrono::seconds dt1(1);
-	std::cout << (tf1 - tf2) / dt1 << std::endl;
+  std::chrono::seconds dt1(1);
+  std::cout << (tf1 - tf2) / dt1 << std::endl;
 
-	std::chrono::seconds dt2(10);
-	std::cout << (tf1 - tf2) / dt2 << std::endl;
+  std::chrono::seconds dt2(10);
+  std::cout << (tf1 - tf2) / dt2 << std::endl;
 
-	std::chrono::milliseconds dt3(100);
-	std::cout << (tf1 - tf2) / dt3 << std::endl;
+  std::chrono::milliseconds dt3(100);
+  std::cout << (tf1 - tf2) / dt3 << std::endl;
 }
 
-TEST(TestImplicitConversion, PositiveNos)
-{
-	Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
-	Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity(); 
-	CartesianPose tf1("t1", pos1, rot1);
+TEST(TestTwistStateMultiplication, PositiveNos) {
+  CartesianTwist twist = CartesianTwist::Random("test");
+  CartesianState state = CartesianTwist::Random("test2", "test");
 
-	CartesianTwist vel("t1");
-	vel.set_linear_velocity(Eigen::Vector3d(0.1,0.1,0.1));
-	vel.set_angular_velocity(Eigen::Vector3d(0.1,0.1,0));
-
-	tf1 += vel;
-
-	std::cout << tf1 << std::endl;
+  std::cout << twist * state << std::endl;
 }
 
-TEST(TestVelocityClamping, PositiveNos)
-{
-	CartesianTwist vel("test", Eigen::Vector3d(1,-2,3), Eigen::Vector3d(1,2,-3));
-	vel.clamp(1, 0.5);
+TEST(TestImplicitConversion, PositiveNos) {
+  Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
+  Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
+  CartesianPose tf1("t1", pos1, rot1);
 
-	std::cout << vel << std::endl;
-	EXPECT_TRUE(vel.get_linear_velocity().norm() <= 1);
-	EXPECT_TRUE(vel.get_angular_velocity().norm() <= 0.5);
+  CartesianTwist vel("t1");
+  vel.set_linear_velocity(Eigen::Vector3d(0.1, 0.1, 0.1));
+  vel.set_angular_velocity(Eigen::Vector3d(0.1, 0.1, 0));
 
-	vel *= 0.01;
+  tf1 += vel;
 
-	std::cout << vel.clamped(1, 0.5, 0.1, 0.1) << std::endl;
-	for(int i=0; i<3; ++i)
-	{
-		EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_linear_velocity()(i) == 0);
-		EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_angular_velocity()(i) == 0);
-	}
+  std::cout << tf1 << std::endl;
 }
 
-TEST(TestPoseDistance, PositiveNos)
-{
-	CartesianPose p1("test", Eigen::Vector3d::Zero());
-	CartesianPose p2("test", Eigen::Vector3d(1,0,0));
-	CartesianPose p3("test", Eigen::Vector3d(1,0,0), Eigen::Quaterniond(0,1,0,0));
+TEST(TestVelocityClamping, PositiveNos) {
+  CartesianTwist vel("test", Eigen::Vector3d(1, -2, 3), Eigen::Vector3d(1, 2, -3));
+  vel.clamp(1, 0.5);
 
-	double d1 = dist(p1, p2);
-	double d2 = p1.dist(p2);
+  std::cout << vel << std::endl;
+  EXPECT_TRUE(vel.get_linear_velocity().norm() <= 1);
+  EXPECT_TRUE(vel.get_angular_velocity().norm() <= 0.5);
 
-	//EXPECT_TRUE(abs(d1 - d2) < 1e-4);
-	//EXPECT_TRUE(d1 < 1e-4);
+  vel *= 0.01;
 
-	double d3 = dist(p1, p3);
-	//EXPECT_TRUE(abs(d3 - 3.14159) < 1e10-3);	
+  std::cout << vel.clamped(1, 0.5, 0.1, 0.1) << std::endl;
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_linear_velocity()(i) == 0);
+    EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_angular_velocity()(i) == 0);
+  }
 }
 
-TEST(TestTwistOperatorsWithEigen, PositiveNos)
-{
-	Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-	CartesianTwist twist("test");
-	twist = vec;
-	EXPECT_TRUE((vec-twist.get_twist()).norm() < 1e-4);
-	twist = vec.array();
-	EXPECT_TRUE((vec-twist.get_twist()).norm() < 1e-4);
+TEST(TestPoseDistance, PositiveNos) {
+  CartesianPose p1("test", Eigen::Vector3d::Zero());
+  CartesianPose p2("test", Eigen::Vector3d(1, 0, 0));
+  CartesianPose p3("test", Eigen::Vector3d(1, 0, 0), Eigen::Quaterniond(0, 1, 0, 0));
 
-	twist += vec;
-	EXPECT_TRUE((2 * vec-twist.get_twist()).norm() < 1e-4);
+  double d1 = dist(p1, p2);
+  double d2 = p1.dist(p2);
 
-	Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
-	twist = twist + arr;
+  //EXPECT_TRUE(abs(d1 - d2) < 1e-4);
+  //EXPECT_TRUE(d1 < 1e-4);
 
-	EXPECT_TRUE(((2 * vec + arr)-twist.get_twist()).norm() < 1e-4);
-
-	twist = arr + twist;
-	EXPECT_TRUE(((2 * vec + 2 * arr)-twist.get_twist()).norm() < 1e-4);
-
-	twist -= arr;
-	EXPECT_TRUE(((2 * vec + arr)-twist.get_twist()).norm() < 1e-4);
-
-	twist = twist - vec;
-	EXPECT_TRUE(((vec + arr)-twist.get_twist()).norm() < 1e-4);
-
-	twist = vec - twist;
-	EXPECT_TRUE((arr+twist.get_twist()).norm() < 1e-4);
+  double d3 = dist(p1, p3);
+  //EXPECT_TRUE(abs(d3 - 3.14159) < 1e10-3);
 }
 
-TEST(TestWrenchOperatorsWithEigen, PositiveNos)
-{
-	Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-	CartesianWrench wrench("test");
-	wrench = vec;
-	EXPECT_TRUE((vec-wrench.get_wrench()).norm() < 1e-4);
-	wrench = vec.array();
-	EXPECT_TRUE((vec-wrench.get_wrench()).norm() < 1e-4);
+TEST(TestFilter, PositiveNos) {
+  CartesianPose tf1("t1", Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
+  CartesianPose tf2("t1", Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
 
-	wrench += vec;
-	EXPECT_TRUE((2 * vec-wrench.get_wrench()).norm() < 1e-4);
+  for (int i = 0; i < 1000; ++i) {
+    CartesianPose temp = tf1;
 
-	Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
-	wrench = wrench + arr;
+    double alpha = 0.1;
+    tf1 = (1 - alpha) * tf1 + alpha * tf2;
+    EXPECT_TRUE((tf1.get_position() - ((1 - alpha) * temp.get_position() + alpha * tf2.get_position())).norm() < 1e-4);
+  }
 
-	EXPECT_TRUE(((2 * vec + arr)-wrench.get_wrench()).norm() < 1e-4);
-
-	wrench = arr + wrench;
-	EXPECT_TRUE(((2 * vec + 2 * arr)-wrench.get_wrench()).norm() < 1e-4);
-
-	wrench -= arr;
-	EXPECT_TRUE(((2 * vec + arr)-wrench.get_wrench()).norm() < 1e-4);
-
-	wrench = wrench - vec;
-	EXPECT_TRUE(((vec + arr)-wrench.get_wrench()).norm() < 1e-4);
-
-	wrench = vec - wrench;
-	EXPECT_TRUE((arr+wrench.get_wrench()).norm() < 1e-4);
+  //EXPECT_TRUE(dist(tf1, tf2) < 1e-4);
 }
 
-TEST(TestFilter, PositiveNos)
-{
-	CartesianPose tf1("t1", Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
-	CartesianPose tf2("t1", Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
-
-	for (int i = 0; i <1000; ++i)
-	{
-		CartesianPose temp = tf1;
-
-		double alpha = 0.1;
-		tf1 = (1-alpha) * tf1 + alpha * tf2;
-		EXPECT_TRUE((tf1.get_position() - ((1-alpha) * temp.get_position() + alpha * tf2.get_position())).norm() < 1e-4);
-	}
-
-	//EXPECT_TRUE(dist(tf1, tf2) < 1e-4);
+TEST(TestToSTDVector, PositiveNos) {
+  CartesianPose p = CartesianPose::Random("t1");
+  std::vector<double> v = p.to_std_vector();
+  for (unsigned int i = 0; i < 3; ++i) EXPECT_NEAR(p.get_position()(i), v[i], 0.00001);
+  EXPECT_NEAR(p.get_orientation().w(), v[3], 0.00001);
+  EXPECT_NEAR(p.get_orientation().x(), v[4], 0.00001);
+  EXPECT_NEAR(p.get_orientation().y(), v[5], 0.00001);
+  EXPECT_NEAR(p.get_orientation().z(), v[6], 0.00001);
 }
 
-TEST(TestToSTDVector, PositiveNos)
-{
-	CartesianPose p = CartesianPose::Random("t1");
-	std::vector<double> v = p.to_std_vector();
-	for(unsigned int i=0; i<3; ++i) EXPECT_NEAR(p.get_position()(i), v[i], 0.00001);
-	EXPECT_NEAR(p.get_orientation().w(), v[3], 0.00001);
-	EXPECT_NEAR(p.get_orientation().x(), v[4], 0.00001);
-	EXPECT_NEAR(p.get_orientation().y(), v[5], 0.00001);
-	EXPECT_NEAR(p.get_orientation().z(), v[6], 0.00001);
-}
-
-int main(int argc, char **argv) 
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR is a refactor of the state_representation library to simplify the getters and setters and avoid code duplication when possible.

It also introduce the *, + and - operators (with their = forms) at the CartesianState level. This was a feature needed to simplify the writing of the equations in the controllers. The basic idea is to be able to do `error = state_desired - state_real` in one go to get the errors in all the levels (pose, twist, accelerations and wrench). This approach should also be extended to the JointState.

At the moment, unit test are not refactored. Modifications made here pass the old test cases but not every functionalities are covered by those.