### PR TITLE
Refactor/joint state

### DIFF
--- a/source/state_representation/include/state_representation/Robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/Robot/Jacobian.hpp
@@ -5,310 +5,291 @@
 
 #pragma once
 
-#include <eigen3/Eigen/Core>
-#include "state_representation/State.hpp"
+#include "state_representation/Exceptions/IncompatibleSizeException.hpp"
+#include "state_representation/Robot/JointTorques.hpp"
+#include "state_representation/Robot/JointVelocities.hpp"
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 #include "state_representation/Space/Cartesian/CartesianWrench.hpp"
-#include "state_representation/Robot/JointVelocities.hpp"
-#include "state_representation/Robot/JointTorques.hpp"
-#include "state_representation/Exceptions/IncompatibleSizeException.hpp"
+#include "state_representation/State.hpp"
+#include <eigen3/Eigen/Core>
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation 
-{
-	class CartesianTwist;
+namespace StateRepresentation {
+class CartesianTwist;
 
-	class CartesianWrench;
+class CartesianWrench;
 
-	class JointVelocities;
+class JointVelocities;
 
-	class JointTorques;	
+class JointTorques;
 
-	/**
-	 * @class Jacobian
-	 * @brief Class to define a robot Jacobian matrix
-	 */
-	class Jacobian: public State
-	{
-	private:
-		std::vector<std::string> joint_names; ///< names of the joints
-		unsigned int nb_rows; ///< number of rows
-		unsigned int nb_cols; ///< number of columns
-		Eigen::MatrixXd data; ///< internal storage of the jacobian matrix
+/**
+ * @class Jacobian
+ * @brief Class to define a robot Jacobian matrix
+ */
+class Jacobian : public State {
+private:
+  std::vector<std::string> joint_names;///< names of the joints
+  unsigned int nb_rows;                ///< number of rows
+  unsigned int nb_cols;                ///< number of columns
+  Eigen::MatrixXd data;                ///< internal storage of the jacobian matrix
 
-	public:
-		/**
-	 	 * @brief Empty constructor for a Jacobian
-	     */
-		explicit Jacobian();
+public:
+  /**
+   * @brief Empty constructor for a Jacobian
+   */
+  explicit Jacobian();
 
-		/**
-	 	 * @brief Constructor with name and number of joints provided
-	 	 * @brief name the name of the robot associated to
-	 	 * @brief nb_joints the number of joints
-	     */
-		explicit Jacobian(const std::string& robot_name, unsigned int nb_joints=0);
+  /**
+   * @brief Constructor with name and number of joints provided
+   * @brief name the name of the robot associated to
+   * @brief nb_joints the number of joints
+   */
+  explicit Jacobian(const std::string& robot_name, unsigned int nb_joints = 0);
 
-		/**
-	 	 * @brief Constructor with name and list of joint names provided
-	 	 * @brief name the name of the robot associated to
-	 	 * @brief joint_names the list of joint names
-	     */
-		explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names);
+  /**
+   * @brief Constructor with name and list of joint names provided
+   * @brief name the name of the robot associated to
+   * @brief joint_names the list of joint names
+   */
+  explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
-		/**
-	 	 * @brief Constructor with name and jacobian matrix as eigen matrix
-	 	 * @brief name the name of the robot associated to
-	 	 * @brief data the value of the jacobian matrix
-	     */
-		explicit Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data);
+  /**
+   * @brief Constructor with name and jacobian matrix as eigen matrix
+   * @brief name the name of the robot associated to
+   * @brief data the value of the jacobian matrix
+   */
+  explicit Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data);
 
-		/**
-	 	 * @brief Constructor with name, list of joint names and jacobian matrix as eigen matrix
-	 	 * @brief name the name of the robot associated to
-	 	 * @brief joint_names the list of joint names
-	 	 * @brief data the value of the jacobian matrix
-	     */
-		explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::MatrixXd& data);
+  /**
+   * @brief Constructor with name, list of joint names and jacobian matrix as eigen matrix
+   * @brief name the name of the robot associated to
+   * @brief joint_names the list of joint names
+   * @brief data the value of the jacobian matrix
+   */
+  explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::MatrixXd& data);
 
-		/**
-	 	 * @brief Copy constructor of a Jacobian
-	     */
-		Jacobian(const Jacobian& jacobian);
+  /**
+   * @brief Copy constructor of a Jacobian
+   */
+  Jacobian(const Jacobian& jacobian);
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param matrix the matrix with value to assign
-		 * @return reference to the current matrix with new values
-		 */
-		Jacobian& operator=(const Jacobian& matrix);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param matrix the matrix with value to assign
+   * @return reference to the current matrix with new values
+   */
+  Jacobian& operator=(const Jacobian& matrix);
 
-		/**
-	 	 * @brief Getter of the nb_rows from the attributes
-	     */
-		unsigned int get_nb_rows() const;
+  /**
+   * @brief Getter of the nb_rows from the attributes
+   */
+  unsigned int get_nb_rows() const;
 
-		/**
-		 * @brief Setter of the nb_rows
-		 */
-		void set_nb_rows(unsigned int nb_rows);
+  /**
+   * @brief Setter of the nb_rows
+   */
+  void set_nb_rows(unsigned int nb_rows);
 
-		/**
-		 * @brief Setter of the nb_cols
-		 */
-		void set_nb_cols(unsigned int nb_cols);
+  /**
+   * @brief Setter of the nb_cols
+   */
+  void set_nb_cols(unsigned int nb_cols);
 
-		/**
-	 	 * @brief Getter of the nb_cols from the attributes
-	     */
-		unsigned int get_nb_cols() const;
+  /**
+   * @brief Getter of the nb_cols from the attributes
+   */
+  unsigned int get_nb_cols() const;
 
-		/**
-	 	 * @brief Getter of the names attribute
-	     */
-		const std::vector<std::string>& get_joint_names() const;
+  /**
+   * @brief Getter of the names attribute
+   */
+  const std::vector<std::string>& get_joint_names() const;
 
-		/**
-	 	 * @brief Setter of the names attribute from the number of joints
-	     */
-		void set_joint_names(unsigned int nb_joints);
+  /**
+   * @brief Setter of the names attribute from the number of joints
+   */
+  void set_joint_names(unsigned int nb_joints);
 
-		/**
-	 	 * @brief Setter of the names attribute
-	     */
-		void set_joint_names(const std::vector<std::string>& names);
+  /**
+   * @brief Setter of the names attribute
+   */
+  void set_joint_names(const std::vector<std::string>& names);
 
-		/**
-	 	 * @brief Getter of the data attribute
-	     */
-		const Eigen::MatrixXd& get_data() const;
+  /**
+   * @brief Getter of the data attribute
+   */
+  const Eigen::MatrixXd& get_data() const;
 
-		/**
-	 	 * @brief Setter of the data attribute
-	     */
-		void set_data(const Eigen::MatrixXd& data);
+  /**
+   * @brief Setter of the data attribute
+   */
+  void set_data(const Eigen::MatrixXd& data);
 
-		/**
-	 	 * @brief Check if the jacobian matrix is compatible for operations with the state given as argument
-	 	 * @param state the state to check compatibility with
-	     */
-		bool is_compatible(const State& state) const;
+  /**
+   * @brief Check if the jacobian matrix is compatible for operations with the state given as argument
+   * @param state the state to check compatibility with
+   */
+  bool is_compatible(const State& state) const;
 
-		/**
-	 	 * @brief Initialize the matrix to a zero value
-	     */
-		void initialize();
+  /**
+   * @brief Initialize the matrix to a zero value
+   */
+  void initialize();
 
-		/**
-		 * @brief Return the transpose of the jacobian matrix
-		 * @return the Jacobian transposed
-		 */
-		const Jacobian transpose();
+  /**
+   * @brief Return the transpose of the jacobian matrix
+   * @return the Jacobian transposed
+   */
+  const Jacobian transpose();
 
-		/**
-	 	 * @brief Overload the * operator with an non specific matrix
-	 	 * @param matrix the vector to multiply with
-	 	 * @return the vector multiply by the jacobian matrix
-	     */
-		const Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix) const;
+  /**
+   * @brief Overload the * operator with an non specific matrix
+   * @param matrix the vector to multiply with
+   * @return the vector multiply by the jacobian matrix
+   */
+  const Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix) const;
 
-		/**
-	 	 * @brief Overload the * operator with a JointVelocities
-	 	 * @param dq the joint velocity to multiply with
-	 	 * @return this result into the CartesianTwist of the end effector
-	 	 * the name of the output CartesianTwist will be "robot"_end_effector and
-	 	 * the reference frame will be "robot"_base 
-	     */
-		const CartesianTwist operator*(const JointVelocities& dq) const;
+  /**
+   * @brief Overload the * operator with a JointVelocities
+   * @param dq the joint velocity to multiply with
+   * @return this result into the CartesianTwist of the end effector
+   * the name of the output CartesianTwist will be "robot"_end_effector and
+   * the reference frame will be "robot"_base 
+   */
+  const CartesianTwist operator*(const JointVelocities& dq) const;
 
-		/**
-	 	 * @brief Solve the system X = inv(J)*M to obtain X which is more efficient than multiplying with the pseudo-inverse
-	 	 * @param matrix the matrix to solve the system with
-	 	 * @return result of X = J.solve(M) from Eigne decomposition
-	     */
-		const Eigen::MatrixXd solve(const Eigen::MatrixXd& matrix) const;
+  /**
+   * @brief Solve the system X = inv(J)*M to obtain X which is more efficient than multiplying with the pseudo-inverse
+   * @param matrix the matrix to solve the system with
+   * @return result of X = J.solve(M) from Eigne decomposition
+   */
+  const Eigen::MatrixXd solve(const Eigen::MatrixXd& matrix) const;
 
-		/**
-	 	 * @brief Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse
-	 	 * @param dX the cartesian velocity to multiply with
-	 	 * @return this result into a JointVelocities
-	     */
-		const JointVelocities solve(const CartesianTwist& dX) const;
+  /**
+   * @brief Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse
+   * @param dX the cartesian velocity to multiply with
+   * @return this result into a JointVelocities
+   */
+  const JointVelocities solve(const CartesianTwist& dX) const;
 
-		/**
-	 	 * @brief Overload the * operator with a CartesianTwist. This is equivalent to using the solve function
-	 	 * @param dX the cartesian velocity to multiply with
-	 	 * @return this result into a JointVelocities
-	     */
-		const JointVelocities operator*(const CartesianTwist& dX) const;
+  /**
+   * @brief Overload the * operator with a CartesianTwist. This is equivalent to using the solve function
+   * @param dX the cartesian velocity to multiply with
+   * @return this result into a JointVelocities
+   */
+  const JointVelocities operator*(const CartesianTwist& dX) const;
 
-		/**
-		 * @brief Overload the () operator in a non const fashion to modify the value at given (row, col)
-		 * @param row the index of the row
-		 * @param the index of the column
-		 * @return the reference to the value at the given row and column
-		 */
-		double& operator()(unsigned int row, unsigned int col);
+  /**
+   * @brief Overload the () operator in a non const fashion to modify the value at given (row, col)
+   * @param row the index of the row
+   * @param the index of the column
+   * @return the reference to the value at the given row and column
+   */
+  double& operator()(unsigned int row, unsigned int col);
 
-		/**
-		 * @brief Overload the () operator const fashion to access the value at given (row, col)
-		 * @param row the index of the row
-		 * @param the index of the column
-		 * @return the const reference to the value at the given row and column
-		 */
-		const double& operator()(unsigned int row, unsigned int col) const;
+  /**
+   * @brief Overload the () operator const fashion to access the value at given (row, col)
+   * @param row the index of the row
+   * @param the index of the column
+   * @return the const reference to the value at the given row and column
+   */
+  const double& operator()(unsigned int row, unsigned int col) const;
 
-		/**
-		 * @brief Return a copy of the JointPositions
-		 * @return the copy
-		 */
-		const Jacobian copy() const;
+  /**
+   * @brief Return a copy of the JointPositions
+   * @return the copy
+   */
+  const Jacobian copy() const;
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to append the string representing the matrix to
-	 	 * @param matrix the matrix to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const Jacobian& matrix);
-	};
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to append the string representing the matrix to
+   * @param matrix the matrix to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const Jacobian& matrix);
+};
 
-	inline Jacobian& Jacobian::operator=(const Jacobian& matrix)
-	{
-		State::operator=(matrix);
-		this->joint_names = matrix.joint_names;
-		this->nb_cols = matrix.nb_cols;
-		this->nb_rows = matrix.nb_rows;
-		this->data = matrix.data;
-		return (*this);
-	}
-
-	inline unsigned int Jacobian::get_nb_rows() const
-	{
-		return this->nb_rows;
-	}
-
-	inline unsigned int Jacobian::get_nb_cols() const
-	{
-		return this->nb_cols;
-	}
-
-	inline void Jacobian::set_nb_rows(unsigned int nb_rows)
-	{
-		this->nb_rows = nb_rows;
-	}
-
-	inline void Jacobian::set_nb_cols(unsigned int nb_cols)
-	{
-		this->nb_cols = nb_cols;
-	}
-
-	inline const std::vector<std::string>& Jacobian::get_joint_names() const
-	{
-		return this->joint_names;
-	}
-
-	inline void Jacobian::set_joint_names(unsigned int nb_joints)
-	{
-		this->joint_names.resize(nb_joints);
-		this->nb_cols = nb_joints;
-		for(unsigned int i=0; i<nb_joints; ++i)
-		{
-			this->joint_names[i] = "joint" + std::to_string(i);
-		}
-		this->initialize();
-	}
-
-	inline void Jacobian::set_joint_names(const std::vector<std::string>& joint_names)
-	{
-		this->joint_names = joint_names;
-		this->nb_cols = joint_names.size();
-		this->initialize();
-	}
-
-	inline const Eigen::MatrixXd& Jacobian::get_data() const
-	{
-		return this->data;
-	}
-
-	inline void Jacobian::set_data(const Eigen::MatrixXd& data)
-	{
-		if(this->get_nb_rows() != data.rows() || this->get_nb_cols() != data.cols()) throw IncompatibleSizeException("Input matrix is of incorrect size");
-		this->set_filled();
-		this->data = data;
-	}
-
-	inline bool Jacobian::is_compatible(const State& state) const
-	{
-		bool compatible = false;
-		if(state.get_type() == StateType::JOINTSTATE)
-		{
-			compatible = (this->get_name() == state.get_name()) && (this->get_nb_cols() == static_cast<const JointState&>(state).get_size());
-			if(compatible)
-			{
-				for(unsigned int i=0; i<this->get_nb_cols(); ++i) compatible = (compatible && this->joint_names[i] == static_cast<const JointState&>(state).get_names()[i]);
-			}
-		}
-		// there is no possibilities to check that a correct frame associated to the robot is sent
-		else if(state.get_type() == StateType::CARTESIANSTATE)
-		{
-			compatible = true;
-		}
-		return compatible;
-	}
-
-	inline double& Jacobian::operator()(unsigned int row, unsigned int col)
-	{
-		if(row > this->get_nb_rows()) throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
-		if(col > this->get_nb_cols()) throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
-		return this->data(row, col);
-	}
-
-	inline const double& Jacobian::operator()(unsigned int row, unsigned int col) const
-	{
-		if(row > this->get_nb_rows()) throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
-		if(col > this->get_nb_cols()) throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
-		return this->data(row, col);
-	}
+inline Jacobian& Jacobian::operator=(const Jacobian& matrix) {
+  State::operator=(matrix);
+  this->joint_names = matrix.joint_names;
+  this->nb_cols = matrix.nb_cols;
+  this->nb_rows = matrix.nb_rows;
+  this->data = matrix.data;
+  return (*this);
 }
+
+inline unsigned int Jacobian::get_nb_rows() const {
+  return this->nb_rows;
+}
+
+inline unsigned int Jacobian::get_nb_cols() const {
+  return this->nb_cols;
+}
+
+inline void Jacobian::set_nb_rows(unsigned int nb_rows) {
+  this->nb_rows = nb_rows;
+}
+
+inline void Jacobian::set_nb_cols(unsigned int nb_cols) {
+  this->nb_cols = nb_cols;
+}
+
+inline const std::vector<std::string>& Jacobian::get_joint_names() const {
+  return this->joint_names;
+}
+
+inline void Jacobian::set_joint_names(unsigned int nb_joints) {
+  this->joint_names.resize(nb_joints);
+  this->nb_cols = nb_joints;
+  for (unsigned int i = 0; i < nb_joints; ++i) {
+    this->joint_names[i] = "joint" + std::to_string(i);
+  }
+  this->initialize();
+}
+
+inline void Jacobian::set_joint_names(const std::vector<std::string>& joint_names) {
+  this->joint_names = joint_names;
+  this->nb_cols = joint_names.size();
+  this->initialize();
+}
+
+inline const Eigen::MatrixXd& Jacobian::get_data() const {
+  return this->data;
+}
+
+inline void Jacobian::set_data(const Eigen::MatrixXd& data) {
+  if (this->get_nb_rows() != data.rows() || this->get_nb_cols() != data.cols()) throw IncompatibleSizeException("Input matrix is of incorrect size");
+  this->set_filled();
+  this->data = data;
+}
+
+inline bool Jacobian::is_compatible(const State& state) const {
+  bool compatible = false;
+  if (state.get_type() == StateType::JOINTSTATE) {
+    compatible = (this->get_name() == state.get_name()) && (this->get_nb_cols() == static_cast<const JointState&>(state).get_size());
+    if (compatible) {
+      for (unsigned int i = 0; i < this->get_nb_cols(); ++i) compatible = (compatible && this->joint_names[i] == static_cast<const JointState&>(state).get_names()[i]);
+    }
+  }
+  // there is no possibilities to check that a correct frame associated to the robot is sent
+  else if (state.get_type() == StateType::CARTESIANSTATE) {
+    compatible = true;
+  }
+  return compatible;
+}
+
+inline double& Jacobian::operator()(unsigned int row, unsigned int col) {
+  if (row > this->get_nb_rows()) throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
+  if (col > this->get_nb_cols()) throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  return this->data(row, col);
+}
+
+inline const double& Jacobian::operator()(unsigned int row, unsigned int col) const {
+  if (row > this->get_nb_rows()) throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
+  if (col > this->get_nb_cols()) throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  return this->data(row, col);
+}
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/Robot/Jacobian.hpp
@@ -68,7 +68,8 @@ public:
    * @brief joint_names the list of joint names
    * @brief data the value of the jacobian matrix
    */
-  explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::MatrixXd& data);
+  explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                    const Eigen::MatrixXd& data);
 
   /**
    * @brief Copy constructor of a Jacobian
@@ -76,7 +77,7 @@ public:
   Jacobian(const Jacobian& jacobian);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param matrix the matrix with value to assign
    * @return reference to the current matrix with new values
    */
@@ -163,7 +164,7 @@ public:
   /**
    * @brief Solve the system X = inv(J)*M to obtain X which is more efficient than multiplying with the pseudo-inverse
    * @param matrix the matrix to solve the system with
-   * @return result of X = J.solve(M) from Eigne decomposition
+   * @return result of X = J.solve(M) from Eigen decomposition
    */
   const Eigen::MatrixXd solve(const Eigen::MatrixXd& matrix) const;
 
@@ -261,7 +262,9 @@ inline const Eigen::MatrixXd& Jacobian::get_data() const {
 }
 
 inline void Jacobian::set_data(const Eigen::MatrixXd& data) {
-  if (this->get_nb_rows() != data.rows() || this->get_nb_cols() != data.cols()) throw IncompatibleSizeException("Input matrix is of incorrect size");
+  if (this->get_nb_rows() != data.rows() || this->get_nb_cols() != data.cols()) {
+    throw IncompatibleSizeException("Input matrix is of incorrect size");
+  }
   this->set_filled();
   this->data = data;
 }
@@ -269,12 +272,15 @@ inline void Jacobian::set_data(const Eigen::MatrixXd& data) {
 inline bool Jacobian::is_compatible(const State& state) const {
   bool compatible = false;
   if (state.get_type() == StateType::JOINTSTATE) {
-    compatible = (this->get_name() == state.get_name()) && (this->get_nb_cols() == static_cast<const JointState&>(state).get_size());
+    compatible = (this->get_name() == state.get_name())
+        && (this->get_nb_cols() == static_cast<const JointState&>(state).get_size());
     if (compatible) {
-      for (unsigned int i = 0; i < this->get_nb_cols(); ++i) compatible = (compatible && this->joint_names[i] == static_cast<const JointState&>(state).get_names()[i]);
+      for (unsigned int i = 0; i < this->get_nb_cols(); ++i) {
+        compatible = (compatible && this->joint_names[i] == static_cast<const JointState&>(state).get_names()[i]);
+      }
     }
   }
-  // there is no possibilities to check that a correct frame associated to the robot is sent
+    // there is no possibilities to check that a correct frame associated to the robot is sent
   else if (state.get_type() == StateType::CARTESIANSTATE) {
     compatible = true;
   }
@@ -282,14 +288,22 @@ inline bool Jacobian::is_compatible(const State& state) const {
 }
 
 inline double& Jacobian::operator()(unsigned int row, unsigned int col) {
-  if (row > this->get_nb_rows()) throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
-  if (col > this->get_nb_cols()) throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  if (row > this->get_nb_rows()) {
+    throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
+  }
+  if (col > this->get_nb_cols()) {
+    throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  }
   return this->data(row, col);
 }
 
 inline const double& Jacobian::operator()(unsigned int row, unsigned int col) const {
-  if (row > this->get_nb_rows()) throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
-  if (col > this->get_nb_cols()) throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  if (row > this->get_nb_rows()) {
+    throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
+  }
+  if (col > this->get_nb_cols()) {
+    throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  }
   return this->data(row, col);
 }
 }// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -74,19 +74,6 @@ public:
   JointPositions& operator=(const JointPositions& state);
 
   /**
-   * @brief Set the values of the  positions from an Eigen Vector
-   * @param positions the positions as an Eigen Vector
-   */
-  JointPositions& operator=(const Eigen::VectorXd& positions);
-
-  /**
-   * @brief Overload the += operator with an Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the JointPositions added the vector given in argument
-   */
-  JointPositions& operator+=(const Eigen::VectorXd& vector);
-
-  /**
    * @brief Overload the += operator
    * @param positions JointPositions to add
    * @return the current JointPositions added the JointPositions given in argument
@@ -94,25 +81,11 @@ public:
   JointPositions& operator+=(const JointPositions& positions);
 
   /**
-   * @brief Overload the + operator with a  Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the JointPositions added the vector given in argument
-   */
-  const JointPositions operator+(const Eigen::VectorXd& vector) const;
-
-  /**
    * @brief Overload the + operator
    * @param positions JointPositions to add
    * @return the current JointPositions added the JointPositions given in argument
    */
-  const JointPositions operator+(const JointPositions& positions) const;
-
-  /**
-   * @brief Overload the -= operator with a  Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the JointPositions substracted the vector given in argument
-   */
-  JointPositions& operator-=(const Eigen::VectorXd& vector);
+  JointPositions operator+(const JointPositions& positions) const;
 
   /**
    * @brief Overload the -= operator
@@ -122,30 +95,86 @@ public:
   JointPositions& operator-=(const JointPositions& positions);
 
   /**
-   * @brief Overload the - operator with an Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the JointPositions substracted the vector given in argument
-   */
-  const JointPositions operator-(const Eigen::VectorXd& vector) const;
-
-  /**
    * @brief Overload the - operator
    * @param positions JointPositions to substract
    * @return the current JointPositions substracted the JointPositions given in argument
    */
-  const JointPositions operator-(const JointPositions& positions) const;
+  JointPositions operator-(const JointPositions& positions) const;
+
+  /**
+   * @brief Overload the *= operator with a double gain
+   * @param lambda the gain to multiply with
+   * @return the JointPositions multiplied by lambda
+   */
+  JointPositions& operator*=(double lambda);
+
+  /**
+   * @brief Overload the * operator with a double gain
+   * @param lambda the gain to multiply with
+   * @return the JointPositions multiplied by lambda
+   */
+  JointPositions operator*(double lambda) const;
+
+  /**
+   * @brief Overload the *= operator with an array of gains
+   * @param lambda the gain array to multiply with
+   * @return the JointPositions multiplied by lambda
+   */
+  JointPositions& operator*=(const Eigen::ArrayXd& lambda);
+
+  /**
+   * @brief Overload the *= operator with an array of gains
+   * @param lambda the gain array to multiply with
+   * @return the JointPositions multiplied by lambda
+   */
+  JointPositions operator*(const Eigen::ArrayXd& lambda) const;
+
+  /**
+   * @brief Overload the *= operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointPositions multiplied by lambda
+   */
+  JointPositions& operator*=(const Eigen::MatrixXd& lambda);
+
+  /**
+   * @brief Overload the * operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointPositions multiplied by lambda
+   */
+  JointPositions operator*(const Eigen::MatrixXd& lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointPositions divided by lambda
+   */
+  JointPositions& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointPositions divided by lambda
+   */
+  JointPositions operator/(double lambda) const;
+
+  /**
+   * @brief Overload the / operator with a time period
+   * @param dt the time period to multiply with
+   * @return the JointVelocities corresponding to the velocities over the time period
+   */
+  JointVelocities operator/(const std::chrono::nanoseconds& dt) const;
 
   /**
    * @brief Return a copy of the JointPositions
    * @return the copy
    */
-  const JointPositions copy() const;
+  JointPositions copy() const;
 
   /**
    * @brief Return the value of the positions as Eigen array
    * @retrun the Eigen array representing the positions
    */
-  const Eigen::ArrayXd array() const;
+  Eigen::ArrayXd array() const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -156,61 +185,31 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const JointPositions& positions);
 
   /**
-   * @brief Overload the + operator with an Eigen Vector
-   * @param vector Eigen Vector to add
-   * @param positions JointPositions to add
-   * @return the Eigen Vector plus the JointPositions represented as a JointPositions
-   */
-  friend const JointPositions operator+(const Eigen::VectorXd& vector, const JointPositions& positions);
-
-  /**
-   * @brief Overload the - operator with a  Eigen Vector
-   * @param vector Eigen Vector
-   * @param positions JointPositions to substract
-   * @return the Eigen Vector minus the JointPositions represented as a JointPositions
-   */
-  friend const JointPositions operator-(const Eigen::VectorXd& vector, const JointPositions& positions);
-
-  /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
    * @return the JointPositions provided multiply by lambda
    */
-  friend const JointPositions operator*(double lambda, const JointPositions& positions);
+  friend JointPositions operator*(double lambda, const JointPositions& positions);
 
   /**
    * @brief Overload the * operator with an array of gains
    * @param lambda the array to multiply with
    * @return the JointPositions provided multiply by lambda
    */
-  friend const JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions);
+  friend JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions);
 
   /**
-   * @brief Overload the / operator with a scalar
-   * @param lambda the scalar to divide with
-   * @return the JointPositions provided divided by lambda
+   * @brief Overload the * operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointPositions provided multiply by lambda
    */
-  friend const JointPositions operator/(const JointPositions& positions, double lambda);
-
-  /**
-   * @brief Overload the / operator with an array of gains
-   * @param lambda the array to divide with
-   * @return the JointPositions provided divided by lambda
-   */
-  friend const JointPositions operator/(const JointPositions& positions, const Eigen::ArrayXd& lambda);
-
-  /**
-   * @brief Overload the / operator with a time period
-   * @param dt the time period to multiply with
-   * @return the JointVelocities corresponding to the velocities over the time period
-   */
-  friend const JointVelocities operator/(const JointPositions& positions, const std::chrono::nanoseconds& dt);
+  friend JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& state);
 
   /**
    * @brief Return the joint positions as a std vector of floats
    * @return std::vector<float> the joint positions vector as a std vector
    */
-  const std::vector<double> to_std_vector() const;
+  std::vector<double> to_std_vector() const;
 
   /**
    * @brief Set the value from a std vector

--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -68,10 +68,10 @@ public:
 
   /**
    * @brief Copy assignement operator that have to be defined to the custom assignement operator
-   * @param state the state with value to assign
+   * @param positions the state with value to assign
    * @return reference to the current state with new values
    */
-  JointPositions& operator=(const JointPositions& state);
+  JointPositions& operator=(const JointPositions& positions);
 
   /**
    * @brief Overload the += operator
@@ -179,7 +179,7 @@ public:
   /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to append the string representing the state
-   * @param state the state to print
+   * @param positions the state to print
    * @return the appended ostream
    */
   friend std::ostream& operator<<(std::ostream& os, const JointPositions& positions);
@@ -203,7 +203,7 @@ public:
    * @param lambda the matrix to multiply with
    * @return the JointPositions provided multiply by lambda
    */
-  friend JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& state);
+  friend JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& positions);
 
   /**
    * @brief Return the joint positions as a std vector of floats

--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -49,7 +49,8 @@ public:
    * @brief joint_names list of joint names
    * @brief positions the vector of positions
    */
-  explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions);
+  explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                          const Eigen::VectorXd& positions);
 
   /**
    * @brief Copy constructor
@@ -67,7 +68,7 @@ public:
   JointPositions(const JointVelocities& positions);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param positions the state with value to assign
    * @return reference to the current state with new values
    */
@@ -89,15 +90,15 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param positions JointPositions to substract
-   * @return the current JointPositions substracted the JointPositions given in argument
+   * @param positions JointPositions to subtract
+   * @return the current JointPositions subtracted the JointPositions given in argument
    */
   JointPositions& operator-=(const JointPositions& positions);
 
   /**
    * @brief Overload the - operator
-   * @param positions JointPositions to substract
-   * @return the current JointPositions substracted the JointPositions given in argument
+   * @param positions JointPositions to subtract
+   * @return the current JointPositions subtracted the JointPositions given in argument
    */
   JointPositions operator-(const JointPositions& positions) const;
 

--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -8,222 +8,219 @@
 #include "state_representation/Robot/JointState.hpp"
 #include "state_representation/Robot/JointVelocities.hpp"
 
-namespace StateRepresentation 
-{
-	class JointVelocities;
-	
-	/**
-	 * @class JointPositions
-	 * @brief Class to define a positions of the joints
-	 */
-	class JointPositions: public JointState
-	{
-	public:
-		/**
-		 * Empty constructor
-		 */
-		explicit JointPositions();
+namespace StateRepresentation {
+class JointVelocities;
 
-		/**
-	 	 * @brief Constructor with name and number of joints provided
-	 	 * @brief name the name of the state
-	 	 * @brief nb_joints the number of joints for initialization
-	     */
-		explicit JointPositions(const std::string& robot_name, unsigned int nb_joints=0);
+/**
+ * @class JointPositions
+ * @brief Class to define a positions of the joints
+ */
+class JointPositions : public JointState {
+public:
+  /**
+   * Empty constructor
+   */
+  explicit JointPositions();
 
-		/**
-	 	 * @brief Constructor with name and list of joint names provided
-	 	 * @brief name the name of the state
-	 	 * @brief joint_names list of joint names
-	     */
-		explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names);
+  /**
+   * @brief Constructor with name and number of joints provided
+   * @brief name the name of the state
+   * @brief nb_joints the number of joints for initialization
+   */
+  explicit JointPositions(const std::string& robot_name, unsigned int nb_joints = 0);
 
-		/**
-	 	 * @brief Constructor with name and position values provided
-	 	 * @brief name the name of the state
-	 	 * @brief positions the vector of positions
-	     */
-		explicit JointPositions(const std::string& robot_name, const Eigen::VectorXd& positions);
+  /**
+   * @brief Constructor with name and list of joint names provided
+   * @brief name the name of the state
+   * @brief joint_names list of joint names
+   */
+  explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
-		/**
-	 	 * @brief Constructor with name, a list of joint names  and position values provided
-	 	 * @brief name the name of the state
-	 	 * @brief joint_names list of joint names
-	 	 * @brief positions the vector of positions
-	     */
-		explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions);
+  /**
+   * @brief Constructor with name and position values provided
+   * @brief name the name of the state
+   * @brief positions the vector of positions
+   */
+  explicit JointPositions(const std::string& robot_name, const Eigen::VectorXd& positions);
 
-		/**
-	 	 * @brief Copy constructor
-	     */
-		JointPositions(const JointPositions& positions);
+  /**
+   * @brief Constructor with name, a list of joint names  and position values provided
+   * @brief name the name of the state
+   * @brief joint_names list of joint names
+   * @brief positions the vector of positions
+   */
+  explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions);
 
-		/**
-	 	 * @brief Copy constructor from a JointState
-	     */
-		JointPositions(const JointState& state);
+  /**
+   * @brief Copy constructor
+   */
+  JointPositions(const JointPositions& positions);
 
-		/**
-	 	 * @brief Copy constructor from a JointVelocities by considering that it is equivalent to multiplying the velocities by 1 second
-	     */
-		JointPositions(const JointVelocities& positions);
+  /**
+   * @brief Copy constructor from a JointState
+   */
+  JointPositions(const JointState& state);
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param state the state with value to assign
-		 * @return reference to the current state with new values
-		 */
-		JointPositions& operator=(const JointPositions& state);
+  /**
+   * @brief Copy constructor from a JointVelocities by considering that it is equivalent to multiplying the velocities by 1 second
+   */
+  JointPositions(const JointVelocities& positions);
 
-		/**
-		 * @brief Set the values of the  positions from an Eigen Vector
-		 * @param positions the positions as an Eigen Vector
-		 */
-		JointPositions& operator=(const Eigen::VectorXd& positions);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param state the state with value to assign
+   * @return reference to the current state with new values
+   */
+  JointPositions& operator=(const JointPositions& state);
 
-		/**
-	 	 * @brief Overload the += operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the JointPositions added the vector given in argument
-	     */
-		JointPositions& operator+=(const Eigen::VectorXd& vector);
+  /**
+   * @brief Set the values of the  positions from an Eigen Vector
+   * @param positions the positions as an Eigen Vector
+   */
+  JointPositions& operator=(const Eigen::VectorXd& positions);
 
-		/**
-	 	 * @brief Overload the += operator
-	 	 * @param positions JointPositions to add
-	 	 * @return the current JointPositions added the JointPositions given in argument
-	     */
-		JointPositions& operator+=(const JointPositions& positions);
+  /**
+   * @brief Overload the += operator with an Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the JointPositions added the vector given in argument
+   */
+  JointPositions& operator+=(const Eigen::VectorXd& vector);
 
-		/**
-	 	 * @brief Overload the + operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the JointPositions added the vector given in argument
-	     */
-		const JointPositions operator+(const Eigen::VectorXd& vector) const;
+  /**
+   * @brief Overload the += operator
+   * @param positions JointPositions to add
+   * @return the current JointPositions added the JointPositions given in argument
+   */
+  JointPositions& operator+=(const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the + operator
-	 	 * @param positions JointPositions to add
-	 	 * @return the current JointPositions added the JointPositions given in argument
-	     */
-		const JointPositions operator+(const JointPositions& positions) const;
+  /**
+   * @brief Overload the + operator with a  Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the JointPositions added the vector given in argument
+   */
+  const JointPositions operator+(const Eigen::VectorXd& vector) const;
 
-		/**
-	 	 * @brief Overload the -= operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the JointPositions substracted the vector given in argument
-	     */
-		JointPositions& operator-=(const Eigen::VectorXd& vector);
+  /**
+   * @brief Overload the + operator
+   * @param positions JointPositions to add
+   * @return the current JointPositions added the JointPositions given in argument
+   */
+  const JointPositions operator+(const JointPositions& positions) const;
 
-		/**
-	 	 * @brief Overload the -= operator
-	 	 * @param positions JointPositions to substract
-	 	 * @return the current JointPositions substracted the JointPositions given in argument
-	     */
-		JointPositions& operator-=(const JointPositions& positions);
+  /**
+   * @brief Overload the -= operator with a  Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the JointPositions substracted the vector given in argument
+   */
+  JointPositions& operator-=(const Eigen::VectorXd& vector);
 
-		/**
-	 	 * @brief Overload the - operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the JointPositions substracted the vector given in argument
-	     */
-		const JointPositions operator-(const Eigen::VectorXd& vector) const;
+  /**
+   * @brief Overload the -= operator
+   * @param positions JointPositions to substract
+   * @return the current JointPositions substracted the JointPositions given in argument
+   */
+  JointPositions& operator-=(const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the - operator
-	 	 * @param positions JointPositions to substract
-	 	 * @return the current JointPositions substracted the JointPositions given in argument
-	     */
-		const JointPositions operator-(const JointPositions& positions) const;
+  /**
+   * @brief Overload the - operator with an Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the JointPositions substracted the vector given in argument
+   */
+  const JointPositions operator-(const Eigen::VectorXd& vector) const;
 
-		/**
-		 * @brief Return a copy of the JointPositions
-		 * @return the copy
-		 */
-		const JointPositions copy() const;
+  /**
+   * @brief Overload the - operator
+   * @param positions JointPositions to substract
+   * @return the current JointPositions substracted the JointPositions given in argument
+   */
+  const JointPositions operator-(const JointPositions& positions) const;
 
-		/**
-		 * @brief Return the value of the positions as Eigen array
-		 * @retrun the Eigen array representing the positions
-		 */
-		const Eigen::ArrayXd array() const;
+  /**
+   * @brief Return a copy of the JointPositions
+   * @return the copy
+   */
+  const JointPositions copy() const;
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to append the string representing the state
-	 	 * @param state the state to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const JointPositions& positions);
+  /**
+   * @brief Return the value of the positions as Eigen array
+   * @retrun the Eigen array representing the positions
+   */
+  const Eigen::ArrayXd array() const;
 
-		/**
-	 	 * @brief Overload the + operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @param positions JointPositions to add
-	 	 * @return the Eigen Vector plus the JointPositions represented as a JointPositions
-	     */
-		friend const JointPositions operator+(const Eigen::VectorXd& vector, const JointPositions& positions);
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to append the string representing the state
+   * @param state the state to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the - operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector
-	 	 * @param positions JointPositions to substract
-	 	 * @return the Eigen Vector minus the JointPositions represented as a JointPositions
-	     */
-		friend const JointPositions operator-(const Eigen::VectorXd& vector, const JointPositions& positions);
+  /**
+   * @brief Overload the + operator with an Eigen Vector
+   * @param vector Eigen Vector to add
+   * @param positions JointPositions to add
+   * @return the Eigen Vector plus the JointPositions represented as a JointPositions
+   */
+  friend const JointPositions operator+(const Eigen::VectorXd& vector, const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the JointPositions provided multiply by lambda
-	     */
-		friend const JointPositions operator*(double lambda, const JointPositions& positions);
+  /**
+   * @brief Overload the - operator with a  Eigen Vector
+   * @param vector Eigen Vector
+   * @param positions JointPositions to substract
+   * @return the Eigen Vector minus the JointPositions represented as a JointPositions
+   */
+  friend const JointPositions operator-(const Eigen::VectorXd& vector, const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the * operator with an array of gains
-	 	 * @param lambda the array to multiply with
-	 	 * @return the JointPositions provided multiply by lambda
-	     */
-		friend const JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions);
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the JointPositions provided multiply by lambda
+   */
+  friend const JointPositions operator*(double lambda, const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the / operator with a scalar
-	 	 * @param lambda the scalar to divide with
-	 	 * @return the JointPositions provided divided by lambda
-	     */
-		friend const JointPositions operator/(const JointPositions& positions, double lambda);
+  /**
+   * @brief Overload the * operator with an array of gains
+   * @param lambda the array to multiply with
+   * @return the JointPositions provided multiply by lambda
+   */
+  friend const JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions);
 
-		/**
-	 	 * @brief Overload the / operator with an array of gains
-	 	 * @param lambda the array to divide with
-	 	 * @return the JointPositions provided divided by lambda
-	     */
-		friend const JointPositions operator/(const JointPositions& positions, const Eigen::ArrayXd& lambda);
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointPositions provided divided by lambda
+   */
+  friend const JointPositions operator/(const JointPositions& positions, double lambda);
 
-		/**
-	 	 * @brief Overload the / operator with a time period
-	 	 * @param dt the time period to multiply with
-	 	 * @return the JointVelocities corresponding to the velocities over the time period
-	     */
-		friend const JointVelocities operator/(const JointPositions& positions, const std::chrono::nanoseconds& dt);
+  /**
+   * @brief Overload the / operator with an array of gains
+   * @param lambda the array to divide with
+   * @return the JointPositions provided divided by lambda
+   */
+  friend const JointPositions operator/(const JointPositions& positions, const Eigen::ArrayXd& lambda);
 
-		/**
-		 * @brief Return the joint positions as a std vector of floats
-		 * @return std::vector<float> the joint positions vector as a std vector
-		 */
-		const std::vector<double> to_std_vector() const;
+  /**
+   * @brief Overload the / operator with a time period
+   * @param dt the time period to multiply with
+   * @return the JointVelocities corresponding to the velocities over the time period
+   */
+  friend const JointVelocities operator/(const JointPositions& positions, const std::chrono::nanoseconds& dt);
 
-		/**
-		 * @brief Set the value from a std vector
-		 * @param value the value as a std vector
-		 */
-		void from_std_vector(const std::vector<double>& value);
-	};
+  /**
+   * @brief Return the joint positions as a std vector of floats
+   * @return std::vector<float> the joint positions vector as a std vector
+   */
+  const std::vector<double> to_std_vector() const;
 
-	inline JointPositions& JointPositions::operator=(const JointPositions& state)
-	{
-		JointState::operator=(state);
-		return (*this);
-	}
+  /**
+   * @brief Set the value from a std vector
+   * @param value the value as a std vector
+   */
+  void from_std_vector(const std::vector<double>& value);
+};
+
+inline JointPositions& JointPositions::operator=(const JointPositions& state) {
+  JointState::operator=(state);
+  return (*this);
 }
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -37,9 +37,10 @@ enum class JointStateVariable {
  * @param s2 the second JointState
  * @param state_variable_type name of the field from the JointStateVariable structure to apply
  * the distance on. Default ALL for full distance across all dimensions
- * @return the distance beteen the two states
+ * @return the distance between the two states
  */
-double dist(const JointState& s1, const JointState& s2, const JointStateVariable& state_variable_type = JointStateVariable::ALL);
+double dist(const JointState& s1, const JointState& s2,
+            const JointStateVariable& state_variable_type = JointStateVariable::ALL);
 
 /**
  * @class JointState
@@ -119,7 +120,7 @@ public:
   JointState(const JointState& state);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
    */
@@ -239,20 +240,22 @@ public:
    * @brief Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)
    * @param max_absolute_value the maximum absolute magnitude of the state variable
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
    * the velocity will be set to 0
    */
-  void clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type, double noise_ratio = 0);
+  void clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type,
+                            double noise_ratio = 0);
 
   /**
    * @brief Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)
    * for each individual joints
    * @param max_absolute_value_array the maximum absolute magnitude of the state variable for each joints individually
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
-   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio_array if provided, this value will be used to apply a dead zone under which
    * the velocity will be set to 0
    */
-  void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array, const JointStateVariable& state_variable_type, const Eigen::ArrayXd& noise_ratio_array);
+  void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
+                            const JointStateVariable& state_variable_type, const Eigen::ArrayXd& noise_ratio_array);
 
   /**
    * @brief Return a copy of the JointState
@@ -276,15 +279,15 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param state JointState to substract
-   * @return the current JointState substracted the JointState given in argument
+   * @param state JointState to subtract
+   * @return the current JointState subtracted the JointState given in argument
    */
   JointState& operator-=(const JointState& state);
 
   /**
    * @brief Overload the - operator
-   * @param state JointState to substract
-   * @return the current JointState substracted the JointState given in argument
+   * @param state JointState to subtract
+   * @return the current JointState subtracted the JointState given in argument
    */
   JointState operator-(const JointState& state) const;
 
@@ -370,7 +373,7 @@ public:
 
   /**
    * @brief Overload the * operator with an array of gains
-   * @param lambda the gain arrayz to multiply with
+   * @param lambda the gain array to multiply with
    * @return the JointState provided multiply by lambda
    */
   friend JointState operator*(const Eigen::ArrayXd& lambda, const JointState& state);
@@ -402,11 +405,11 @@ inline Eigen::VectorXd JointState::get_all_state_variables() const {
 }
 
 inline void JointState::set_state_variable(Eigen::VectorXd& state_variable, const Eigen::VectorXd& new_value) {
-  if (new_value.size() != this->get_size())
-    throw IncompatibleSizeException("Input vector is of incorrect size: expected "
-                                    + std::to_string(this->get_size())
-                                    + ", given "
-                                    + std::to_string(new_value.size()));
+  if (new_value.size() != this->get_size()) {
+    throw IncompatibleSizeException(
+        "Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given "
+            + std::to_string(new_value.size()));
+  }
   this->set_filled();
   state_variable = new_value;
 }
@@ -433,8 +436,9 @@ inline bool JointState::is_compatible(const State& state) const {
   bool compatible = this->State::is_compatible(state);
   compatible = compatible && (this->names.size() == static_cast<const JointState&>(state).names.size());
   if (compatible) {
-    for (unsigned int i = 0; i < this->names.size(); ++i)
+    for (unsigned int i = 0; i < this->names.size(); ++i) {
       compatible = (compatible && this->names[i] == static_cast<const JointState&>(state).names[i]);
+    }
   }
   return compatible;
 }
@@ -531,7 +535,8 @@ inline Eigen::VectorXd JointState::get_state_variable(const JointStateVariable& 
   return Eigen::Vector3d::Zero();
 }
 
-inline void JointState::set_state_variable(const Eigen::VectorXd& new_value, const JointStateVariable& state_variable_type) {
+inline void JointState::set_state_variable(const Eigen::VectorXd& new_value,
+                                           const JointStateVariable& state_variable_type) {
   switch (state_variable_type) {
     case JointStateVariable::POSITIONS:
       this->set_positions(new_value);

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -78,6 +78,21 @@ private:
    */
   void set_all_state_variables(const Eigen::VectorXd& new_values);
 
+protected:
+  /**
+   * @brief Proxy function that multiply the specified state variable by an array of gain
+   * @param lambda the gain array to multiply with
+   * @param state_variable_type the state variable on which to apply the multiplication
+   */
+  void multiply_state_variable(const Eigen::ArrayXd& lambda, const JointStateVariable& state_variable_type);
+
+  /**
+   * @brief Proxy function that multiply the specified state variable by an array of gain
+   * @param lambda the gain array to multiply with
+   * @param state_variable_type the state variable on which to apply the multiplication
+   */
+  void multiply_state_variable(const Eigen::MatrixXd& lambda, const JointStateVariable& state_variable_type);
+
 public:
   /**
    * @brief Empty constructor for a JointState

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -237,12 +237,22 @@ public:
 
   /**
    * @brief Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)
-   * @param max_value the maximum absolute magnitude of the state variable
+   * @param max_absolute_value the maximum absolute magnitude of the state variable
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
    * the velocity will be set to 0
    */
-  void clamp_state_variable(double max_value, const JointStateVariable& state_variable_type, double noise_ratio = 0);
+  void clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type, double noise_ratio = 0);
+
+  /**
+   * @brief Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)
+   * for each individual joints
+   * @param max_absolute_value_array the maximum absolute magnitude of the state variable for each joints individually
+   * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
+   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   */
+  void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array, const JointStateVariable& state_variable_type, const Eigen::ArrayXd& noise_ratio_array);
 
   /**
    * @brief Return a copy of the JointState

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -77,7 +77,7 @@ public:
    * @param torques JointTorques to add
    * @return the current JointTorques added the JointTorques given in argument
    */
-  const JointTorques operator+(const JointTorques& torques) const;
+  JointTorques operator+(const JointTorques& torques) const;
 
   /**
    * @brief Overload the -= operator
@@ -91,19 +91,75 @@ public:
    * @param torques JointTorques to substract
    * @return the current JointTorques substracted the JointTorques given in argument
    */
-  const JointTorques operator-(const JointTorques& torques) const;
+  JointTorques operator-(const JointTorques& torques) const;
+
+  /**
+   * @brief Overload the *= operator with a double gain
+   * @param lambda the gain to multiply with
+   * @return the JointTorques multiplied by lambda
+   */
+  JointTorques& operator*=(double lambda);
+
+  /**
+   * @brief Overload the * operator with a double gain
+   * @param lambda the gain to multiply with
+   * @return the JointTorques multiplied by lambda
+   */
+  JointTorques operator*(double lambda) const;
+
+  /**
+   * @brief Overload the *= operator with an array of gains
+   * @param lambda the gain array to multiply with
+   * @return the JointTorques multiplied by lambda
+   */
+  JointTorques& operator*=(const Eigen::ArrayXd& lambda);
+
+  /**
+   * @brief Overload the *= operator with an array of gains
+   * @param lambda the gain array to multiply with
+   * @return the JointTorques multiplied by lambda
+   */
+  JointTorques operator*(const Eigen::ArrayXd& lambda) const;
+
+  /**
+   * @brief Overload the *= operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointTorques multiplied by lambda
+   */
+  JointTorques& operator*=(const Eigen::MatrixXd& lambda);
+
+  /**
+   * @brief Overload the * operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointTorques multiplied by lambda
+   */
+  JointTorques operator*(const Eigen::MatrixXd& lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointTorques divided by lambda
+   */
+  JointTorques& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointTorques divided by lambda
+   */
+  JointTorques operator/(double lambda) const;
 
   /**
    * @brief Return a copy of the JointTorques
    * @return the copy
    */
-  const JointTorques copy() const;
+  JointTorques copy() const;
 
   /**
    * @brief Return the value of the torques vector as Eigen array
    * @retrun the Eigen array representing the torques
    */
-  const Eigen::ArrayXd array() const;
+  Eigen::ArrayXd array() const;
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
@@ -120,7 +176,7 @@ public:
    * the torque will be set to 0
    * @return the clamped JointTorques
    */
-  const JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
+  JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -135,28 +191,21 @@ public:
    * @param lambda the scalar to multiply with
    * @return the JointTorques provided multiply by lambda
    */
-  friend const JointTorques operator*(double lambda, const JointTorques& torques);
+  friend JointTorques operator*(double lambda, const JointTorques& torques);
 
   /**
    * @brief Overload the * operator with an array of gains
    * @param lambda the array to multiply with
    * @return the JointTorques provided multiply by lambda
    */
-  friend const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques);
+  friend JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques);
 
   /**
-   * @brief Overload the / operator with a scalar
-   * @param lambda the scalar to divide with
-   * @return the JointTorques provided divided by lambda
+   * @brief Overload the * operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointTorques provided multiply by lambda
    */
-  friend const JointTorques operator/(const JointTorques& torques, double lambda);
-
-  /**
-   * @brief Overload the / operator with an array of gains
-   * @param lambda the array to divide with
-   * @return the JointTorques provided divided by lambda
-   */
-  friend const JointTorques operator/(const JointTorques& torques, const Eigen::ArrayXd& lambda);
+  friend JointTorques operator*(const Eigen::MatrixXd& lambda, const JointTorques& torques);
 };
 
 inline JointTorques& JointTorques::operator=(const JointTorques& state) {

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -163,37 +163,37 @@ public:
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
-   * @param max_absolute the maximum magnitude of torque for all the joints
+   * @param max_absolute_value the maximum magnitude of torque for all the joints
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
    * the torque will be set to 0
    */
-  void clamp(double max_absolute, double noise_ratio);
+  void clamp(double max_absolute_value, double noise_ratio);
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
-   * @param max_absolute the maximum magnitude of torque for all the joints
+   * @param max_absolute_value the maximum magnitude of torque for all the joints
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
    * the torque will be set to 0
    * @return the clamped JointTorques
    */
-  JointTorques clamped(double max_absolute, double noise_ratio) const;
+  JointTorques clamped(double max_absolute_value, double noise_ratio) const;
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
-   * @param max_absolute the maximum magnitude of torque for each joint 
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param max_absolute_value_array the maximum magnitude of torque for each joint
+   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
    * the torque will be set to 0
    */
-  //void clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio);
+  void clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array);
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
-   * @param max_absolute the maximum magnitude of torque for each joint 
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param max_absolute_value_array the maximum magnitude of torque for each joint
+   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
    * the torque will be set to 0
    * @return the clamped JointTorques
    */
-  //JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
+  JointTorques clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const;
 
   /**
    * @brief Overload the ostream operator for printing

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -163,11 +163,28 @@ public:
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute the maximum magnitude of torque for all the joints
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
+   */
+  void clamp(double max_absolute, double noise_ratio);
+
+  /**
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute the maximum magnitude of torque for all the joints
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
+   * @return the clamped JointTorques
+   */
+  JointTorques clamped(double max_absolute, double noise_ratio) const;
+
+  /**
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute the maximum magnitude of torque for each joint 
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
    * the torque will be set to 0
    */
-  void clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio);
+  //void clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio);
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
@@ -176,7 +193,7 @@ public:
    * the torque will be set to 0
    * @return the clamped JointTorques
    */
-  JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
+  //JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
 
   /**
    * @brief Overload the ostream operator for printing

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -167,7 +167,7 @@ public:
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
    * the torque will be set to 0
    */
-  void clamp(double max_absolute_value, double noise_ratio);
+  void clamp(double max_absolute_value, double noise_ratio = 0.);
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
@@ -176,7 +176,7 @@ public:
    * the torque will be set to 0
    * @return the clamped JointTorques
    */
-  JointTorques clamped(double max_absolute_value, double noise_ratio) const;
+  JointTorques clamped(double max_absolute_value, double noise_ratio = 0.) const;
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -66,31 +66,11 @@ public:
   JointTorques& operator=(const JointTorques& state);
 
   /**
-   * @brief Set the values of the  torques from an Eigen Vector
-   * @param torques the torques as an Eigen Vector
-   */
-  JointTorques& operator=(const Eigen::VectorXd& torques);
-
-  /**
-   * @brief Overload the += operator with an Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the JointTorques added the vector given in argument
-   */
-  JointTorques& operator+=(const Eigen::VectorXd& vector);
-
-  /**
    * @brief Overload the += operator
    * @param torques JointTorques to add
    * @return the current JointTorques added the JointTorques given in argument
    */
   JointTorques& operator+=(const JointTorques& torques);
-
-  /**
-   * @brief Overload the + operator with a  Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the JointTorques added the vector given in argument
-   */
-  const JointTorques operator+(const Eigen::VectorXd& vector) const;
 
   /**
    * @brief Overload the + operator
@@ -100,25 +80,11 @@ public:
   const JointTorques operator+(const JointTorques& torques) const;
 
   /**
-   * @brief Overload the -= operator with a  Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the JointTorques substracted the vector given in argument
-   */
-  JointTorques& operator-=(const Eigen::VectorXd& vector);
-
-  /**
    * @brief Overload the -= operator
    * @param torques JointTorques to substract
    * @return the current JointTorques substracted the JointTorques given in argument
    */
   JointTorques& operator-=(const JointTorques& torques);
-
-  /**
-   * @brief Overload the - operator with an Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the JointTorques substracted the vector given in argument
-   */
-  const JointTorques operator-(const Eigen::VectorXd& vector) const;
 
   /**
    * @brief Overload the - operator
@@ -163,22 +129,6 @@ public:
    * @return the appended ostream
    */
   friend std::ostream& operator<<(std::ostream& os, const JointTorques& torques);
-
-  /**
-   * @brief Overload the + operator with an Eigen Vector
-   * @param vector Eigen Vector to add
-   * @param torques JointTorques to add
-   * @return the Eigen Vector plus the JointTorques represented as a JointTorques
-   */
-  friend const JointTorques operator+(const Eigen::VectorXd& vector, const JointTorques& torques);
-
-  /**
-   * @brief Overload the - operator with a  Eigen Vector
-   * @param vector Eigen Vector
-   * @param torques JointTorques to substract
-   * @return the Eigen Vector minus the JointTorques represented as a JointTorques
-   */
-  friend const JointTorques operator-(const Eigen::VectorXd& vector, const JointTorques& torques);
 
   /**
    * @brief Overload the * operator with a scalar

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -46,7 +46,8 @@ public:
    * @brief joint_names list of joint names
    * @brief torques the vector of torques
    */
-  explicit JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& torques);
+  explicit JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                        const Eigen::VectorXd& torques);
 
   /**
    * @brief Copy constructor
@@ -59,7 +60,7 @@ public:
   JointTorques(const JointState& state);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
    */
@@ -81,15 +82,15 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param torques JointTorques to substract
-   * @return the current JointTorques substracted the JointTorques given in argument
+   * @param torques JointTorques to subtract
+   * @return the current JointTorques subtracted the JointTorques given in argument
    */
   JointTorques& operator-=(const JointTorques& torques);
 
   /**
    * @brief Overload the - operator
-   * @param torques JointTorques to substract
-   * @return the current JointTorques substracted the JointTorques given in argument
+   * @param torques JointTorques to subtract
+   * @return the current JointTorques subtracted the JointTorques given in argument
    */
   JointTorques operator-(const JointTorques& torques) const;
 
@@ -164,7 +165,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value the maximum magnitude of torque for all the joints
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    */
   void clamp(double max_absolute_value, double noise_ratio = 0.);
@@ -172,7 +173,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value the maximum magnitude of torque for all the joints
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    * @return the clamped JointTorques
    */
@@ -181,7 +182,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value_array the maximum magnitude of torque for each joint
-   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio_array if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    */
   void clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array);
@@ -189,7 +190,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value_array the maximum magnitude of torque for each joint
-   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio_array if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    * @return the clamped JointTorques
    */

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -7,213 +7,210 @@
 
 #include "state_representation/Robot/JointState.hpp"
 
-namespace StateRepresentation 
-{
-	/**
-	 * @class JointTorques
-	 * @brief Class to define torques of the joints
-	 */
-	class JointTorques: public JointState
-	{
-	public:
-		/**
-		 * Empty constructor
-		 */
-		explicit JointTorques();
+namespace StateRepresentation {
+/**
+ * @class JointTorques
+ * @brief Class to define torques of the joints
+ */
+class JointTorques : public JointState {
+public:
+  /**
+   * Empty constructor
+   */
+  explicit JointTorques();
 
-		/**
-	 	 * @brief Constructor with name and number of joints provided
-	 	 * @brief name the name of the state
-	 	 * @brief nb_joints the number of joints for initialization
-	     */
-		explicit JointTorques(const std::string& robot_name, unsigned int nb_joints=0);
+  /**
+   * @brief Constructor with name and number of joints provided
+   * @brief name the name of the state
+   * @brief nb_joints the number of joints for initialization
+   */
+  explicit JointTorques(const std::string& robot_name, unsigned int nb_joints = 0);
 
-		/**
-	 	 * @brief Constructor with name and list of joint names provided
-	 	 * @brief name the name of the state
-	 	 * @brief joint_names list of joint names
-	     */
-		explicit JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names);
+  /**
+   * @brief Constructor with name and list of joint names provided
+   * @brief name the name of the state
+   * @brief joint_names list of joint names
+   */
+  explicit JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
-		/**
-	 	 * @brief Constructor with name and torques values provided
-	 	 * @brief name the name of the state
-	 	 * @brief torques the vector of torques
-	     */
-		explicit JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques);
+  /**
+   * @brief Constructor with name and torques values provided
+   * @brief name the name of the state
+   * @brief torques the vector of torques
+   */
+  explicit JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques);
 
-		/**
-	 	 * @brief Constructor with name, a list of joint names  and torques values provided
-	 	 * @brief name the name of the state
-	 	 * @brief joint_names list of joint names
-	 	 * @brief torques the vector of torques
-	     */
-		explicit JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& torques);
+  /**
+   * @brief Constructor with name, a list of joint names  and torques values provided
+   * @brief name the name of the state
+   * @brief joint_names list of joint names
+   * @brief torques the vector of torques
+   */
+  explicit JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& torques);
 
-		/**
-	 	 * @brief Copy constructor
-	     */
-		JointTorques(const JointTorques& torques);
+  /**
+   * @brief Copy constructor
+   */
+  JointTorques(const JointTorques& torques);
 
-		/**
-	 	 * @brief Copy constructor from a JointState
-	     */
-		JointTorques(const JointState& state);
+  /**
+   * @brief Copy constructor from a JointState
+   */
+  JointTorques(const JointState& state);
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param state the state with value to assign
-		 * @return reference to the current state with new values
-		 */
-		JointTorques& operator=(const JointTorques& state);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param state the state with value to assign
+   * @return reference to the current state with new values
+   */
+  JointTorques& operator=(const JointTorques& state);
 
-		/**
-		 * @brief Set the values of the  torques from an Eigen Vector
-		 * @param torques the torques as an Eigen Vector
-		 */
-		JointTorques& operator=(const Eigen::VectorXd& torques);
+  /**
+   * @brief Set the values of the  torques from an Eigen Vector
+   * @param torques the torques as an Eigen Vector
+   */
+  JointTorques& operator=(const Eigen::VectorXd& torques);
 
-		/**
-	 	 * @brief Overload the += operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the JointTorques added the vector given in argument
-	     */
-		JointTorques& operator+=(const Eigen::VectorXd& vector);
+  /**
+   * @brief Overload the += operator with an Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the JointTorques added the vector given in argument
+   */
+  JointTorques& operator+=(const Eigen::VectorXd& vector);
 
-		/**
-	 	 * @brief Overload the += operator
-	 	 * @param torques JointTorques to add
-	 	 * @return the current JointTorques added the JointTorques given in argument
-	     */
-		JointTorques& operator+=(const JointTorques& torques);
+  /**
+   * @brief Overload the += operator
+   * @param torques JointTorques to add
+   * @return the current JointTorques added the JointTorques given in argument
+   */
+  JointTorques& operator+=(const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the + operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the JointTorques added the vector given in argument
-	     */
-		const JointTorques operator+(const Eigen::VectorXd& vector) const;
+  /**
+   * @brief Overload the + operator with a  Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the JointTorques added the vector given in argument
+   */
+  const JointTorques operator+(const Eigen::VectorXd& vector) const;
 
-		/**
-	 	 * @brief Overload the + operator
-	 	 * @param torques JointTorques to add
-	 	 * @return the current JointTorques added the JointTorques given in argument
-	     */
-		const JointTorques operator+(const JointTorques& torques) const;
+  /**
+   * @brief Overload the + operator
+   * @param torques JointTorques to add
+   * @return the current JointTorques added the JointTorques given in argument
+   */
+  const JointTorques operator+(const JointTorques& torques) const;
 
-		/**
-	 	 * @brief Overload the -= operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the JointTorques substracted the vector given in argument
-	     */
-		JointTorques& operator-=(const Eigen::VectorXd& vector);
+  /**
+   * @brief Overload the -= operator with a  Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the JointTorques substracted the vector given in argument
+   */
+  JointTorques& operator-=(const Eigen::VectorXd& vector);
 
-		/**
-	 	 * @brief Overload the -= operator
-	 	 * @param torques JointTorques to substract
-	 	 * @return the current JointTorques substracted the JointTorques given in argument
-	     */
-		JointTorques& operator-=(const JointTorques& torques);
+  /**
+   * @brief Overload the -= operator
+   * @param torques JointTorques to substract
+   * @return the current JointTorques substracted the JointTorques given in argument
+   */
+  JointTorques& operator-=(const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the - operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the JointTorques substracted the vector given in argument
-	     */
-		const JointTorques operator-(const Eigen::VectorXd& vector) const;
+  /**
+   * @brief Overload the - operator with an Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the JointTorques substracted the vector given in argument
+   */
+  const JointTorques operator-(const Eigen::VectorXd& vector) const;
 
-		/**
-	 	 * @brief Overload the - operator
-	 	 * @param torques JointTorques to substract
-	 	 * @return the current JointTorques substracted the JointTorques given in argument
-	     */
-		const JointTorques operator-(const JointTorques& torques) const;
+  /**
+   * @brief Overload the - operator
+   * @param torques JointTorques to substract
+   * @return the current JointTorques substracted the JointTorques given in argument
+   */
+  const JointTorques operator-(const JointTorques& torques) const;
 
-		/**
-		 * @brief Return a copy of the JointTorques
-		 * @return the copy
-		 */
-		const JointTorques copy() const;
+  /**
+   * @brief Return a copy of the JointTorques
+   * @return the copy
+   */
+  const JointTorques copy() const;
 
-		/**
-		 * @brief Return the value of the torques vector as Eigen array
-		 * @retrun the Eigen array representing the torques
-		 */
-		const Eigen::ArrayXd array() const;
+  /**
+   * @brief Return the value of the torques vector as Eigen array
+   * @retrun the Eigen array representing the torques
+   */
+  const Eigen::ArrayXd array() const;
 
-		/**
-		 * @brief Clamp inplace the magnitude of the velocity to the values in argument
-		 * @param max_absolute the maximum magnitude of torque for each joint 
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the torque will be set to 0
-		 */
-		void clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio);
+  /**
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute the maximum magnitude of torque for each joint 
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
+   */
+  void clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio);
 
-		/**
-		 * @brief Clamp inplace the magnitude of the velocity to the values in argument
-		 * @param max_absolute the maximum magnitude of torque for each joint 
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the torque will be set to 0
-		 * @return the clamped JointTorques
-		 */
-		const JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
+  /**
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute the maximum magnitude of torque for each joint 
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
+   * @return the clamped JointTorques
+   */
+  const JointTorques clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const;
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to append the string representing the state
-	 	 * @param state the state to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const JointTorques& torques);
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to append the string representing the state
+   * @param state the state to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the + operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @param torques JointTorques to add
-	 	 * @return the Eigen Vector plus the JointTorques represented as a JointTorques
-	     */
-		friend const JointTorques operator+(const Eigen::VectorXd& vector, const JointTorques& torques);
+  /**
+   * @brief Overload the + operator with an Eigen Vector
+   * @param vector Eigen Vector to add
+   * @param torques JointTorques to add
+   * @return the Eigen Vector plus the JointTorques represented as a JointTorques
+   */
+  friend const JointTorques operator+(const Eigen::VectorXd& vector, const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the - operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector
-	 	 * @param torques JointTorques to substract
-	 	 * @return the Eigen Vector minus the JointTorques represented as a JointTorques
-	     */
-		friend const JointTorques operator-(const Eigen::VectorXd& vector, const JointTorques& torques);
+  /**
+   * @brief Overload the - operator with a  Eigen Vector
+   * @param vector Eigen Vector
+   * @param torques JointTorques to substract
+   * @return the Eigen Vector minus the JointTorques represented as a JointTorques
+   */
+  friend const JointTorques operator-(const Eigen::VectorXd& vector, const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the JointTorques provided multiply by lambda
-	     */
-		friend const JointTorques operator*(double lambda, const JointTorques& torques);
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the JointTorques provided multiply by lambda
+   */
+  friend const JointTorques operator*(double lambda, const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the * operator with an array of gains
-	 	 * @param lambda the array to multiply with
-	 	 * @return the JointTorques provided multiply by lambda
-	     */
-		friend const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques);
+  /**
+   * @brief Overload the * operator with an array of gains
+   * @param lambda the array to multiply with
+   * @return the JointTorques provided multiply by lambda
+   */
+  friend const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques);
 
-		/**
-	 	 * @brief Overload the / operator with a scalar
-	 	 * @param lambda the scalar to divide with
-	 	 * @return the JointTorques provided divided by lambda
-	     */
-		friend const JointTorques operator/(const JointTorques& torques, double lambda);
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointTorques provided divided by lambda
+   */
+  friend const JointTorques operator/(const JointTorques& torques, double lambda);
 
-		/**
-	 	 * @brief Overload the / operator with an array of gains
-	 	 * @param lambda the array to divide with
-	 	 * @return the JointTorques provided divided by lambda
-	     */
-		friend const JointTorques operator/(const JointTorques& torques, const Eigen::ArrayXd& lambda);
-	};
+  /**
+   * @brief Overload the / operator with an array of gains
+   * @param lambda the array to divide with
+   * @return the JointTorques provided divided by lambda
+   */
+  friend const JointTorques operator/(const JointTorques& torques, const Eigen::ArrayXd& lambda);
+};
 
-	inline JointTorques& JointTorques::operator=(const JointTorques& state)
-	{
-		JointState::operator=(state);
-		return (*this);
-	}
+inline JointTorques& JointTorques::operator=(const JointTorques& state) {
+  JointState::operator=(state);
+  return (*this);
 }
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -5,254 +5,251 @@
 
 #pragma once
 
-#include "state_representation/Robot/JointState.hpp"
 #include "state_representation/Robot/JointPositions.hpp"
+#include "state_representation/Robot/JointState.hpp"
 
-namespace StateRepresentation 
-{
-	class JointPositions;
-	
-	/**
-	 * @class JointVelocities
-	 * @brief Class to define velocities of the joints
-	 */
-	class JointVelocities: public JointState
-	{
-	public:
-		/**
-		 * Empty constructor
-		 */
-		explicit JointVelocities();
+namespace StateRepresentation {
+class JointPositions;
 
-		/**
-	 	 * @brief Constructor with name and number of joints provided
-	 	 * @brief name the name of the state
-	 	 * @brief nb_joints the number of joints for initialization
-	     */
-		explicit JointVelocities(const std::string& robot_name, unsigned int nb_joints=0);
+/**
+ * @class JointVelocities
+ * @brief Class to define velocities of the joints
+ */
+class JointVelocities : public JointState {
+public:
+  /**
+   * Empty constructor
+   */
+  explicit JointVelocities();
 
-		/**
-	 	 * @brief Constructor with name and list of joint names provided
-	 	 * @brief name the name of the state
-	 	 * @brief joint_names list of joint names
-	     */
-		explicit JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names);
+  /**
+   * @brief Constructor with name and number of joints provided
+   * @brief name the name of the state
+   * @brief nb_joints the number of joints for initialization
+   */
+  explicit JointVelocities(const std::string& robot_name, unsigned int nb_joints = 0);
 
-		/**
-	 	 * @brief Constructor with name and velocities values provided
-	 	 * @brief name the name of the state
-	 	 * @brief velocities the vector of velocities
-	     */
-		explicit JointVelocities(const std::string& robot_name, const Eigen::VectorXd& velocities);
+  /**
+   * @brief Constructor with name and list of joint names provided
+   * @brief name the name of the state
+   * @brief joint_names list of joint names
+   */
+  explicit JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
-		/**
-	 	 * @brief Constructor with name, a list of joint names  and velocities values provided
-	 	 * @brief name the name of the state
-	 	 * @brief joint_names list of joint names
-	 	 * @brief velocities the vector of velocities
-	     */
-		explicit JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& velocities);
+  /**
+   * @brief Constructor with name and velocities values provided
+   * @brief name the name of the state
+   * @brief velocities the vector of velocities
+   */
+  explicit JointVelocities(const std::string& robot_name, const Eigen::VectorXd& velocities);
 
-		/**
-	 	 * @brief Copy constructor
-	     */
-		JointVelocities(const JointVelocities& velocities);
+  /**
+   * @brief Constructor with name, a list of joint names  and velocities values provided
+   * @brief name the name of the state
+   * @brief joint_names list of joint names
+   * @brief velocities the vector of velocities
+   */
+  explicit JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& velocities);
 
-		/**
-	 	 * @brief Copy constructor from a JointState
-	     */
-		JointVelocities(const JointState& state);
+  /**
+   * @brief Copy constructor
+   */
+  JointVelocities(const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Copy constructor from a JointPositions by considering that it is equivalent to dividing the positions by 1 second
-	     */
-		JointVelocities(const JointPositions& positions);
+  /**
+   * @brief Copy constructor from a JointState
+   */
+  JointVelocities(const JointState& state);
 
-		/**
-		 * @brief Copy assignement operator that have to be defined to the custom assignement operator
-		 * @param state the state with value to assign
-		 * @return reference to the current state with new values
-		 */
-		JointVelocities& operator=(const JointVelocities& state);
+  /**
+   * @brief Copy constructor from a JointPositions by considering that it is equivalent to dividing the positions by 1 second
+   */
+  JointVelocities(const JointPositions& positions);
 
-		/**
-		 * @brief Set the values of the  velocities from an Eigen Vector
-		 * @param velocities the velocities as an Eigen Vector
-		 */
-		JointVelocities& operator=(const Eigen::VectorXd& velocities);
+  /**
+   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @param state the state with value to assign
+   * @return reference to the current state with new values
+   */
+  JointVelocities& operator=(const JointVelocities& state);
 
-		/**
-	 	 * @brief Overload the += operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the JointVelocities added the vector given in argument
-	     */
-		JointVelocities& operator+=(const Eigen::VectorXd& vector);
+  /**
+   * @brief Set the values of the  velocities from an Eigen Vector
+   * @param velocities the velocities as an Eigen Vector
+   */
+  JointVelocities& operator=(const Eigen::VectorXd& velocities);
 
-		/**
-	 	 * @brief Overload the += operator
-	 	 * @param velocities JointVelocities to add
-	 	 * @return the current JointVelocities added the JointVelocities given in argument
-	     */
-		JointVelocities& operator+=(const JointVelocities& velocities);
+  /**
+   * @brief Overload the += operator with an Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the JointVelocities added the vector given in argument
+   */
+  JointVelocities& operator+=(const Eigen::VectorXd& vector);
 
-		/**
-	 	 * @brief Overload the + operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @return the JointVelocities added the vector given in argument
-	     */
-		const JointVelocities operator+(const Eigen::VectorXd& vector) const;
+  /**
+   * @brief Overload the += operator
+   * @param velocities JointVelocities to add
+   * @return the current JointVelocities added the JointVelocities given in argument
+   */
+  JointVelocities& operator+=(const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the + operator
-	 	 * @param velocities JointVelocities to add
-	 	 * @return the current JointVelocities added the JointVelocities given in argument
-	     */
-		const JointVelocities operator+(const JointVelocities& velocities) const;
+  /**
+   * @brief Overload the + operator with a  Eigen Vector
+   * @param vector Eigen Vector to add
+   * @return the JointVelocities added the vector given in argument
+   */
+  const JointVelocities operator+(const Eigen::VectorXd& vector) const;
 
-		/**
-	 	 * @brief Overload the -= operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the JointVelocities substracted the vector given in argument
-	     */
-		JointVelocities& operator-=(const Eigen::VectorXd& vector);
+  /**
+   * @brief Overload the + operator
+   * @param velocities JointVelocities to add
+   * @return the current JointVelocities added the JointVelocities given in argument
+   */
+  const JointVelocities operator+(const JointVelocities& velocities) const;
 
-		/**
-	 	 * @brief Overload the -= operator
-	 	 * @param velocities JointVelocities to substract
-	 	 * @return the current JointVelocities substracted the JointVelocities given in argument
-	     */
-		JointVelocities& operator-=(const JointVelocities& velocities);
+  /**
+   * @brief Overload the -= operator with a  Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the JointVelocities substracted the vector given in argument
+   */
+  JointVelocities& operator-=(const Eigen::VectorXd& vector);
 
-		/**
-	 	 * @brief Overload the - operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to substract
-	 	 * @return the JointVelocities substracted the vector given in argument
-	     */
-		const JointVelocities operator-(const Eigen::VectorXd& vector) const;
+  /**
+   * @brief Overload the -= operator
+   * @param velocities JointVelocities to substract
+   * @return the current JointVelocities substracted the JointVelocities given in argument
+   */
+  JointVelocities& operator-=(const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the - operator
-	 	 * @param velocities JointVelocities to substract
-	 	 * @return the current JointVelocities substracted the JointVelocities given in argument
-	     */
-		const JointVelocities operator-(const JointVelocities& velocities) const;
+  /**
+   * @brief Overload the - operator with an Eigen Vector
+   * @param vector Eigen Vector to substract
+   * @return the JointVelocities substracted the vector given in argument
+   */
+  const JointVelocities operator-(const Eigen::VectorXd& vector) const;
 
-		/**
-		 * @brief Return a copy of the JointVelocities
-		 * @return the copy
-		 */
-		const JointVelocities copy() const;
+  /**
+   * @brief Overload the - operator
+   * @param velocities JointVelocities to substract
+   * @return the current JointVelocities substracted the JointVelocities given in argument
+   */
+  const JointVelocities operator-(const JointVelocities& velocities) const;
 
-		/**
-		 * @brief Return the value of the velocities as Eigen array
-		 * @retrun the Eigen array representing the velocities
-		 */
-		const Eigen::ArrayXd array() const;
+  /**
+   * @brief Return a copy of the JointVelocities
+   * @return the copy
+   */
+  const JointVelocities copy() const;
 
-		/**
-		 * @brief Clamp inplace the magnitude of the joint velocities to the values in argument
-		 * @param max_value the maximum magnitude of the velocities
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocity will be set to 0
-		 */
-		void clamp(double max_value, double noise_ratio=0);
+  /**
+   * @brief Return the value of the velocities as Eigen array
+   * @retrun the Eigen array representing the velocities
+   */
+  const Eigen::ArrayXd array() const;
 
-		/**
-		 * @brief Clamp inplace the magnitude of the joint velocities to the values in argument
-		 * @param max_values the maximum magnitudes of the velocities for each join
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocities will be set to 0
-		 */
-		void clamp(const std::vector<double>& max_values, const std::vector<double>& noise_ratio=std::vector<double>());
+  /**
+   * @brief Clamp inplace the magnitude of the joint velocities to the values in argument
+   * @param max_value the maximum magnitude of the velocities
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   */
+  void clamp(double max_value, double noise_ratio = 0);
 
-		/**
-		 * @brief Return the clamped velocity
-		 * @param max_value the maximum magnitude of the velocities
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocity will be set to 0
-		 * @return the clamped velocity
-		 */
-		const JointVelocities clamped(double max_value, double noise_ratio=0) const;
+  /**
+   * @brief Clamp inplace the magnitude of the joint velocities to the values in argument
+   * @param max_values the maximum magnitudes of the velocities for each join
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocities will be set to 0
+   */
+  void clamp(const std::vector<double>& max_values, const std::vector<double>& noise_ratio = std::vector<double>());
 
-		/**
-		 * @brief Return the clamped velocity
-		 * @param max_value the maximum magnitude of the velocities
-		 * @param max_values the maximum magnitudes of the velocities for each join
-		 * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-		 * the velocities will be set to 0
-		 */
-		const JointVelocities clamped(const std::vector<double>& max_values, const std::vector<double>& noise_ratio=std::vector<double>()) const;
+  /**
+   * @brief Return the clamped velocity
+   * @param max_value the maximum magnitude of the velocities
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocity will be set to 0
+   * @return the clamped velocity
+   */
+  const JointVelocities clamped(double max_value, double noise_ratio = 0) const;
 
-		/**
-	 	 * @brief Overload the ostream operator for printing
-	 	 * @param os the ostream to append the string representing the state
-	 	 * @param state the state to print
-	 	 * @return the appended ostream
-	     */
-		friend std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities);
+  /**
+   * @brief Return the clamped velocity
+   * @param max_value the maximum magnitude of the velocities
+   * @param max_values the maximum magnitudes of the velocities for each join
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the velocities will be set to 0
+   */
+  const JointVelocities clamped(const std::vector<double>& max_values, const std::vector<double>& noise_ratio = std::vector<double>()) const;
 
-		/**
-	 	 * @brief Overload the + operator with an Eigen Vector
-	 	 * @param vector Eigen Vector to add
-	 	 * @param velocities JointVelocities to add
-	 	 * @return the Eigen Vector plus the JointVelocities represented as a JointVelocities
-	     */
-		friend const JointVelocities operator+(const Eigen::VectorXd& vector, const JointVelocities& velocities);
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to append the string representing the state
+   * @param state the state to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the - operator with a  Eigen Vector
-	 	 * @param vector Eigen Vector
-	 	 * @param velocities JointVelocities to substract
-	 	 * @return the Eigen Vector minus the JointVelocities represented as a JointVelocities
-	     */
-		friend const JointVelocities operator-(const Eigen::VectorXd& vector, const JointVelocities& velocities);
+  /**
+   * @brief Overload the + operator with an Eigen Vector
+   * @param vector Eigen Vector to add
+   * @param velocities JointVelocities to add
+   * @return the Eigen Vector plus the JointVelocities represented as a JointVelocities
+   */
+  friend const JointVelocities operator+(const Eigen::VectorXd& vector, const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the * operator with a scalar
-	 	 * @param lambda the scalar to multiply with
-	 	 * @return the JointVelocities provided multiply by lambda
-	     */
-		friend const JointVelocities operator*(double lambda, const JointVelocities& velocities);
+  /**
+   * @brief Overload the - operator with a  Eigen Vector
+   * @param vector Eigen Vector
+   * @param velocities JointVelocities to substract
+   * @return the Eigen Vector minus the JointVelocities represented as a JointVelocities
+   */
+  friend const JointVelocities operator-(const Eigen::VectorXd& vector, const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the * operator with an array of gains
-	 	 * @param lambda the array to multiply with
-	 	 * @return the JointVelocities provided multiply by lambda
-	     */
-		friend const JointVelocities operator*(const Eigen::ArrayXd& lambda, const JointVelocities& velocities);
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the JointVelocities provided multiply by lambda
+   */
+  friend const JointVelocities operator*(double lambda, const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the * operator with a time period
-	 	 * @param dt the time period to multiply with
-	 	 * @return the JointPositions corresponding to the displacement over the time period
-	     */
-		friend const JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities);
+  /**
+   * @brief Overload the * operator with an array of gains
+   * @param lambda the array to multiply with
+   * @return the JointVelocities provided multiply by lambda
+   */
+  friend const JointVelocities operator*(const Eigen::ArrayXd& lambda, const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the * operator with a time period
-	 	 * @param dt the time period to multiply with
-	 	 * @return the JointPositions corresponding to the displacement over the time period
-	     */
-		friend const JointPositions operator*(const JointVelocities& velocities, const std::chrono::nanoseconds& dt);
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the JointPositions corresponding to the displacement over the time period
+   */
+  friend const JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities);
 
-		/**
-	 	 * @brief Overload the / operator with a scalar
-	 	 * @param lambda the scalar to divide with
-	 	 * @return the JointVelocities provided divided by lambda
-	     */
-		friend const JointVelocities operator/(const JointVelocities& positions, double lambda);
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the JointPositions corresponding to the displacement over the time period
+   */
+  friend const JointPositions operator*(const JointVelocities& velocities, const std::chrono::nanoseconds& dt);
 
-		/**
-	 	 * @brief Overload the / operator with an array of gains
-	 	 * @param lambda the array to divide with
-	 	 * @return the JointVelocities provided divided by lambda
-	     */
-		friend const JointVelocities operator/(const JointVelocities& positions, const Eigen::ArrayXd& lambda);
-	};
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointVelocities provided divided by lambda
+   */
+  friend const JointVelocities operator/(const JointVelocities& positions, double lambda);
 
-	inline JointVelocities& JointVelocities::operator=(const JointVelocities& state)
-	{
-		JointState::operator=(state);
-		return (*this);
-	}
+  /**
+   * @brief Overload the / operator with an array of gains
+   * @param lambda the array to divide with
+   * @return the JointVelocities provided divided by lambda
+   */
+  friend const JointVelocities operator/(const JointVelocities& positions, const Eigen::ArrayXd& lambda);
+};
+
+inline JointVelocities& JointVelocities::operator=(const JointVelocities& state) {
+  JointState::operator=(state);
+  return (*this);
 }
+}// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -74,31 +74,11 @@ public:
   JointVelocities& operator=(const JointVelocities& state);
 
   /**
-   * @brief Set the values of the  velocities from an Eigen Vector
-   * @param velocities the velocities as an Eigen Vector
-   */
-  JointVelocities& operator=(const Eigen::VectorXd& velocities);
-
-  /**
-   * @brief Overload the += operator with an Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the JointVelocities added the vector given in argument
-   */
-  JointVelocities& operator+=(const Eigen::VectorXd& vector);
-
-  /**
    * @brief Overload the += operator
    * @param velocities JointVelocities to add
    * @return the current JointVelocities added the JointVelocities given in argument
    */
   JointVelocities& operator+=(const JointVelocities& velocities);
-
-  /**
-   * @brief Overload the + operator with a  Eigen Vector
-   * @param vector Eigen Vector to add
-   * @return the JointVelocities added the vector given in argument
-   */
-  const JointVelocities operator+(const Eigen::VectorXd& vector) const;
 
   /**
    * @brief Overload the + operator
@@ -108,25 +88,11 @@ public:
   const JointVelocities operator+(const JointVelocities& velocities) const;
 
   /**
-   * @brief Overload the -= operator with a  Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the JointVelocities substracted the vector given in argument
-   */
-  JointVelocities& operator-=(const Eigen::VectorXd& vector);
-
-  /**
    * @brief Overload the -= operator
    * @param velocities JointVelocities to substract
    * @return the current JointVelocities substracted the JointVelocities given in argument
    */
   JointVelocities& operator-=(const JointVelocities& velocities);
-
-  /**
-   * @brief Overload the - operator with an Eigen Vector
-   * @param vector Eigen Vector to substract
-   * @return the JointVelocities substracted the vector given in argument
-   */
-  const JointVelocities operator-(const Eigen::VectorXd& vector) const;
 
   /**
    * @brief Overload the - operator
@@ -188,22 +154,6 @@ public:
    * @return the appended ostream
    */
   friend std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities);
-
-  /**
-   * @brief Overload the + operator with an Eigen Vector
-   * @param vector Eigen Vector to add
-   * @param velocities JointVelocities to add
-   * @return the Eigen Vector plus the JointVelocities represented as a JointVelocities
-   */
-  friend const JointVelocities operator+(const Eigen::VectorXd& vector, const JointVelocities& velocities);
-
-  /**
-   * @brief Overload the - operator with a  Eigen Vector
-   * @param vector Eigen Vector
-   * @param velocities JointVelocities to substract
-   * @return the Eigen Vector minus the JointVelocities represented as a JointVelocities
-   */
-  friend const JointVelocities operator-(const Eigen::VectorXd& vector, const JointVelocities& velocities);
 
   /**
    * @brief Overload the * operator with a scalar

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -85,7 +85,7 @@ public:
    * @param velocities JointVelocities to add
    * @return the current JointVelocities added the JointVelocities given in argument
    */
-  const JointVelocities operator+(const JointVelocities& velocities) const;
+  JointVelocities operator+(const JointVelocities& velocities) const;
 
   /**
    * @brief Overload the -= operator
@@ -99,53 +99,116 @@ public:
    * @param velocities JointVelocities to substract
    * @return the current JointVelocities substracted the JointVelocities given in argument
    */
-  const JointVelocities operator-(const JointVelocities& velocities) const;
+  JointVelocities operator-(const JointVelocities& velocities) const;
+
+  /**
+   * @brief Overload the *= operator with a double gain
+   * @param lambda the gain to multiply with
+   * @return the JointVelocities multiplied by lambda
+   */
+  JointVelocities& operator*=(double lambda);
+
+  /**
+   * @brief Overload the * operator with a double gain
+   * @param lambda the gain to multiply with
+   * @return the JointVelocities multiplied by lambda
+   */
+  JointVelocities operator*(double lambda) const;
+
+  /**
+   * @brief Overload the *= operator with an array of gains
+   * @param lambda the gain array to multiply with
+   * @return the JointVelocities multiplied by lambda
+   */
+  JointVelocities& operator*=(const Eigen::ArrayXd& lambda);
+
+  /**
+   * @brief Overload the *= operator with an array of gains
+   * @param lambda the gain array to multiply with
+   * @return the JointVelocities multiplied by lambda
+   */
+  JointVelocities operator*(const Eigen::ArrayXd& lambda) const;
+
+  /**
+   * @brief Overload the *= operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointVelocities multiplied by lambda
+   */
+  JointVelocities& operator*=(const Eigen::MatrixXd& lambda);
+
+  /**
+   * @brief Overload the * operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointVelocities multiplied by lambda
+   */
+  JointVelocities operator*(const Eigen::MatrixXd& lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointVelocities divided by lambda
+   */
+  JointVelocities& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the JointVelocities divided by lambda
+   */
+  JointVelocities operator/(double lambda) const;
+
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the JointPositions corresponding to the displacement over the time period
+   */
+  JointPositions operator*(const std::chrono::nanoseconds& dt) const;
 
   /**
    * @brief Return a copy of the JointVelocities
    * @return the copy
    */
-  const JointVelocities copy() const;
+  JointVelocities copy() const;
 
   /**
    * @brief Return the value of the velocities as Eigen array
    * @retrun the Eigen array representing the velocities
    */
-  const Eigen::ArrayXd array() const;
+  Eigen::ArrayXd array() const;
 
   /**
-   * @brief Clamp inplace the magnitude of the joint velocities to the values in argument
-   * @param max_value the maximum magnitude of the velocities
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute_value the maximum magnitude of torque for all the joints
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
+   * the torque will be set to 0
    */
-  void clamp(double max_value, double noise_ratio = 0);
+  void clamp(double max_absolute_value, double noise_ratio = 0.);
 
   /**
-   * @brief Clamp inplace the magnitude of the joint velocities to the values in argument
-   * @param max_values the maximum magnitudes of the velocities for each join
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute_value the maximum magnitude of torque for all the joints
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocities will be set to 0
+   * the torque will be set to 0
+   * @return the clamped JointVelocities
    */
-  void clamp(const std::vector<double>& max_values, const std::vector<double>& noise_ratio = std::vector<double>());
+  JointVelocities clamped(double max_absolute_value, double noise_ratio = 0.) const;
 
   /**
-   * @brief Return the clamped velocity
-   * @param max_value the maximum magnitude of the velocities
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
-   * @return the clamped velocity
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute_value_array the maximum magnitude of torque for each joint
+   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
    */
-  const JointVelocities clamped(double max_value, double noise_ratio = 0) const;
+  void clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array);
 
   /**
-   * @brief Return the clamped velocity
-   * @param max_value the maximum magnitude of the velocities
-   * @param max_values the maximum magnitudes of the velocities for each join
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocities will be set to 0
+   * @brief Clamp inplace the magnitude of the velocity to the values in argument
+   * @param max_absolute_value_array the maximum magnitude of torque for each joint
+   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * the torque will be set to 0
+   * @return the clamped JointVelocities
    */
-  const JointVelocities clamped(const std::vector<double>& max_values, const std::vector<double>& noise_ratio = std::vector<double>()) const;
+  JointVelocities clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -160,42 +223,28 @@ public:
    * @param lambda the scalar to multiply with
    * @return the JointVelocities provided multiply by lambda
    */
-  friend const JointVelocities operator*(double lambda, const JointVelocities& velocities);
+  friend JointVelocities operator*(double lambda, const JointVelocities& velocities);
 
   /**
    * @brief Overload the * operator with an array of gains
    * @param lambda the array to multiply with
    * @return the JointVelocities provided multiply by lambda
    */
-  friend const JointVelocities operator*(const Eigen::ArrayXd& lambda, const JointVelocities& velocities);
+  friend JointVelocities operator*(const Eigen::ArrayXd& lambda, const JointVelocities& velocities);
+
+  /**
+   * @brief Overload the * operator with a matrix of gains
+   * @param lambda the matrix to multiply with
+   * @return the JointVelocities provided multiply by lambda
+   */
+  friend JointVelocities operator*(const Eigen::MatrixXd& lambda, const JointVelocities& velocities);
 
   /**
    * @brief Overload the * operator with a time period
    * @param dt the time period to multiply with
    * @return the JointPositions corresponding to the displacement over the time period
    */
-  friend const JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities);
-
-  /**
-   * @brief Overload the * operator with a time period
-   * @param dt the time period to multiply with
-   * @return the JointPositions corresponding to the displacement over the time period
-   */
-  friend const JointPositions operator*(const JointVelocities& velocities, const std::chrono::nanoseconds& dt);
-
-  /**
-   * @brief Overload the / operator with a scalar
-   * @param lambda the scalar to divide with
-   * @return the JointVelocities provided divided by lambda
-   */
-  friend const JointVelocities operator/(const JointVelocities& positions, double lambda);
-
-  /**
-   * @brief Overload the / operator with an array of gains
-   * @param lambda the array to divide with
-   * @return the JointVelocities provided divided by lambda
-   */
-  friend const JointVelocities operator/(const JointVelocities& positions, const Eigen::ArrayXd& lambda);
+  friend JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities);
 };
 
 inline JointVelocities& JointVelocities::operator=(const JointVelocities& state) {

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -49,7 +49,8 @@ public:
    * @brief joint_names list of joint names
    * @brief velocities the vector of velocities
    */
-  explicit JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& velocities);
+  explicit JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                           const Eigen::VectorXd& velocities);
 
   /**
    * @brief Copy constructor
@@ -67,7 +68,7 @@ public:
   JointVelocities(const JointPositions& positions);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
    */
@@ -89,15 +90,15 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param velocities JointVelocities to substract
-   * @return the current JointVelocities substracted the JointVelocities given in argument
+   * @param velocities JointVelocities to subtract
+   * @return the current JointVelocities subtracted the JointVelocities given in argument
    */
   JointVelocities& operator-=(const JointVelocities& velocities);
 
   /**
    * @brief Overload the - operator
-   * @param velocities JointVelocities to substract
-   * @return the current JointVelocities substracted the JointVelocities given in argument
+   * @param velocities JointVelocities to subtract
+   * @return the current JointVelocities subtracted the JointVelocities given in argument
    */
   JointVelocities operator-(const JointVelocities& velocities) const;
 
@@ -179,7 +180,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value the maximum magnitude of torque for all the joints
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    */
   void clamp(double max_absolute_value, double noise_ratio = 0.);
@@ -187,7 +188,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value the maximum magnitude of torque for all the joints
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    * @return the clamped JointVelocities
    */
@@ -196,7 +197,7 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value_array the maximum magnitude of torque for each joint
-   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio_array if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    */
   void clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array);
@@ -204,11 +205,12 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value_array the maximum magnitude of torque for each joint
-   * @param noise_ratio_array if provided, this value will be used to apply a deadzone under which
+   * @param noise_ratio_array if provided, this value will be used to apply a dead zone under which
    * the torque will be set to 0
    * @return the clamped JointVelocities
    */
-  JointVelocities clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const;
+  JointVelocities clamped(const Eigen::ArrayXd& max_absolute_value_array,
+                          const Eigen::ArrayXd& noise_ratio_array) const;
 
   /**
    * @brief Overload the ostream operator for printing

--- a/source/state_representation/src/Robot/Jacobian.cpp
+++ b/source/state_representation/src/Robot/Jacobian.cpp
@@ -5,29 +5,35 @@
 namespace StateRepresentation {
 Jacobian::Jacobian() : State(StateType::JACOBIANMATRIX), nb_rows(6) {}
 
-Jacobian::Jacobian(const std::string& robot_name, unsigned int nb_joints) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(nb_joints) {
+Jacobian::Jacobian(const std::string& robot_name, unsigned int nb_joints) :
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(nb_joints) {
   this->set_joint_names(nb_joints);
 }
 
-Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(joint_names.size()) {
+Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names) :
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(joint_names.size()) {
   this->set_joint_names(joint_names);
 }
 
-Jacobian::Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(data.cols()) {
+Jacobian::Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data) :
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(data.cols()) {
   this->set_joint_names(this->get_nb_cols());
   this->set_data(data);
 }
 
-Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::MatrixXd& data) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(joint_names.size()) {
+Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                   const Eigen::MatrixXd& data) :
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(joint_names.size()) {
   this->set_joint_names(joint_names);
   this->set_data(data);
 }
 
-Jacobian::Jacobian(const Jacobian& jacobian) : State(jacobian),
-                                               joint_names(jacobian.joint_names),
-                                               nb_rows(jacobian.nb_rows),
-                                               nb_cols(jacobian.nb_cols),
-                                               data(jacobian.data) {}
+Jacobian::Jacobian(const Jacobian& jacobian) :
+    State(jacobian),
+    joint_names(jacobian.joint_names),
+    nb_rows(jacobian.nb_rows),
+    nb_cols(jacobian.nb_cols),
+    data(jacobian.data) {}
 
 void Jacobian::initialize() {
   this->State::initialize();
@@ -44,14 +50,16 @@ const Jacobian Jacobian::transpose() {
 }
 
 const Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (matrix.rows() != this->get_nb_cols()) throw IncompatibleSizeException("Input matrix is of incorrect size");
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
+  if (matrix.rows() != this->get_nb_cols()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
   return this->get_data() * matrix;
 }
 
 const CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
-  if (dq.is_empty()) throw EmptyStateException(dq.get_name() + " state is empty");
-  if (!this->is_compatible(dq)) throw IncompatibleStatesException("The Jacobian and the input JointVelocities are incompatible");
+  if (dq.is_empty()) { throw EmptyStateException(dq.get_name() + " state is empty"); }
+  if (!this->is_compatible(dq)) {
+    throw IncompatibleStatesException("The Jacobian and the input JointVelocities are incompatible");
+  }
   Eigen::Matrix<double, 6, 1> twist = (*this) * dq.get_velocities();
   // crate a CartesianTwist with name "robot"_end_effector and reference frame "robot"_base
   CartesianTwist result(this->get_name() + "_end_effector", twist, this->get_name() + "_base");
@@ -59,13 +67,13 @@ const CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
 }
 
 const Eigen::MatrixXd Jacobian::solve(const Eigen::MatrixXd& matrix) const {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (this->get_nb_rows() != matrix.rows()) throw IncompatibleSizeException("Input matrix is of incorrect size");
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
+  if (this->get_nb_rows() != matrix.rows()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
   return this->get_data().colPivHouseholderQr().solve(matrix);
 }
 
 const JointVelocities Jacobian::solve(const CartesianTwist& dX) const {
-  if (dX.is_empty()) throw EmptyStateException(dX.get_name() + " state is empty");
+  if (dX.is_empty()) { throw EmptyStateException(dX.get_name() + " state is empty"); }
   // extract the velocity as a 6d vector
   auto twist = dX.get_twist();
   // this use the solve operation instead of using the inverse or pseudo-inverse of the jacobian
@@ -90,7 +98,7 @@ std::ostream& operator<<(std::ostream& os, const Jacobian& matrix) {
   } else {
     os << matrix.get_name() << " Jacobian" << std::endl;
     os << "joint names: [";
-    for (auto& n : matrix.get_joint_names()) os << n << ", ";
+    for (auto& n : matrix.get_joint_names()) { os << n << ", "; }
     os << "]" << std::endl;
     os << "number of rows: " << matrix.get_nb_rows() << std::endl;
     os << "number of columns: " << matrix.get_nb_cols() << std::endl;

--- a/source/state_representation/src/Robot/Jacobian.cpp
+++ b/source/state_representation/src/Robot/Jacobian.cpp
@@ -1,134 +1,107 @@
 #include "state_representation/Robot/Jacobian.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
-namespace StateRepresentation 
-{
-	Jacobian::Jacobian():
-	State(StateType::JACOBIANMATRIX), nb_rows(6)
-	{}
+namespace StateRepresentation {
+Jacobian::Jacobian() : State(StateType::JACOBIANMATRIX), nb_rows(6) {}
 
-	Jacobian::Jacobian(const std::string& robot_name, unsigned int nb_joints):
-	State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(nb_joints)
-	{
-		this->set_joint_names(nb_joints);
-	}
-
-	Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names):
-	State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(joint_names.size())
-	{
-		this->set_joint_names(joint_names);
-	}
-
-	Jacobian::Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data):
-	State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(data.cols())
-	{
-		this->set_joint_names(this->get_nb_cols());
-		this->set_data(data);
-	}
-
-	Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::MatrixXd& data):
-	State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(joint_names.size())
-	{
-		this->set_joint_names(joint_names);
-		this->set_data(data);
-	}
-
-	Jacobian::Jacobian(const Jacobian& jacobian):
-	State(jacobian),
-	joint_names(jacobian.joint_names),
-	nb_rows(jacobian.nb_rows),
-	nb_cols(jacobian.nb_cols),
-	data(jacobian.data)
-	{}
-
-	void Jacobian::initialize()
-	{
-		this->State::initialize();
-		this->data.resize(this->nb_rows, this->nb_cols);
-		this->data.setZero();
-	}
-
-	const Jacobian Jacobian::transpose()
-	{
-		Jacobian result(*this);
-		result.set_nb_cols(this->get_nb_rows());
-		result.set_nb_rows(this->get_nb_cols());
-		result.set_data(result.get_data().transpose());
-		return result;
-	}
-
-	const Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(matrix.rows() != this->get_nb_cols()) throw IncompatibleSizeException("Input matrix is of incorrect size");
-		return this->get_data() * matrix;
-	}
-
-	const CartesianTwist Jacobian::operator*(const JointVelocities& dq) const
-	{
-		if(dq.is_empty()) throw EmptyStateException(dq.get_name() + " state is empty");
-		if(!this->is_compatible(dq)) throw IncompatibleStatesException("The Jacobian and the input JointVelocities are incompatible");
-		Eigen::Matrix<double, 6, 1> twist = (*this) * dq.get_velocities();
-		// crate a CartesianTwist with name "robot"_end_effector and reference frame "robot"_base
-		CartesianTwist result(this->get_name() + "_end_effector", twist, this->get_name() + "_base");
-		return result;
-	}
-
-	const Eigen::MatrixXd Jacobian::solve(const Eigen::MatrixXd& matrix) const
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_nb_rows() != matrix.rows()) throw IncompatibleSizeException("Input matrix is of incorrect size");
-		return this->get_data().colPivHouseholderQr().solve(matrix);
-	}
-
-	const JointVelocities Jacobian::solve(const CartesianTwist& dX) const
-	{
-		if(dX.is_empty()) throw EmptyStateException(dX.get_name() + " state is empty");
-		// extract the velocity as a 6d vector
-		auto twist = dX.get_twist();
-		// this use the solve operation instead of using the inverse or pseudo-inverse of the jacobian
-		Eigen::VectorXd joint_velocities = (*this).solve(twist);
-		// return a JointVelocities state
-		JointVelocities result(this->get_name(), this->get_joint_names(), joint_velocities);
-		return result;
-	}
-
-	const JointVelocities Jacobian::operator*(const CartesianTwist& dX) const
-	{
-		return this->solve(dX);
-	}
-
-	const Jacobian Jacobian::copy() const
-	{
-		Jacobian result(*this);
-		return result;
-	}
-
-	std::ostream& operator<<(std::ostream& os, const Jacobian& matrix)
-	{
-		if(matrix.is_empty())
-		{
-			os << "Empty Jacobian";
-		}
-		else
-		{
-			os << matrix.get_name() << " Jacobian" << std::endl;
-			os << "joint names: [";
-			for(auto& n:matrix.get_joint_names()) os << n << ", ";
-			os << "]" << std::endl;
-			os << "number of rows: " << matrix.get_nb_rows() << std::endl;
-			os << "number of columns: " << matrix.get_nb_cols() << std::endl;
-			for(unsigned int i = 0; i < matrix.get_nb_rows(); ++i)
-			{
-				os << "| " << matrix(i,0);
-				for(unsigned int j = 1; j < matrix.get_nb_cols(); ++j)
-				{
-					os << ", " << matrix(i,j);
-				}
-				os << " |" << std::endl;
-			}
-		}
-		return os;
-	}
+Jacobian::Jacobian(const std::string& robot_name, unsigned int nb_joints) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(nb_joints) {
+  this->set_joint_names(nb_joints);
 }
+
+Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(joint_names.size()) {
+  this->set_joint_names(joint_names);
+}
+
+Jacobian::Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(data.cols()) {
+  this->set_joint_names(this->get_nb_cols());
+  this->set_data(data);
+}
+
+Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::MatrixXd& data) : State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(joint_names.size()) {
+  this->set_joint_names(joint_names);
+  this->set_data(data);
+}
+
+Jacobian::Jacobian(const Jacobian& jacobian) : State(jacobian),
+                                               joint_names(jacobian.joint_names),
+                                               nb_rows(jacobian.nb_rows),
+                                               nb_cols(jacobian.nb_cols),
+                                               data(jacobian.data) {}
+
+void Jacobian::initialize() {
+  this->State::initialize();
+  this->data.resize(this->nb_rows, this->nb_cols);
+  this->data.setZero();
+}
+
+const Jacobian Jacobian::transpose() {
+  Jacobian result(*this);
+  result.set_nb_cols(this->get_nb_rows());
+  result.set_nb_rows(this->get_nb_cols());
+  result.set_data(result.get_data().transpose());
+  return result;
+}
+
+const Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (matrix.rows() != this->get_nb_cols()) throw IncompatibleSizeException("Input matrix is of incorrect size");
+  return this->get_data() * matrix;
+}
+
+const CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
+  if (dq.is_empty()) throw EmptyStateException(dq.get_name() + " state is empty");
+  if (!this->is_compatible(dq)) throw IncompatibleStatesException("The Jacobian and the input JointVelocities are incompatible");
+  Eigen::Matrix<double, 6, 1> twist = (*this) * dq.get_velocities();
+  // crate a CartesianTwist with name "robot"_end_effector and reference frame "robot"_base
+  CartesianTwist result(this->get_name() + "_end_effector", twist, this->get_name() + "_base");
+  return result;
+}
+
+const Eigen::MatrixXd Jacobian::solve(const Eigen::MatrixXd& matrix) const {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_nb_rows() != matrix.rows()) throw IncompatibleSizeException("Input matrix is of incorrect size");
+  return this->get_data().colPivHouseholderQr().solve(matrix);
+}
+
+const JointVelocities Jacobian::solve(const CartesianTwist& dX) const {
+  if (dX.is_empty()) throw EmptyStateException(dX.get_name() + " state is empty");
+  // extract the velocity as a 6d vector
+  auto twist = dX.get_twist();
+  // this use the solve operation instead of using the inverse or pseudo-inverse of the jacobian
+  Eigen::VectorXd joint_velocities = (*this).solve(twist);
+  // return a JointVelocities state
+  JointVelocities result(this->get_name(), this->get_joint_names(), joint_velocities);
+  return result;
+}
+
+const JointVelocities Jacobian::operator*(const CartesianTwist& dX) const {
+  return this->solve(dX);
+}
+
+const Jacobian Jacobian::copy() const {
+  Jacobian result(*this);
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const Jacobian& matrix) {
+  if (matrix.is_empty()) {
+    os << "Empty Jacobian";
+  } else {
+    os << matrix.get_name() << " Jacobian" << std::endl;
+    os << "joint names: [";
+    for (auto& n : matrix.get_joint_names()) os << n << ", ";
+    os << "]" << std::endl;
+    os << "number of rows: " << matrix.get_nb_rows() << std::endl;
+    os << "number of columns: " << matrix.get_nb_cols() << std::endl;
+    for (unsigned int i = 0; i < matrix.get_nb_rows(); ++i) {
+      os << "| " << matrix(i, 0);
+      for (unsigned int j = 1; j < matrix.get_nb_cols(); ++j) {
+        os << ", " << matrix(i, j);
+      }
+      os << " |" << std::endl;
+    }
+  }
+  return os;
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -7,15 +7,19 @@ using namespace StateRepresentation::Exceptions;
 namespace StateRepresentation {
 JointPositions::JointPositions() {}
 
-JointPositions::JointPositions(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
+JointPositions::JointPositions(const std::string& robot_name, unsigned int nb_joints) :
+    JointState(robot_name, nb_joints) {}
 
-JointPositions::JointPositions(const std::string& robot_name, const Eigen::VectorXd& positions) : JointState(robot_name, positions.size()) {
+JointPositions::JointPositions(const std::string& robot_name, const Eigen::VectorXd& positions) :
+    JointState(robot_name, positions.size()) {
   this->set_positions(positions);
 }
 
-JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names) : JointState(robot_name, joint_names) {}
+JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names) :
+    JointState(robot_name, joint_names) {}
 
-JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions) : JointState(robot_name, joint_names) {
+JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                               const Eigen::VectorXd& positions) : JointState(robot_name, joint_names) {
   this->set_positions(positions);
 }
 
@@ -84,7 +88,7 @@ JointPositions JointPositions::operator/(double lambda) const {
 }
 
 JointVelocities JointPositions::operator/(const std::chrono::nanoseconds& dt) const {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
   // operations
   JointVelocities velocities(this->get_name(), this->get_names());
   // convert the period to a double with the second as reference
@@ -110,10 +114,10 @@ std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {
   } else {
     os << positions.get_name() << " JointPositions" << std::endl;
     os << "names: [";
-    for (auto& n : positions.get_names()) os << n << ", ";
+    for (auto& n : positions.get_names()) { os << n << ", "; }
     os << "]" << std::endl;
     os << "positions: [";
-    for (unsigned int i = 0; i < positions.get_size(); ++i) os << positions.get_positions()(i) << ", ";
+    for (unsigned int i = 0; i < positions.get_size(); ++i) { os << positions.get_positions()(i) << ", "; }
     os << "]";
   }
   return os;

--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -1,214 +1,173 @@
 #include "state_representation/Robot/JointPositions.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation
-{
-	JointPositions::JointPositions()
-	{}
+namespace StateRepresentation {
+JointPositions::JointPositions() {}
 
-	JointPositions::JointPositions(const std::string& robot_name, unsigned int nb_joints):
-	JointState(robot_name, nb_joints)
-	{}
+JointPositions::JointPositions(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
 
-	JointPositions::JointPositions(const std::string& robot_name, const Eigen::VectorXd& positions):
-	JointState(robot_name, positions.size())
-	{
-		this->set_positions(positions);
-	}
-
-	JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names):
-	JointState(robot_name, joint_names)
-	{}
-
-	JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions):
-	JointState(robot_name, joint_names)
-	{
-		this->set_positions(positions);
-	}
-
-	JointPositions::JointPositions(const JointPositions& positions):
-	JointState(positions)
-	{}
-
-	JointPositions::JointPositions(const JointState& state):
-	JointState(state)
-	{}
-
-	JointPositions::JointPositions(const JointVelocities& velocities):
-	JointState(std::chrono::seconds(1) * velocities)
-	{}
-
-	JointPositions& JointPositions::operator=(const Eigen::VectorXd& positions)
-	{
-		this->set_positions(positions);
-		return (*this);
-	}
-
-	JointPositions& JointPositions::operator+=(const Eigen::VectorXd& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-		this->set_positions(this->get_positions() + vector);
-		return (*this);
-	}
-
-	JointPositions& JointPositions::operator+=(const JointPositions& positions)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		if(!this->is_compatible(positions)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
-		// operation
-		this->set_positions(this->get_positions() + positions.get_positions());
-		return (*this);
-	}
-
-	const JointPositions JointPositions::operator+(const Eigen::VectorXd& vector) const
-	{
-		JointPositions result(*this);
-		result += vector;
-		return result;
-	}
-
-	const JointPositions JointPositions::operator+(const JointPositions& positions) const
-	{
-		JointPositions result(*this);
-		result += positions;
-		return result;
-	}
-
-	JointPositions& JointPositions::operator-=(const Eigen::VectorXd& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-		this->set_positions(this->get_positions() - vector);
-		return (*this);
-	}
-
-	JointPositions& JointPositions::operator-=(const JointPositions& positions)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		if(!this->is_compatible(positions)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
-		// operation
-		this->set_positions(this->get_positions() - positions.get_positions());
-		return (*this);
-	}
-
-	const JointPositions JointPositions::operator-(const Eigen::VectorXd& vector) const
-	{
-		JointPositions result(*this);
-		result -= vector;
-		return result;
-	}
-
-	const JointPositions JointPositions::operator-(const JointPositions& positions) const
-	{
-		JointPositions result(*this);
-		result -= positions;
-		return result;
-	}
-
-	const JointPositions JointPositions::copy() const
-	{
-		JointPositions result(*this);
-		return result;
-	}
-
-	const Eigen::ArrayXd JointPositions::array() const
-	{
-		return this->get_positions().array();
-	}
-
-	std::ostream& operator<<(std::ostream& os, const JointPositions& positions)
-	{
-		if(positions.is_empty())
-		{
-			os << "Empty JointPositions";
-		}
-		else
-		{
-			os << positions.get_name() << " JointPositions" << std::endl;
-	  		os << "names: [";
-			for(auto& n:positions.get_names()) os << n << ", ";
-			os << "]" << std::endl;
-			os << "positions: [";
-			for(unsigned int i=0; i<positions.get_size(); ++i) os << positions.get_positions()(i) << ", ";
-			os << "]";
-		}
-  		return os;
-	}
-
-	const JointPositions operator+(const Eigen::VectorXd& vector, const JointPositions& positions)
-	{
-		return positions + vector;
-	}
-
-	const JointPositions operator-(const Eigen::VectorXd& vector, const JointPositions& positions)
-	{
-		return vector + (-1) * positions;
-	}
-
-	const JointPositions operator*(double lambda, const JointPositions& positions)
-	{
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		JointPositions result(positions);
-		result.set_positions(lambda * positions.get_positions());
-		return result;
-	}
-
-
-	const JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions)
-	{
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		if(lambda.size() != positions.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size: expected " + std::to_string(positions.get_size()) + ", given " + std::to_string(lambda.size()));
-		JointPositions result(positions);
-		result.set_positions(lambda * positions.get_positions().array());
-		return result;
-	}
-
-	const JointPositions operator/(const JointPositions& positions, double lambda)
-	{
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		JointPositions result(positions);
-		result.set_positions(positions.get_positions() / lambda);
-		return result;
-	}
-
-	const JointPositions operator/(const JointPositions& positions, const Eigen::ArrayXd& lambda)
-	{
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		if(lambda.size() != positions.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size: expected " + std::to_string(positions.get_size()) + + ", given " + std::to_string(lambda.size()));
-		JointPositions result(positions);
-		result.set_positions(positions.get_positions().array() / lambda);
-		return result;
-	}
-
-	const JointVelocities operator/(const JointPositions& positions, const std::chrono::nanoseconds& dt)
-	{
-		if(positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
-		// operations
-		JointVelocities velocities(positions.get_name(), positions.get_names());
-		// convert the period to a double with the second as reference
-		double period = dt.count();
-		period /= 1e9;
-		// multiply the positions by this period value
-		velocities.set_velocities(positions.get_positions() / period);
-		return velocities;
-	}
-
-	const std::vector<double> JointPositions::to_std_vector() const
-	{
-		std::vector<double> temp(this->get_positions().data(), this->get_positions().data() + this->get_size());
-		return temp;
-	}
-
-	void JointPositions::from_std_vector(const std::vector<double>& value)
-	{
-		this->set_positions(value);
-	}
+JointPositions::JointPositions(const std::string& robot_name, const Eigen::VectorXd& positions) : JointState(robot_name, positions.size()) {
+  this->set_positions(positions);
 }
+
+JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names) : JointState(robot_name, joint_names) {}
+
+JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions) : JointState(robot_name, joint_names) {
+  this->set_positions(positions);
+}
+
+JointPositions::JointPositions(const JointPositions& positions) : JointState(positions) {}
+
+JointPositions::JointPositions(const JointState& state) : JointState(state) {}
+
+JointPositions::JointPositions(const JointVelocities& velocities) : JointState(std::chrono::seconds(1) * velocities) {}
+
+JointPositions& JointPositions::operator=(const Eigen::VectorXd& positions) {
+  this->set_positions(positions);
+  return (*this);
+}
+
+JointPositions& JointPositions::operator+=(const Eigen::VectorXd& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
+  this->set_positions(this->get_positions() + vector);
+  return (*this);
+}
+
+JointPositions& JointPositions::operator+=(const JointPositions& positions) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  if (!this->is_compatible(positions)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  // operation
+  this->set_positions(this->get_positions() + positions.get_positions());
+  return (*this);
+}
+
+const JointPositions JointPositions::operator+(const Eigen::VectorXd& vector) const {
+  JointPositions result(*this);
+  result += vector;
+  return result;
+}
+
+const JointPositions JointPositions::operator+(const JointPositions& positions) const {
+  JointPositions result(*this);
+  result += positions;
+  return result;
+}
+
+JointPositions& JointPositions::operator-=(const Eigen::VectorXd& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
+  this->set_positions(this->get_positions() - vector);
+  return (*this);
+}
+
+JointPositions& JointPositions::operator-=(const JointPositions& positions) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  if (!this->is_compatible(positions)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  // operation
+  this->set_positions(this->get_positions() - positions.get_positions());
+  return (*this);
+}
+
+const JointPositions JointPositions::operator-(const Eigen::VectorXd& vector) const {
+  JointPositions result(*this);
+  result -= vector;
+  return result;
+}
+
+const JointPositions JointPositions::operator-(const JointPositions& positions) const {
+  JointPositions result(*this);
+  result -= positions;
+  return result;
+}
+
+const JointPositions JointPositions::copy() const {
+  JointPositions result(*this);
+  return result;
+}
+
+const Eigen::ArrayXd JointPositions::array() const {
+  return this->get_positions().array();
+}
+
+std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {
+  if (positions.is_empty()) {
+    os << "Empty JointPositions";
+  } else {
+    os << positions.get_name() << " JointPositions" << std::endl;
+    os << "names: [";
+    for (auto& n : positions.get_names()) os << n << ", ";
+    os << "]" << std::endl;
+    os << "positions: [";
+    for (unsigned int i = 0; i < positions.get_size(); ++i) os << positions.get_positions()(i) << ", ";
+    os << "]";
+  }
+  return os;
+}
+
+const JointPositions operator+(const Eigen::VectorXd& vector, const JointPositions& positions) {
+  return positions + vector;
+}
+
+const JointPositions operator-(const Eigen::VectorXd& vector, const JointPositions& positions) {
+  return vector + (-1) * positions;
+}
+
+const JointPositions operator*(double lambda, const JointPositions& positions) {
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  JointPositions result(positions);
+  result.set_positions(lambda * positions.get_positions());
+  return result;
+}
+
+const JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions) {
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  if (lambda.size() != positions.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size: expected " + std::to_string(positions.get_size()) + ", given " + std::to_string(lambda.size()));
+  JointPositions result(positions);
+  result.set_positions(lambda * positions.get_positions().array());
+  return result;
+}
+
+const JointPositions operator/(const JointPositions& positions, double lambda) {
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  JointPositions result(positions);
+  result.set_positions(positions.get_positions() / lambda);
+  return result;
+}
+
+const JointPositions operator/(const JointPositions& positions, const Eigen::ArrayXd& lambda) {
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  if (lambda.size() != positions.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size: expected " + std::to_string(positions.get_size()) + +", given " + std::to_string(lambda.size()));
+  JointPositions result(positions);
+  result.set_positions(positions.get_positions().array() / lambda);
+  return result;
+}
+
+const JointVelocities operator/(const JointPositions& positions, const std::chrono::nanoseconds& dt) {
+  if (positions.is_empty()) throw EmptyStateException(positions.get_name() + " state is empty");
+  // operations
+  JointVelocities velocities(positions.get_name(), positions.get_names());
+  // convert the period to a double with the second as reference
+  double period = dt.count();
+  period /= 1e9;
+  // multiply the positions by this period value
+  velocities.set_velocities(positions.get_positions() / period);
+  return velocities;
+}
+
+const std::vector<double> JointPositions::to_std_vector() const {
+  std::vector<double> temp(this->get_positions().data(), this->get_positions().data() + this->get_size());
+  return temp;
+}
+
+void JointPositions::from_std_vector(const std::vector<double>& value) {
+  this->set_positions(value);
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -119,6 +119,24 @@ std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {
   return os;
 }
 
+JointPositions operator*(double lambda, const JointPositions& positions) {
+  JointPositions result(positions);
+  result *= lambda;
+  return result;
+}
+
+JointPositions operator*(const Eigen::ArrayXd& lambda, const JointPositions& positions) {
+  JointPositions result(positions);
+  result *= lambda;
+  return result;
+}
+
+JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& positions) {
+  JointPositions result(positions);
+  result *= lambda;
+  return result;
+}
+
 std::vector<double> JointPositions::to_std_vector() const {
   std::vector<double> temp(this->get_positions().data(), this->get_positions().data() + this->get_size());
   return temp;

--- a/source/state_representation/src/Robot/JointState.cpp
+++ b/source/state_representation/src/Robot/JointState.cpp
@@ -8,16 +8,23 @@ JointState::JointState() : State(StateType::JOINTSTATE) {
   this->initialize();
 }
 
-JointState::JointState(const std::string& robot_name, unsigned int nb_joints) : State(StateType::JOINTSTATE, robot_name), names(nb_joints) {
+JointState::JointState(const std::string& robot_name, unsigned int nb_joints) :
+    State(StateType::JOINTSTATE, robot_name), names(nb_joints) {
   this->set_names(nb_joints);
 }
 
-JointState::JointState(const std::string& robot_name, const std::vector<std::string>& joint_names) : State(StateType::JOINTSTATE, robot_name) {
+JointState::JointState(const std::string& robot_name, const std::vector<std::string>& joint_names) :
+    State(StateType::JOINTSTATE, robot_name) {
   this->set_names(joint_names);
 }
 
-JointState::JointState(const JointState& state) : State(state), names(state.names), positions(state.positions), velocities(state.velocities),
-                                                  accelerations(state.accelerations), torques(state.torques) {}
+JointState::JointState(const JointState& state) :
+    State(state),
+    names(state.names),
+    positions(state.positions),
+    velocities(state.velocities),
+    accelerations(state.accelerations),
+    torques(state.torques) {}
 
 void JointState::initialize() {
   this->State::initialize();
@@ -39,7 +46,10 @@ void JointState::set_zero() {
 }
 
 JointState& JointState::operator+=(const JointState& state) {
-  if (!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  if (!this->is_compatible(state)) {
+    throw IncompatibleStatesException(
+        "The two joint states are incompatible, check name, joint names and order or size");
+  }
   this->set_all_state_variables(this->get_all_state_variables() + state.get_all_state_variables());
   return (*this);
 }
@@ -51,7 +61,10 @@ JointState JointState::operator+(const JointState& state) const {
 }
 
 JointState& JointState::operator-=(const JointState& state) {
-  if (!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  if (!this->is_compatible(state)) {
+    throw IncompatibleStatesException(
+        "The two joint states are incompatible, check name, joint names and order or size");
+  }
   this->set_all_state_variables(this->get_all_state_variables() - state.get_all_state_variables());
   return (*this);
 }
@@ -63,7 +76,7 @@ JointState JointState::operator-(const JointState& state) const {
 }
 
 JointState& JointState::operator*=(double lambda) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
   this->set_all_state_variables(lambda * this->get_all_state_variables());
   return (*this);
 }
@@ -71,18 +84,22 @@ JointState& JointState::operator*=(double lambda) {
 void JointState::multiply_state_variable(const Eigen::ArrayXd& lambda, const JointStateVariable& state_variable_type) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  if (lambda.size() != expected_size) throw IncompatibleSizeException("Gain matrix is of incorrect size: expected "
-                                                                      + std::to_string(expected_size)
-                                                                      + ", given " + std::to_string(lambda.size()));
+  if (lambda.size() != expected_size) {
+    throw IncompatibleSizeException(
+        "Gain matrix is of incorrect size: expected " + std::to_string(expected_size) + ", given "
+            + std::to_string(lambda.size()));
+  }
   this->set_state_variable((lambda * state_variable.array()).matrix(), state_variable_type);
 }
 
 void JointState::multiply_state_variable(const Eigen::MatrixXd& lambda, const JointStateVariable& state_variable_type) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  if (lambda.rows() != expected_size || lambda.cols() != expected_size) throw IncompatibleSizeException("Gain matrix is of incorrect size: expected "
-                                                                                                        + std::to_string(expected_size) + "x" + std::to_string(expected_size)
-                                                                                                        + ", given " + std::to_string(lambda.rows()) + "x" + std::to_string(lambda.cols()));
+  if (lambda.rows() != expected_size || lambda.cols() != expected_size) {
+    throw IncompatibleSizeException("Gain matrix is of incorrect size: expected " + std::to_string(expected_size) + "x"
+                                        + std::to_string(expected_size) + ", given " + std::to_string(lambda.rows())
+                                        + "x" + std::to_string(lambda.cols()));
+  }
   this->set_all_state_variables(lambda * this->get_all_state_variables());
 }
 
@@ -129,41 +146,54 @@ JointState JointState::copy() const {
   return result;
 }
 
-void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array, const JointStateVariable& state_variable_type, const Eigen::ArrayXd& noise_ratio_array) {
+void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
+                                      const JointStateVariable& state_variable_type,
+                                      const Eigen::ArrayXd& noise_ratio_array) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  if (max_absolute_value_array.size() != expected_size) throw IncompatibleSizeException("Array of max values is of incorrect size: expected "
-                                                                                        + std::to_string(expected_size)
-                                                                                        + ", given " + std::to_string(max_absolute_value_array.size()));
+  if (max_absolute_value_array.size() != expected_size) {
+    throw IncompatibleSizeException(
+        "Array of max values is of incorrect size: expected " + std::to_string(expected_size) + ", given "
+            + std::to_string(max_absolute_value_array.size()));
+  }
 
-  if (noise_ratio_array.size() != expected_size) throw IncompatibleSizeException("Array of max values is of incorrect size: expected "
-                                                                                 + std::to_string(expected_size)
-                                                                                 + ", given " + std::to_string(noise_ratio_array.size()));
+  if (noise_ratio_array.size() != expected_size) {
+    throw IncompatibleSizeException(
+        "Array of max values is of incorrect size: expected " + std::to_string(expected_size) + ", given "
+            + std::to_string(noise_ratio_array.size()));
+  }
   for (int i = 0; i < expected_size; ++i) {
     if (state_variable(i) > 0) {
       state_variable(i) -= noise_ratio_array(i);
       state_variable(i) = (state_variable(i) < 0) ? 0 : state_variable(i);
-      state_variable(i) = (state_variable(i) > max_absolute_value_array(i)) ? max_absolute_value_array(i) : state_variable(i);
+      state_variable(i) =
+          (state_variable(i) > max_absolute_value_array(i)) ? max_absolute_value_array(i) : state_variable(i);
     } else {
       state_variable(i) += noise_ratio_array(i);
       state_variable(i) = (state_variable(i) > 0) ? 0 : state_variable(i);
-      state_variable(i) = (state_variable(i) < -max_absolute_value_array(i)) ? -max_absolute_value_array(i) : state_variable(i);
+      state_variable(i) =
+          (state_variable(i) < -max_absolute_value_array(i)) ? -max_absolute_value_array(i) : state_variable(i);
     }
   }
   this->set_state_variable(state_variable, state_variable_type);
 }
 
-void JointState::clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type, double noise_ratio) {
+void JointState::clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type,
+                                      double noise_ratio) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  this->clamp_state_variable(max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type, noise_ratio * Eigen::ArrayXd::Ones(expected_size));
+  this->clamp_state_variable(max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
+                             noise_ratio * Eigen::ArrayXd::Ones(expected_size));
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {
   // sanity check
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-  if (!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
+  if (state.is_empty()) { throw EmptyStateException(state.get_name() + " state is empty"); }
+  if (!this->is_compatible(state)) {
+    throw IncompatibleStatesException(
+        "The two joint states are incompatible, check name, joint names and order or size");
+  }
   // calculation
   double result = 0;
   if (state_variable_type == JointStateVariable::POSITIONS || state_variable_type == JointStateVariable::ALL) {
@@ -187,19 +217,19 @@ std::ostream& operator<<(std::ostream& os, const JointState& state) {
   } else {
     os << state.get_name() << " JointState" << std::endl;
     os << "names: [";
-    for (auto& n : state.names) os << n << ", ";
+    for (auto& n : state.names) { os << n << ", "; }
     os << "]" << std::endl;
     os << "positions: [";
-    for (unsigned int i = 0; i < state.positions.size(); ++i) os << state.positions(i) << ", ";
+    for (unsigned int i = 0; i < state.positions.size(); ++i) { os << state.positions(i) << ", "; }
     os << "]" << std::endl;
     os << "velocities: [";
-    for (unsigned int i = 0; i < state.velocities.size(); ++i) os << state.velocities(i) << ", ";
+    for (unsigned int i = 0; i < state.velocities.size(); ++i) { os << state.velocities(i) << ", "; }
     os << "]" << std::endl;
     os << "accelerations: [";
-    for (unsigned int i = 0; i < state.accelerations.size(); ++i) os << state.accelerations(i) << ", ";
+    for (unsigned int i = 0; i < state.accelerations.size(); ++i) { os << state.accelerations(i) << ", "; }
     os << "]" << std::endl;
     os << "torques: [";
-    for (unsigned int i = 0; i < state.torques.size(); ++i) os << state.torques(i) << ", ";
+    for (unsigned int i = 0; i < state.torques.size(); ++i) { os << state.torques(i) << ", "; }
     os << "]";
   }
   return os;
@@ -210,7 +240,7 @@ double dist(const JointState& s1, const JointState& s2, const JointStateVariable
 }
 
 JointState operator*(double lambda, const JointState& state) {
-  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (state.is_empty()) { throw EmptyStateException(state.get_name() + " state is empty"); }
   JointState result(state);
   result *= lambda;
   return result;
@@ -229,11 +259,11 @@ JointState operator*(const Eigen::ArrayXd& lambda, const JointState& state) {
 }
 
 std::vector<double> JointState::to_std_vector() const {
-  throw(NotImplementedException("to_std_vector() is not implemented for the base JointState class"));
+  throw (NotImplementedException("to_std_vector() is not implemented for the base JointState class"));
   return std::vector<double>();
 }
 
 void JointState::from_std_vector(const std::vector<double>&) {
-  throw(NotImplementedException("from_std_vector() is not implemented for the base JointState class"));
+  throw (NotImplementedException("from_std_vector() is not implemented for the base JointState class"));
 }
 }// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointState.cpp
+++ b/source/state_representation/src/Robot/JointState.cpp
@@ -1,167 +1,142 @@
 #include "state_representation/Robot/JointState.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/NotImplementedException.hpp"
 
-namespace StateRepresentation 
-{
-	JointState::JointState():
-	State(StateType::JOINTSTATE)
-	{
-		this->initialize();
-	}
-
-	JointState::JointState(const std::string& robot_name, unsigned int nb_joints):
-	State(StateType::JOINTSTATE, robot_name), names(nb_joints)
-	{
-		this->set_names(nb_joints);
-	}
-
-	JointState::JointState(const std::string& robot_name, const std::vector<std::string>& joint_names):
-	State(StateType::JOINTSTATE, robot_name)
-	{
-		this->set_names(joint_names);
-	}
-
-	JointState::JointState(const JointState& state):
-	State(state), names(state.names), positions(state.positions), velocities(state.velocities),
-	accelerations(state.accelerations), torques(state.torques)
-	{}
-
-	void JointState::initialize()
-	{
-		this->State::initialize();
-		// resize
-		unsigned int size = this->names.size();
-		this->positions.resize(size);
-		this->velocities.resize(size);
-		this->accelerations.resize(size);
-		this->torques.resize(size);
-		// set to zeros
-		this->set_zero();
-	}
-
-	void JointState::set_zero()
-	{
-		this->positions.setZero();
-		this->velocities.setZero();
-		this->accelerations.setZero();
-		this->torques.setZero();
-	}
-
-	JointState& JointState::operator+=(const JointState& state)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		if(!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
-		// operation
-		this->set_positions(this->get_positions() + state.get_positions());
-		this->set_velocities(this->get_velocities() + state.get_velocities());
-		this->set_accelerations(this->get_accelerations() + state.get_accelerations());
-		this->set_torques(this->get_torques() + state.get_torques());
-		return (*this);
-	}
-
-	const JointState JointState::operator+(const JointState& state) const
-	{
-		JointState result(*this);
-		result += state;
-		return result;
-	}
-
-	JointState& JointState::operator-=(const JointState& state)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		if(!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
-		// operation
-		this->set_positions(this->get_positions() - state.get_positions());
-		this->set_velocities(this->get_velocities() - state.get_velocities());
-		this->set_accelerations(this->get_accelerations() - state.get_accelerations());
-		this->set_torques(this->get_torques() - state.get_torques());
-		return (*this);
-	}
-
-	const JointState JointState::operator-(const JointState& state) const
-	{
-		JointState result(*this);
-		result -= state;
-		return result;
-	}
-
-	JointState& JointState::operator*=(const Eigen::MatrixXd& lambda)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(lambda.rows() != this->get_size() || lambda.cols() != this->get_size()) throw IncompatibleSizeException("Gain matrix is of incorrect size: expected " + std::to_string(this->get_size()) + "x" + std::to_string(this->get_size()) + ", given " + std::to_string(lambda.cols()) + "x" + std::to_string(lambda.cols()));
-		this->set_positions(lambda * this->get_positions());
-		this->set_velocities(lambda * this->get_velocities());
-		this->set_accelerations(lambda * this->get_accelerations());
-		this->set_torques(lambda * this->get_torques());
-		return (*this);
-	}
-
-	const JointState JointState::copy() const
-	{
-		JointState result(*this);
-		return result;
-	}
-
-	std::ostream& operator<<(std::ostream& os, const JointState& state) 
-	{
-		if(state.is_empty())
-		{
-			os << "Empty " << state.get_name() << " JointState";
-		}
-		else
-		{
-			os << state.get_name() << " JointState" << std::endl;
-	  		os << "names: [";
-			for(auto& n:state.names) os << n << ", ";
-			os << "]" << std::endl;
-			os << "positions: [";
-			for(unsigned int i=0; i<state.positions.size(); ++i) os << state.positions(i) << ", ";
-			os << "]" << std::endl;
-			os << "velocities: [";
-			for(unsigned int i=0; i<state.velocities.size(); ++i) os << state.velocities(i) << ", ";
-			os << "]" << std::endl;
-			os << "accelerations: [";
-			for(unsigned int i=0; i<state.accelerations.size(); ++i) os << state.accelerations(i) << ", ";
-			os << "]" << std::endl;
-			os << "torques: [";
-			for(unsigned int i=0; i<state.torques.size(); ++i) os << state.torques(i) << ", ";
-			os << "]";
-		}
-  		return os;
-	}
-
-	const JointState operator*(double lambda, const JointState& state)
-	{
-		if(state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
-		JointState result(state);
-		result.set_positions(lambda * state.get_positions());
-		result.set_velocities(lambda * state.get_velocities());
-		result.set_accelerations(lambda * state.get_accelerations());
-		result.set_torques(lambda * state.get_torques());
-		return result;
-	}
-
-	const JointState operator*(const Eigen::MatrixXd& lambda, const JointState& state)
-	{
-		JointState result(state);
-		result *= lambda;
-		return result;
-	}
-
-	const std::vector<double> JointState::to_std_vector() const
-	{
-		throw(NotImplementedException("to_std_vector() is not implemented for the base JointState class"));
-		return std::vector<double>();
-	}
-
-	void JointState::from_std_vector(const std::vector<double>&)
-	{
-		throw(NotImplementedException("from_std_vector() is not implemented for the base JointState class"));
-	}
+namespace StateRepresentation {
+JointState::JointState() : State(StateType::JOINTSTATE) {
+  this->initialize();
 }
+
+JointState::JointState(const std::string& robot_name, unsigned int nb_joints) : State(StateType::JOINTSTATE, robot_name), names(nb_joints) {
+  this->set_names(nb_joints);
+}
+
+JointState::JointState(const std::string& robot_name, const std::vector<std::string>& joint_names) : State(StateType::JOINTSTATE, robot_name) {
+  this->set_names(joint_names);
+}
+
+JointState::JointState(const JointState& state) : State(state), names(state.names), positions(state.positions), velocities(state.velocities),
+                                                  accelerations(state.accelerations), torques(state.torques) {}
+
+void JointState::initialize() {
+  this->State::initialize();
+  // resize
+  unsigned int size = this->names.size();
+  this->positions.resize(size);
+  this->velocities.resize(size);
+  this->accelerations.resize(size);
+  this->torques.resize(size);
+  // set to zeros
+  this->set_zero();
+}
+
+void JointState::set_zero() {
+  this->positions.setZero();
+  this->velocities.setZero();
+  this->accelerations.setZero();
+  this->torques.setZero();
+}
+
+JointState& JointState::operator+=(const JointState& state) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  // operation
+  this->set_positions(this->get_positions() + state.get_positions());
+  this->set_velocities(this->get_velocities() + state.get_velocities());
+  this->set_accelerations(this->get_accelerations() + state.get_accelerations());
+  this->set_torques(this->get_torques() + state.get_torques());
+  return (*this);
+}
+
+const JointState JointState::operator+(const JointState& state) const {
+  JointState result(*this);
+  result += state;
+  return result;
+}
+
+JointState& JointState::operator-=(const JointState& state) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  if (!this->is_compatible(state)) throw IncompatibleStatesException("The two joint states are incompatible, check name, joint names and order or size");
+  // operation
+  this->set_positions(this->get_positions() - state.get_positions());
+  this->set_velocities(this->get_velocities() - state.get_velocities());
+  this->set_accelerations(this->get_accelerations() - state.get_accelerations());
+  this->set_torques(this->get_torques() - state.get_torques());
+  return (*this);
+}
+
+const JointState JointState::operator-(const JointState& state) const {
+  JointState result(*this);
+  result -= state;
+  return result;
+}
+
+JointState& JointState::operator*=(const Eigen::MatrixXd& lambda) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (lambda.rows() != this->get_size() || lambda.cols() != this->get_size()) throw IncompatibleSizeException("Gain matrix is of incorrect size: expected " + std::to_string(this->get_size()) + "x" + std::to_string(this->get_size()) + ", given " + std::to_string(lambda.cols()) + "x" + std::to_string(lambda.cols()));
+  this->set_positions(lambda * this->get_positions());
+  this->set_velocities(lambda * this->get_velocities());
+  this->set_accelerations(lambda * this->get_accelerations());
+  this->set_torques(lambda * this->get_torques());
+  return (*this);
+}
+
+const JointState JointState::copy() const {
+  JointState result(*this);
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const JointState& state) {
+  if (state.is_empty()) {
+    os << "Empty " << state.get_name() << " JointState";
+  } else {
+    os << state.get_name() << " JointState" << std::endl;
+    os << "names: [";
+    for (auto& n : state.names) os << n << ", ";
+    os << "]" << std::endl;
+    os << "positions: [";
+    for (unsigned int i = 0; i < state.positions.size(); ++i) os << state.positions(i) << ", ";
+    os << "]" << std::endl;
+    os << "velocities: [";
+    for (unsigned int i = 0; i < state.velocities.size(); ++i) os << state.velocities(i) << ", ";
+    os << "]" << std::endl;
+    os << "accelerations: [";
+    for (unsigned int i = 0; i < state.accelerations.size(); ++i) os << state.accelerations(i) << ", ";
+    os << "]" << std::endl;
+    os << "torques: [";
+    for (unsigned int i = 0; i < state.torques.size(); ++i) os << state.torques(i) << ", ";
+    os << "]";
+  }
+  return os;
+}
+
+const JointState operator*(double lambda, const JointState& state) {
+  if (state.is_empty()) throw EmptyStateException(state.get_name() + " state is empty");
+  JointState result(state);
+  result.set_positions(lambda * state.get_positions());
+  result.set_velocities(lambda * state.get_velocities());
+  result.set_accelerations(lambda * state.get_accelerations());
+  result.set_torques(lambda * state.get_torques());
+  return result;
+}
+
+const JointState operator*(const Eigen::MatrixXd& lambda, const JointState& state) {
+  JointState result(state);
+  result *= lambda;
+  return result;
+}
+
+const std::vector<double> JointState::to_std_vector() const {
+  throw(NotImplementedException("to_std_vector() is not implemented for the base JointState class"));
+  return std::vector<double>();
+}
+
+void JointState::from_std_vector(const std::vector<double>&) {
+  throw(NotImplementedException("from_std_vector() is not implemented for the base JointState class"));
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -23,18 +23,6 @@ JointTorques::JointTorques(const JointTorques& torques) : JointState(torques) {}
 
 JointTorques::JointTorques(const JointState& state) : JointState(state) {}
 
-JointTorques& JointTorques::operator=(const Eigen::VectorXd& torques) {
-  this->set_torques(torques);
-  return (*this);
-}
-
-JointTorques& JointTorques::operator+=(const Eigen::VectorXd& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-  this->set_torques(this->get_torques() + vector);
-  return (*this);
-}
-
 JointTorques& JointTorques::operator+=(const JointTorques& torques) {
   // sanity check
   if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
@@ -45,23 +33,10 @@ JointTorques& JointTorques::operator+=(const JointTorques& torques) {
   return (*this);
 }
 
-const JointTorques JointTorques::operator+(const Eigen::VectorXd& vector) const {
-  JointTorques result(*this);
-  result += vector;
-  return result;
-}
-
 const JointTorques JointTorques::operator+(const JointTorques& torques) const {
   JointTorques result(*this);
   result += torques;
   return result;
-}
-
-JointTorques& JointTorques::operator-=(const Eigen::VectorXd& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-  this->set_torques(this->get_torques() - vector);
-  return (*this);
 }
 
 JointTorques& JointTorques::operator-=(const JointTorques& torques) {
@@ -72,12 +47,6 @@ JointTorques& JointTorques::operator-=(const JointTorques& torques) {
   // operation
   this->set_torques(this->get_torques() - torques.get_torques());
   return (*this);
-}
-
-const JointTorques JointTorques::operator-(const Eigen::VectorXd& vector) const {
-  JointTorques result(*this);
-  result -= vector;
-  return result;
 }
 
 const JointTorques JointTorques::operator-(const JointTorques& torques) const {
@@ -130,14 +99,6 @@ std::ostream& operator<<(std::ostream& os, const JointTorques& torques) {
     os << "]";
   }
   return os;
-}
-
-const JointTorques operator+(const Eigen::VectorXd& vector, const JointTorques& torques) {
-  return torques + vector;
-}
-
-const JointTorques operator-(const Eigen::VectorXd& vector, const JointTorques& torques) {
-  return vector + (-1) * torques;
 }
 
 const JointTorques operator*(double lambda, const JointTorques& torques) {

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -1,213 +1,172 @@
 #include "state_representation/Robot/JointTorques.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation
-{
-	JointTorques::JointTorques()
-	{}
+namespace StateRepresentation {
+JointTorques::JointTorques() {}
 
-	JointTorques::JointTorques(const std::string& robot_name, unsigned int nb_joints):
-	JointState(robot_name, nb_joints)
-	{}
+JointTorques::JointTorques(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
 
-	JointTorques::JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques):
-	JointState(robot_name, torques.size())
-	{
-		this->set_torques(torques);
-	}
-
-	JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names):
-	JointState(robot_name, joint_names)
-	{}
-
-	JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& torques):
-	JointState(robot_name, joint_names)
-	{
-		this->set_torques(torques);
-	}
-
-	JointTorques::JointTorques(const JointTorques& torques):
-	JointState(torques)
-	{}
-
-	JointTorques::JointTorques(const JointState& state):
-	JointState(state)
-	{}
-
-	JointTorques& JointTorques::operator=(const Eigen::VectorXd& torques)
-	{
-		this->set_torques(torques);
-		return (*this);
-	}
-
-	JointTorques& JointTorques::operator+=(const Eigen::VectorXd& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-		this->set_torques(this->get_torques() + vector);
-		return (*this);
-	}
-
-	JointTorques& JointTorques::operator+=(const JointTorques& torques)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-		if(!this->is_compatible(torques)) throw IncompatibleStatesException("The two joint states are incompatible");
-		// operation
-		this->set_torques(this->get_torques() + torques.get_torques());
-		return (*this);
-	}
-
-	const JointTorques JointTorques::operator+(const Eigen::VectorXd& vector) const
-	{
-		JointTorques result(*this);
-		result += vector;
-		return result;
-	}
-
-	const JointTorques JointTorques::operator+(const JointTorques& torques) const
-	{
-		JointTorques result(*this);
-		result += torques;
-		return result;
-	}
-
-	JointTorques& JointTorques::operator-=(const Eigen::VectorXd& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-		this->set_torques(this->get_torques() - vector);
-		return (*this);
-	}
-
-	JointTorques& JointTorques::operator-=(const JointTorques& torques)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-		if(!this->is_compatible(torques)) throw IncompatibleStatesException("The two joint states are incompatible");
-		// operation
-		this->set_torques(this->get_torques() - torques.get_torques());
-		return (*this);
-	}
-
-	const JointTorques JointTorques::operator-(const Eigen::VectorXd& vector) const
-	{
-		JointTorques result(*this);
-		result -= vector;
-		return result;
-	}
-
-	const JointTorques JointTorques::operator-(const JointTorques& torques) const
-	{
-		JointTorques result(*this);
-		result -= torques;
-		return result;
-	}
-
-	const JointTorques JointTorques::copy() const
-	{
-		JointTorques result(*this);
-		return result;
-	}
-
-	const Eigen::ArrayXd JointTorques::array() const
-	{
-		return this->get_torques().array();
-	}
-
-	void JointTorques::clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio)
-	{
-		Eigen::VectorXd torques = this->get_torques();
-		for (int i = 0; i < torques.size(); ++i)
-		{
-			if (torques(i) > 0)
-			{
-    			torques(i) -= noise_ratio(i);
-    			torques(i) = (torques(i) < 0) ? 0 : torques(i);
-    			torques(i) = (torques(i) > max_absolute(i)) ? max_absolute(i) : torques(i);
-			}
-			else
-			{
-    			torques(i) += noise_ratio(i);
-    			torques(i) = (torques(i) > 0) ? 0 : torques(i);
-    			torques(i) = (torques(i) < -max_absolute(i)) ? -max_absolute(i) : torques(i);
-			}
-		}
-		this->set_torques(torques);
-	}
-
-	const JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const
-	{
-		JointTorques result(*this);
-		result.clamp(max_absolute, noise_ratio);
-		return result;
-	}
-
-	std::ostream& operator<<(std::ostream& os, const JointTorques& torques)
-	{
-		if(torques.is_empty())
-		{
-			os << "Empty JointTorques";
-		}
-		else
-		{
-			os << torques.get_name() << " JointTorques" << std::endl;
-	  		os << "names: [";
-			for(auto& n:torques.get_names()) os << n << ", ";
-			os << "]" << std::endl;
-			os << "torques: [";
-			for(unsigned int i=0; i<torques.get_size(); ++i) os << torques.get_torques()(i) << ", ";
-			os << "]";
-		}
-  		return os;
-	}
-
-	const JointTorques operator+(const Eigen::VectorXd& vector, const JointTorques& torques)
-	{
-		return torques + vector;
-	}
-
-	const JointTorques operator-(const Eigen::VectorXd& vector, const JointTorques& torques)
-	{
-		return vector + (-1) * torques;
-	}
-
-	const JointTorques operator*(double lambda, const JointTorques& torques)
-	{
-		if(torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-		JointTorques result(torques);
-		result.set_torques(lambda * torques.get_torques());
-		return result;
-	}
-
-	const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques)
-	{
-		if(torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-		if(lambda.size() != torques.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
-		JointTorques result(torques);
-		result.set_torques(lambda * torques.get_torques().array());
-		return result;
-	}
-
-	const JointTorques operator/(const JointTorques& torques, double lambda)
-	{
-		if(torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-		JointTorques result(torques);
-		result.set_torques(torques.get_torques() / lambda);
-		return result;
-	}
-
-	const JointTorques operator/(const JointTorques& torques, const Eigen::ArrayXd& lambda)
-	{
-		if(torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-		if(lambda.size() != torques.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
-		JointTorques result(torques);
-		result.set_torques(torques.get_torques().array() / lambda);
-		return result;
-	}
+JointTorques::JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques) : JointState(robot_name, torques.size()) {
+  this->set_torques(torques);
 }
+
+JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names) : JointState(robot_name, joint_names) {}
+
+JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& torques) : JointState(robot_name, joint_names) {
+  this->set_torques(torques);
+}
+
+JointTorques::JointTorques(const JointTorques& torques) : JointState(torques) {}
+
+JointTorques::JointTorques(const JointState& state) : JointState(state) {}
+
+JointTorques& JointTorques::operator=(const Eigen::VectorXd& torques) {
+  this->set_torques(torques);
+  return (*this);
+}
+
+JointTorques& JointTorques::operator+=(const Eigen::VectorXd& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
+  this->set_torques(this->get_torques() + vector);
+  return (*this);
+}
+
+JointTorques& JointTorques::operator+=(const JointTorques& torques) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
+  if (!this->is_compatible(torques)) throw IncompatibleStatesException("The two joint states are incompatible");
+  // operation
+  this->set_torques(this->get_torques() + torques.get_torques());
+  return (*this);
+}
+
+const JointTorques JointTorques::operator+(const Eigen::VectorXd& vector) const {
+  JointTorques result(*this);
+  result += vector;
+  return result;
+}
+
+const JointTorques JointTorques::operator+(const JointTorques& torques) const {
+  JointTorques result(*this);
+  result += torques;
+  return result;
+}
+
+JointTorques& JointTorques::operator-=(const Eigen::VectorXd& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
+  this->set_torques(this->get_torques() - vector);
+  return (*this);
+}
+
+JointTorques& JointTorques::operator-=(const JointTorques& torques) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
+  if (!this->is_compatible(torques)) throw IncompatibleStatesException("The two joint states are incompatible");
+  // operation
+  this->set_torques(this->get_torques() - torques.get_torques());
+  return (*this);
+}
+
+const JointTorques JointTorques::operator-(const Eigen::VectorXd& vector) const {
+  JointTorques result(*this);
+  result -= vector;
+  return result;
+}
+
+const JointTorques JointTorques::operator-(const JointTorques& torques) const {
+  JointTorques result(*this);
+  result -= torques;
+  return result;
+}
+
+const JointTorques JointTorques::copy() const {
+  JointTorques result(*this);
+  return result;
+}
+
+const Eigen::ArrayXd JointTorques::array() const {
+  return this->get_torques().array();
+}
+
+void JointTorques::clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) {
+  Eigen::VectorXd torques = this->get_torques();
+  for (int i = 0; i < torques.size(); ++i) {
+    if (torques(i) > 0) {
+      torques(i) -= noise_ratio(i);
+      torques(i) = (torques(i) < 0) ? 0 : torques(i);
+      torques(i) = (torques(i) > max_absolute(i)) ? max_absolute(i) : torques(i);
+    } else {
+      torques(i) += noise_ratio(i);
+      torques(i) = (torques(i) > 0) ? 0 : torques(i);
+      torques(i) = (torques(i) < -max_absolute(i)) ? -max_absolute(i) : torques(i);
+    }
+  }
+  this->set_torques(torques);
+}
+
+const JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const {
+  JointTorques result(*this);
+  result.clamp(max_absolute, noise_ratio);
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const JointTorques& torques) {
+  if (torques.is_empty()) {
+    os << "Empty JointTorques";
+  } else {
+    os << torques.get_name() << " JointTorques" << std::endl;
+    os << "names: [";
+    for (auto& n : torques.get_names()) os << n << ", ";
+    os << "]" << std::endl;
+    os << "torques: [";
+    for (unsigned int i = 0; i < torques.get_size(); ++i) os << torques.get_torques()(i) << ", ";
+    os << "]";
+  }
+  return os;
+}
+
+const JointTorques operator+(const Eigen::VectorXd& vector, const JointTorques& torques) {
+  return torques + vector;
+}
+
+const JointTorques operator-(const Eigen::VectorXd& vector, const JointTorques& torques) {
+  return vector + (-1) * torques;
+}
+
+const JointTorques operator*(double lambda, const JointTorques& torques) {
+  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
+  JointTorques result(torques);
+  result.set_torques(lambda * torques.get_torques());
+  return result;
+}
+
+const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques) {
+  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
+  if (lambda.size() != torques.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
+  JointTorques result(torques);
+  result.set_torques(lambda * torques.get_torques().array());
+  return result;
+}
+
+const JointTorques operator/(const JointTorques& torques, double lambda) {
+  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
+  JointTorques result(torques);
+  result.set_torques(torques.get_torques() / lambda);
+  return result;
+}
+
+const JointTorques operator/(const JointTorques& torques, const Eigen::ArrayXd& lambda) {
+  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
+  if (lambda.size() != torques.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
+  JointTorques result(torques);
+  result.set_torques(torques.get_torques().array() / lambda);
+  return result;
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -142,5 +142,4 @@ JointTorques operator*(const Eigen::MatrixXd& lambda, const JointTorques& torque
   result *= lambda;
   return result;
 }
-
 }// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -9,13 +9,16 @@ JointTorques::JointTorques() {}
 
 JointTorques::JointTorques(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
 
-JointTorques::JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques) : JointState(robot_name, torques.size()) {
+JointTorques::JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques) :
+    JointState(robot_name, torques.size()) {
   this->set_torques(torques);
 }
 
-JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names) : JointState(robot_name, joint_names) {}
+JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names) :
+    JointState(robot_name, joint_names) {}
 
-JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& torques) : JointState(robot_name, joint_names) {
+JointTorques::JointTorques(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                           const Eigen::VectorXd& torques) : JointState(robot_name, joint_names) {
   this->set_torques(torques);
 }
 
@@ -104,7 +107,8 @@ void JointTorques::clamp(const Eigen::ArrayXd& max_absolute_value_array, const E
   this->clamp_state_variable(max_absolute_value_array, JointStateVariable::TORQUES, noise_ratio_array);
 }
 
-JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const {
+JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute_value_array,
+                                   const Eigen::ArrayXd& noise_ratio_array) const {
   JointTorques result(*this);
   result.clamp(max_absolute_value_array, noise_ratio_array);
   return result;
@@ -116,10 +120,10 @@ std::ostream& operator<<(std::ostream& os, const JointTorques& torques) {
   } else {
     os << torques.get_name() << " JointTorques" << std::endl;
     os << "names: [";
-    for (auto& n : torques.get_names()) os << n << ", ";
+    for (auto& n : torques.get_names()) { os << n << ", "; }
     os << "]" << std::endl;
     os << "torques: [";
-    for (unsigned int i = 0; i < torques.get_size(); ++i) os << torques.get_torques()(i) << ", ";
+    for (unsigned int i = 0; i < torques.get_size(); ++i) { os << torques.get_torques()(i) << ", "; }
     os << "]";
   }
   return os;

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -33,7 +33,7 @@ JointTorques& JointTorques::operator+=(const JointTorques& torques) {
   return (*this);
 }
 
-const JointTorques JointTorques::operator+(const JointTorques& torques) const {
+JointTorques JointTorques::operator+(const JointTorques& torques) const {
   JointTorques result(*this);
   result += torques;
   return result;
@@ -49,18 +49,18 @@ JointTorques& JointTorques::operator-=(const JointTorques& torques) {
   return (*this);
 }
 
-const JointTorques JointTorques::operator-(const JointTorques& torques) const {
+JointTorques JointTorques::operator-(const JointTorques& torques) const {
   JointTorques result(*this);
   result -= torques;
   return result;
 }
 
-const JointTorques JointTorques::copy() const {
+JointTorques JointTorques::copy() const {
   JointTorques result(*this);
   return result;
 }
 
-const Eigen::ArrayXd JointTorques::array() const {
+Eigen::ArrayXd JointTorques::array() const {
   return this->get_torques().array();
 }
 
@@ -80,7 +80,7 @@ void JointTorques::clamp(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayX
   this->set_torques(torques);
 }
 
-const JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const {
+JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute, const Eigen::ArrayXd& noise_ratio) const {
   JointTorques result(*this);
   result.clamp(max_absolute, noise_ratio);
   return result;
@@ -101,14 +101,14 @@ std::ostream& operator<<(std::ostream& os, const JointTorques& torques) {
   return os;
 }
 
-const JointTorques operator*(double lambda, const JointTorques& torques) {
+JointTorques operator*(double lambda, const JointTorques& torques) {
   if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
   JointTorques result(torques);
   result.set_torques(lambda * torques.get_torques());
   return result;
 }
 
-const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques) {
+JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& torques) {
   if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
   if (lambda.size() != torques.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
   JointTorques result(torques);
@@ -116,18 +116,4 @@ const JointTorques operator*(const Eigen::ArrayXd& lambda, const JointTorques& t
   return result;
 }
 
-const JointTorques operator/(const JointTorques& torques, double lambda) {
-  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-  JointTorques result(torques);
-  result.set_torques(torques.get_torques() / lambda);
-  return result;
-}
-
-const JointTorques operator/(const JointTorques& torques, const Eigen::ArrayXd& lambda) {
-  if (torques.is_empty()) throw EmptyStateException(torques.get_name() + " state is empty");
-  if (lambda.size() != torques.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
-  JointTorques result(torques);
-  result.set_torques(torques.get_torques().array() / lambda);
-  return result;
-}
 }// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -90,25 +90,25 @@ Eigen::ArrayXd JointTorques::array() const {
   return this->get_torques().array();
 }
 
-void JointTorques::clamp(double max_absolute, double noise_ratio) {
-  this->clamp_state_variable(max_absolute, JointStateVariable::TORQUES, noise_ratio);
+void JointTorques::clamp(double max_absolute_value, double noise_ratio) {
+  this->clamp_state_variable(max_absolute_value, JointStateVariable::TORQUES, noise_ratio);
 }
 
-JointTorques JointTorques::clamped(double max_absolute, double noise_ratio) const {
+JointTorques JointTorques::clamped(double max_absolute_value, double noise_ratio) const {
   JointTorques result(*this);
-  result.clamp(max_absolute, noise_ratio);
+  result.clamp(max_absolute_value, noise_ratio);
   return result;
 }
 
-/*void JointTorques::clamp(const Eigen::ArrayXd& max_absolute_array, const Eigen::ArrayXd& noise_ratio_array) {
-  this->clamp_state_variable(max_absolute_array, JointStateVariable::TORQUES, noise_ratio_array);
+void JointTorques::clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) {
+  this->clamp_state_variable(max_absolute_value_array, JointStateVariable::TORQUES, noise_ratio_array);
 }
 
-JointTorques JointTorques::clamped(const Eigen::ArrayXd& noise_ratio_array, const Eigen::ArrayXd& noise_ratio_array) const {
+JointTorques JointTorques::clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const {
   JointTorques result(*this);
-  result.clamp(noise_ratio_array, noise_ratio_array);
+  result.clamp(max_absolute_value_array, noise_ratio_array);
   return result;
-}*/
+}
 
 std::ostream& operator<<(std::ostream& os, const JointTorques& torques) {
   if (torques.is_empty()) {

--- a/source/state_representation/src/Robot/JointVelocities.cpp
+++ b/source/state_representation/src/Robot/JointVelocities.cpp
@@ -7,15 +7,19 @@ using namespace StateRepresentation::Exceptions;
 namespace StateRepresentation {
 JointVelocities::JointVelocities() {}
 
-JointVelocities::JointVelocities(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
+JointVelocities::JointVelocities(const std::string& robot_name, unsigned int nb_joints) :
+    JointState(robot_name, nb_joints) {}
 
-JointVelocities::JointVelocities(const std::string& robot_name, const Eigen::VectorXd& velocities) : JointState(robot_name, velocities.size()) {
+JointVelocities::JointVelocities(const std::string& robot_name, const Eigen::VectorXd& velocities) :
+    JointState(robot_name, velocities.size()) {
   this->set_velocities(velocities);
 }
 
-JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names) : JointState(robot_name, joint_names) {}
+JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names) :
+    JointState(robot_name, joint_names) {}
 
-JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& velocities) : JointState(robot_name, joint_names) {
+JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names,
+                                 const Eigen::VectorXd& velocities) : JointState(robot_name, joint_names) {
   this->set_velocities(velocities);
 }
 
@@ -84,7 +88,7 @@ JointVelocities JointVelocities::operator/(double lambda) const {
 }
 
 JointPositions JointVelocities::operator*(const std::chrono::nanoseconds& dt) const {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
   // operations
   JointPositions displacement(this->get_name(), this->get_names());
   // convert the period to a double with the second as reference
@@ -118,7 +122,8 @@ void JointVelocities::clamp(const Eigen::ArrayXd& max_absolute_value_array, cons
   this->clamp_state_variable(max_absolute_value_array, JointStateVariable::VELOCITIES, noise_ratio_array);
 }
 
-JointVelocities JointVelocities::clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const {
+JointVelocities JointVelocities::clamped(const Eigen::ArrayXd& max_absolute_value_array,
+                                         const Eigen::ArrayXd& noise_ratio_array) const {
   JointVelocities result(*this);
   result.clamp(max_absolute_value_array, noise_ratio_array);
   return result;
@@ -130,10 +135,10 @@ std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities) {
   } else {
     os << velocities.get_name() << " JointVelocities" << std::endl;
     os << "names: [";
-    for (auto& n : velocities.get_names()) os << n << ", ";
+    for (auto& n : velocities.get_names()) { os << n << ", "; }
     os << "]" << std::endl;
     os << "velocities: [";
-    for (unsigned int i = 0; i < velocities.get_size(); ++i) os << velocities.get_velocities()(i) << ", ";
+    for (unsigned int i = 0; i < velocities.get_size(); ++i) { os << velocities.get_velocities()(i) << ", "; }
     os << "]";
   }
   return os;

--- a/source/state_representation/src/Robot/JointVelocities.cpp
+++ b/source/state_representation/src/Robot/JointVelocities.cpp
@@ -1,241 +1,195 @@
 #include "state_representation/Robot/JointVelocities.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
+#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
-namespace StateRepresentation
-{
-	JointVelocities::JointVelocities()
-	{}
+namespace StateRepresentation {
+JointVelocities::JointVelocities() {}
 
-	JointVelocities::JointVelocities(const std::string& robot_name, unsigned int nb_joints):
-	JointState(robot_name, nb_joints)
-	{}
+JointVelocities::JointVelocities(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
 
-	JointVelocities::JointVelocities(const std::string& robot_name, const Eigen::VectorXd& velocities):
-	JointState(robot_name, velocities.size())
-	{
-		this->set_velocities(velocities);
-	}
-
-	JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names):
-	JointState(robot_name, joint_names)
-	{}
-
-	JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& velocities):
-	JointState(robot_name, joint_names)
-	{
-		this->set_velocities(velocities);
-	}
-
-	JointVelocities::JointVelocities(const JointVelocities& velocities):
-	JointState(velocities)
-	{}
-
-	JointVelocities::JointVelocities(const JointState& state):
-	JointState(state)
-	{}
-
-	JointVelocities::JointVelocities(const JointPositions& positions):
-	JointState(positions / std::chrono::seconds(1))
-	{}
-
-	JointVelocities& JointVelocities::operator=(const Eigen::VectorXd& velocities)
-	{
-		this->set_velocities(velocities);
-		return (*this);
-	}
-
-	JointVelocities& JointVelocities::operator+=(const Eigen::VectorXd& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-		this->set_velocities(this->get_velocities() + vector);
-		return (*this);
-	}
-
-	JointVelocities& JointVelocities::operator+=(const JointVelocities& velocities)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		if(!this->is_compatible(velocities)) throw IncompatibleStatesException("The two joint states are incompatible");
-		// operation
-		this->set_velocities(this->get_velocities() + velocities.get_velocities());
-		return (*this);
-	}
-
-	const JointVelocities JointVelocities::operator+(const Eigen::VectorXd& vector) const
-	{
-		JointVelocities result(*this);
-		result += vector;
-		return result;
-	}
-
-	const JointVelocities JointVelocities::operator+(const JointVelocities& velocities) const
-	{
-		JointVelocities result(*this);
-		result += velocities;
-		return result;
-	}
-
-	JointVelocities& JointVelocities::operator-=(const Eigen::VectorXd& vector)
-	{
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-		this->set_velocities(this->get_velocities() - vector);
-		return (*this);
-	}
-
-	JointVelocities& JointVelocities::operator-=(const JointVelocities& velocities)
-	{
-		// sanity check
-		if(this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		if(!this->is_compatible(velocities)) throw IncompatibleStatesException("The two joint states are incompatible");
-		// operation
-		this->set_velocities(this->get_velocities() - velocities.get_velocities());
-		return (*this);
-	}
-
-	const JointVelocities JointVelocities::operator-(const Eigen::VectorXd& vector) const
-	{
-		JointVelocities result(*this);
-		result -= vector;
-		return result;
-	}
-
-	const JointVelocities JointVelocities::operator-(const JointVelocities& velocities) const
-	{
-		JointVelocities result(*this);
-		result -= velocities;
-		return result;
-	}
-
-	const JointVelocities JointVelocities::copy() const
-	{
-		JointVelocities result(*this);
-		return result;
-	}
-
-	const Eigen::ArrayXd JointVelocities::array() const
-	{
-		return this->get_velocities().array();
-	}
-
-	void JointVelocities::clamp(const std::vector<double>& max_values, const std::vector<double>& noise_ratio)
-	{
-		Eigen::VectorXd velocities(this->get_size());
-		for (unsigned int i; i<this->get_size(); ++i)
-		{
-			// apply a deadzone
-			if (!noise_ratio.empty() && abs(this->get_velocities()(i)) < noise_ratio[i]) velocities(i) = 0.0; 
-			// clamp the velocities to their maximum amplitude provided
-			if(abs(this->get_velocities()(i)) > max_values[i]) velocities(i) = copysign(1.0, this->get_velocities()(i)) * max_values[i];
-		}
-		this->set_velocities(velocities);
-	}
-
-	void JointVelocities::clamp(double max_value, double noise_ratio)
-	{
-		this->clamp(std::vector<double>(this->get_size(), max_value), std::vector<double>(this->get_size(), noise_ratio));
-	}
-
-	const JointVelocities JointVelocities::clamped(double max_value, double noise_ratio) const
-	{
-		JointVelocities result(*this);
-		result.clamp(max_value, noise_ratio);
-		return result;
-	}
-
-	const JointVelocities JointVelocities::clamped(const std::vector<double>& max_values, const std::vector<double>& noise_ratio) const
-	{
-		JointVelocities result(*this);
-		result.clamp(max_values, noise_ratio);
-		return result;
-	}
-
-	std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities)
-	{
-		if(velocities.is_empty())
-		{
-			os << "Empty JointVelocities";
-		}
-		else
-		{
-			os << velocities.get_name() << " JointVelocities" << std::endl;
-	  		os << "names: [";
-			for(auto& n:velocities.get_names()) os << n << ", ";
-			os << "]" << std::endl;
-			os << "velocities: [";
-			for(unsigned int i=0; i<velocities.get_size(); ++i) os << velocities.get_velocities()(i) << ", ";
-			os << "]";
-		}
-  		return os;
-	}
-
-	const JointVelocities operator+(const Eigen::VectorXd& vector, const JointVelocities& velocities)
-	{
-		return velocities + vector;
-	}
-
-	const JointVelocities operator-(const Eigen::VectorXd& vector, const JointVelocities& velocities)
-	{
-		return vector + (-1) * velocities;
-	}
-
-	const JointVelocities operator*(double lambda, const JointVelocities& velocities)
-	{
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		JointVelocities result(velocities);
-		result.set_velocities(lambda * velocities.get_velocities());
-		return result;
-	}
-
-
-	const JointVelocities operator*(const Eigen::ArrayXd& lambda, const JointVelocities& velocities)
-	{
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		if(lambda.size() != velocities.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
-		JointVelocities result(velocities);
-		result.set_velocities(lambda * velocities.get_velocities().array());
-		return result;
-	}
-
-	const JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities)
-	{
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		// operations
-		JointPositions displacement(velocities.get_name(), velocities.get_names());
-		// convert the period to a double with the second as reference
-		double period = dt.count();
-		period /= 1e9;
-		// multiply the velocities by this period value
-		displacement.set_positions(period * velocities.get_velocities());
-		return displacement;
-
-	}
-
-	const JointPositions operator*(const JointVelocities& velocities, const std::chrono::nanoseconds& dt)
-	{
-		return dt * velocities;
-	}
-
-	const JointVelocities operator/(const JointVelocities& velocities, double lambda)
-	{
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		JointVelocities result(velocities);
-		result.set_velocities(velocities.get_velocities() / lambda);
-		return result;
-	}
-
-	const JointVelocities operator/(const JointVelocities& velocities, const Eigen::ArrayXd& lambda)
-	{
-		if(velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
-		if(lambda.size() != velocities.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
-		JointVelocities result(velocities);
-		result.set_velocities(velocities.get_velocities().array() / lambda);
-		return result;
-	}
+JointVelocities::JointVelocities(const std::string& robot_name, const Eigen::VectorXd& velocities) : JointState(robot_name, velocities.size()) {
+  this->set_velocities(velocities);
 }
+
+JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names) : JointState(robot_name, joint_names) {}
+
+JointVelocities::JointVelocities(const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& velocities) : JointState(robot_name, joint_names) {
+  this->set_velocities(velocities);
+}
+
+JointVelocities::JointVelocities(const JointVelocities& velocities) : JointState(velocities) {}
+
+JointVelocities::JointVelocities(const JointState& state) : JointState(state) {}
+
+JointVelocities::JointVelocities(const JointPositions& positions) : JointState(positions / std::chrono::seconds(1)) {}
+
+JointVelocities& JointVelocities::operator=(const Eigen::VectorXd& velocities) {
+  this->set_velocities(velocities);
+  return (*this);
+}
+
+JointVelocities& JointVelocities::operator+=(const Eigen::VectorXd& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
+  this->set_velocities(this->get_velocities() + vector);
+  return (*this);
+}
+
+JointVelocities& JointVelocities::operator+=(const JointVelocities& velocities) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  if (!this->is_compatible(velocities)) throw IncompatibleStatesException("The two joint states are incompatible");
+  // operation
+  this->set_velocities(this->get_velocities() + velocities.get_velocities());
+  return (*this);
+}
+
+const JointVelocities JointVelocities::operator+(const Eigen::VectorXd& vector) const {
+  JointVelocities result(*this);
+  result += vector;
+  return result;
+}
+
+const JointVelocities JointVelocities::operator+(const JointVelocities& velocities) const {
+  JointVelocities result(*this);
+  result += velocities;
+  return result;
+}
+
+JointVelocities& JointVelocities::operator-=(const Eigen::VectorXd& vector) {
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
+  this->set_velocities(this->get_velocities() - vector);
+  return (*this);
+}
+
+JointVelocities& JointVelocities::operator-=(const JointVelocities& velocities) {
+  // sanity check
+  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  if (!this->is_compatible(velocities)) throw IncompatibleStatesException("The two joint states are incompatible");
+  // operation
+  this->set_velocities(this->get_velocities() - velocities.get_velocities());
+  return (*this);
+}
+
+const JointVelocities JointVelocities::operator-(const Eigen::VectorXd& vector) const {
+  JointVelocities result(*this);
+  result -= vector;
+  return result;
+}
+
+const JointVelocities JointVelocities::operator-(const JointVelocities& velocities) const {
+  JointVelocities result(*this);
+  result -= velocities;
+  return result;
+}
+
+const JointVelocities JointVelocities::copy() const {
+  JointVelocities result(*this);
+  return result;
+}
+
+const Eigen::ArrayXd JointVelocities::array() const {
+  return this->get_velocities().array();
+}
+
+void JointVelocities::clamp(const std::vector<double>& max_values, const std::vector<double>& noise_ratio) {
+  Eigen::VectorXd velocities(this->get_size());
+  for (unsigned int i; i < this->get_size(); ++i) {
+    // apply a deadzone
+    if (!noise_ratio.empty() && abs(this->get_velocities()(i)) < noise_ratio[i]) velocities(i) = 0.0;
+    // clamp the velocities to their maximum amplitude provided
+    if (abs(this->get_velocities()(i)) > max_values[i]) velocities(i) = copysign(1.0, this->get_velocities()(i)) * max_values[i];
+  }
+  this->set_velocities(velocities);
+}
+
+void JointVelocities::clamp(double max_value, double noise_ratio) {
+  this->clamp(std::vector<double>(this->get_size(), max_value), std::vector<double>(this->get_size(), noise_ratio));
+}
+
+const JointVelocities JointVelocities::clamped(double max_value, double noise_ratio) const {
+  JointVelocities result(*this);
+  result.clamp(max_value, noise_ratio);
+  return result;
+}
+
+const JointVelocities JointVelocities::clamped(const std::vector<double>& max_values, const std::vector<double>& noise_ratio) const {
+  JointVelocities result(*this);
+  result.clamp(max_values, noise_ratio);
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities) {
+  if (velocities.is_empty()) {
+    os << "Empty JointVelocities";
+  } else {
+    os << velocities.get_name() << " JointVelocities" << std::endl;
+    os << "names: [";
+    for (auto& n : velocities.get_names()) os << n << ", ";
+    os << "]" << std::endl;
+    os << "velocities: [";
+    for (unsigned int i = 0; i < velocities.get_size(); ++i) os << velocities.get_velocities()(i) << ", ";
+    os << "]";
+  }
+  return os;
+}
+
+const JointVelocities operator+(const Eigen::VectorXd& vector, const JointVelocities& velocities) {
+  return velocities + vector;
+}
+
+const JointVelocities operator-(const Eigen::VectorXd& vector, const JointVelocities& velocities) {
+  return vector + (-1) * velocities;
+}
+
+const JointVelocities operator*(double lambda, const JointVelocities& velocities) {
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  JointVelocities result(velocities);
+  result.set_velocities(lambda * velocities.get_velocities());
+  return result;
+}
+
+const JointVelocities operator*(const Eigen::ArrayXd& lambda, const JointVelocities& velocities) {
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  if (lambda.size() != velocities.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
+  JointVelocities result(velocities);
+  result.set_velocities(lambda * velocities.get_velocities().array());
+  return result;
+}
+
+const JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities) {
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  // operations
+  JointPositions displacement(velocities.get_name(), velocities.get_names());
+  // convert the period to a double with the second as reference
+  double period = dt.count();
+  period /= 1e9;
+  // multiply the velocities by this period value
+  displacement.set_positions(period * velocities.get_velocities());
+  return displacement;
+}
+
+const JointPositions operator*(const JointVelocities& velocities, const std::chrono::nanoseconds& dt) {
+  return dt * velocities;
+}
+
+const JointVelocities operator/(const JointVelocities& velocities, double lambda) {
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  JointVelocities result(velocities);
+  result.set_velocities(velocities.get_velocities() / lambda);
+  return result;
+}
+
+const JointVelocities operator/(const JointVelocities& velocities, const Eigen::ArrayXd& lambda) {
+  if (velocities.is_empty()) throw EmptyStateException(velocities.get_name() + " state is empty");
+  if (lambda.size() != velocities.get_size()) throw IncompatibleSizeException("Gain vector is of incorrect size");
+  JointVelocities result(velocities);
+  result.set_velocities(velocities.get_velocities().array() / lambda);
+  return result;
+}
+}// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointVelocities.cpp
+++ b/source/state_representation/src/Robot/JointVelocities.cpp
@@ -25,18 +25,6 @@ JointVelocities::JointVelocities(const JointState& state) : JointState(state) {}
 
 JointVelocities::JointVelocities(const JointPositions& positions) : JointState(positions / std::chrono::seconds(1)) {}
 
-JointVelocities& JointVelocities::operator=(const Eigen::VectorXd& velocities) {
-  this->set_velocities(velocities);
-  return (*this);
-}
-
-JointVelocities& JointVelocities::operator+=(const Eigen::VectorXd& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-  this->set_velocities(this->get_velocities() + vector);
-  return (*this);
-}
-
 JointVelocities& JointVelocities::operator+=(const JointVelocities& velocities) {
   // sanity check
   if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
@@ -46,24 +34,10 @@ JointVelocities& JointVelocities::operator+=(const JointVelocities& velocities) 
   this->set_velocities(this->get_velocities() + velocities.get_velocities());
   return (*this);
 }
-
-const JointVelocities JointVelocities::operator+(const Eigen::VectorXd& vector) const {
-  JointVelocities result(*this);
-  result += vector;
-  return result;
-}
-
 const JointVelocities JointVelocities::operator+(const JointVelocities& velocities) const {
   JointVelocities result(*this);
   result += velocities;
   return result;
-}
-
-JointVelocities& JointVelocities::operator-=(const Eigen::VectorXd& vector) {
-  if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");
-  if (this->get_size() != vector.size()) throw IncompatibleSizeException("Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given " + std::to_string(vector.size()));
-  this->set_velocities(this->get_velocities() - vector);
-  return (*this);
 }
 
 JointVelocities& JointVelocities::operator-=(const JointVelocities& velocities) {
@@ -74,12 +48,6 @@ JointVelocities& JointVelocities::operator-=(const JointVelocities& velocities) 
   // operation
   this->set_velocities(this->get_velocities() - velocities.get_velocities());
   return (*this);
-}
-
-const JointVelocities JointVelocities::operator-(const Eigen::VectorXd& vector) const {
-  JointVelocities result(*this);
-  result -= vector;
-  return result;
 }
 
 const JointVelocities JointVelocities::operator-(const JointVelocities& velocities) const {
@@ -137,14 +105,6 @@ std::ostream& operator<<(std::ostream& os, const JointVelocities& velocities) {
     os << "]";
   }
   return os;
-}
-
-const JointVelocities operator+(const Eigen::VectorXd& vector, const JointVelocities& velocities) {
-  return velocities + vector;
-}
-
-const JointVelocities operator-(const Eigen::VectorXd& vector, const JointVelocities& velocities) {
-  return vector + (-1) * velocities;
 }
 
 const JointVelocities operator*(double lambda, const JointVelocities& velocities) {

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -1,141 +1,131 @@
-#include "state_representation/Robot/JointState.hpp"
 #include "state_representation/Robot/JointPositions.hpp"
+#include "state_representation/Robot/JointState.hpp"
 #include "state_representation/Robot/JointTorques.hpp"
-#include <gtest/gtest.h>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <unistd.h>
 
+TEST(SetPositonsWithModulo, PositiveNos) {
+  Eigen::VectorXd positions(4);
+  positions << 1, 2, 3, 4;
 
-TEST(SetPositonsWithModulo, PositiveNos)
-{
-	Eigen::VectorXd positions(4);
-	positions << 1,2,3,4;
-	
-	StateRepresentation::JointState j1("test_robot", 4);
-	j1.set_positions(positions);
+  StateRepresentation::JointState j1("test_robot", 4);
+  j1.set_positions(positions);
 
-	std::cerr << j1 << std::endl;
-	
-	for(unsigned int i=0; i<j1.get_size(); ++i) EXPECT_TRUE(-M_PI < j1.get_positions()(i) && j1.get_positions()(i) < M_PI);
+  std::cerr << j1 << std::endl;
+
+  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(-M_PI < j1.get_positions()(i) && j1.get_positions()(i) < M_PI);
 }
 
-TEST(SetPositonsWithModuloAndNegativeNumbers, PositiveNos)
-{
-	Eigen::VectorXd positions(4);
-	positions << -1,-2,-3,-4;
-	
-	StateRepresentation::JointState j1("test_robot", 4);
-	j1.set_positions(positions);
+TEST(SetPositonsWithModuloAndNegativeNumbers, PositiveNos) {
+  Eigen::VectorXd positions(4);
+  positions << -1, -2, -3, -4;
 
-	std::cerr << j1 << std::endl;
+  StateRepresentation::JointState j1("test_robot", 4);
+  j1.set_positions(positions);
 
-	for(unsigned int i=0; i<j1.get_size(); ++i) EXPECT_TRUE(-M_PI < j1.get_positions()(i) && j1.get_positions()(i) < M_PI);
-	EXPECT_TRUE(j1.get_positions()(0) < 0 && j1.get_positions()(3) > 0);
+  std::cerr << j1 << std::endl;
+
+  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(-M_PI < j1.get_positions()(i) && j1.get_positions()(i) < M_PI);
+  EXPECT_TRUE(j1.get_positions()(0) < 0 && j1.get_positions()(3) > 0);
 }
 
-TEST(AddTwoState, PositiveNos)
-{
-	Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
-	Eigen::VectorXd pos2 = Eigen::VectorXd::Random(4);
+TEST(AddTwoState, PositiveNos) {
+  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
+  Eigen::VectorXd pos2 = Eigen::VectorXd::Random(4);
 
-	StateRepresentation::JointState j1("test_robot", 4);
-	j1.set_positions(pos1);
+  StateRepresentation::JointState j1("test_robot", 4);
+  j1.set_positions(pos1);
 
-	StateRepresentation::JointState j2("test_robot", 4);
-	j2.set_positions(pos2);
+  StateRepresentation::JointState j2("test_robot", 4);
+  j2.set_positions(pos2);
 
-	StateRepresentation::JointState jsum = j1 + j2;
-	for(unsigned int i=0; i<j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(j1.get_positions()(i) + j2.get_positions()(i)), cos(j1.get_positions()(i) + j2.get_positions()(i))));
+  StateRepresentation::JointState jsum = j1 + j2;
+  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(j1.get_positions()(i) + j2.get_positions()(i)), cos(j1.get_positions()(i) + j2.get_positions()(i))));
 }
 
-TEST(MultiplyByScalar, PositiveNos)
-{
-	Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
+TEST(MultiplyByScalar, PositiveNos) {
+  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
 
-	StateRepresentation::JointState j1("test_robot", 4);
-	j1.set_positions(pos1);
+  StateRepresentation::JointState j1("test_robot", 4);
+  j1.set_positions(pos1);
 
-	StateRepresentation::JointState jsum = 0.5 * j1;
-	std::cerr << jsum << std::endl;
-	
-	for(unsigned int i=0; i<j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(0.5 * j1.get_positions()(i)), cos(0.5 * j1.get_positions()(i))));
+  StateRepresentation::JointState jsum = 0.5 * j1;
+  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(0.5 * j1.get_positions()(i)), cos(0.5 * j1.get_positions()(i))));
 }
 
-TEST(MultiplyByArray, PositiveNos)
-{
-	Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
-	Eigen::MatrixXd gain = Eigen::VectorXd::Random(4).asDiagonal();
+TEST(MultiplyByArray, PositiveNos) {
+  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
+  Eigen::MatrixXd gain = Eigen::VectorXd::Random(16).asDiagonal();
 
-	StateRepresentation::JointState j1("test_robot", 4);
-	j1.set_positions(pos1);
+  StateRepresentation::JointState j1("test_robot", 4);
+  j1.set_positions(pos1);
 
-	StateRepresentation::JointState jsum = gain * j1;
-	std::cerr << jsum << std::endl;
-
-	for(unsigned int i=0; i<j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(gain(i) * j1.get_positions()(i)), cos(gain(i) * j1.get_positions()(i))));
+  StateRepresentation::JointState jsum = gain * j1;
+  for (unsigned int i = 0; i < j1.get_size(); ++i) {
+    EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(gain(i, i) * j1.get_positions()(i)), cos(gain(i, i) * j1.get_positions()(i))));
+  }
 }
 
-TEST(TestVelocitiesOperatorsWithEigen, PositiveNos)
-{
-	Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-	StateRepresentation::JointVelocities velocities("test", 6);
-	velocities = vec;
-	EXPECT_TRUE((vec-velocities.get_velocities()).norm() < 1e-4);
-	velocities = vec.array();
-	EXPECT_TRUE((vec-velocities.get_velocities()).norm() < 1e-4);
+TEST(TestVelocitiesOperatorsWithEigen, PositiveNos) {
+  Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
+  StateRepresentation::JointVelocities velocities("test", 6);
+  velocities = vec;
+  EXPECT_TRUE((vec - velocities.get_velocities()).norm() < 1e-4);
+  velocities = vec.array();
+  EXPECT_TRUE((vec - velocities.get_velocities()).norm() < 1e-4);
 
-	velocities += vec;
-	EXPECT_TRUE((2 * vec-velocities.get_velocities()).norm() < 1e-4);
+  velocities += vec;
+  EXPECT_TRUE((2 * vec - velocities.get_velocities()).norm() < 1e-4);
 
-	Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
-	velocities = velocities + arr;
+  Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
+  velocities = velocities + arr;
 
-	EXPECT_TRUE(((2 * vec + arr)-velocities.get_velocities()).norm() < 1e-4);
+  EXPECT_TRUE(((2 * vec + arr) - velocities.get_velocities()).norm() < 1e-4);
 
-	velocities = arr + velocities;
-	EXPECT_TRUE(((2 * vec + 2 * arr)-velocities.get_velocities()).norm() < 1e-4);
+  velocities = arr + velocities;
+  EXPECT_TRUE(((2 * vec + 2 * arr) - velocities.get_velocities()).norm() < 1e-4);
 
-	velocities -= arr;
-	EXPECT_TRUE(((2 * vec + arr)-velocities.get_velocities()).norm() < 1e-4);
+  velocities -= arr;
+  EXPECT_TRUE(((2 * vec + arr) - velocities.get_velocities()).norm() < 1e-4);
 
-	velocities = velocities - vec;
-	EXPECT_TRUE(((vec + arr)-velocities.get_velocities()).norm() < 1e-4);
+  velocities = velocities - vec;
+  EXPECT_TRUE(((vec + arr) - velocities.get_velocities()).norm() < 1e-4);
 
-	velocities = vec - velocities;
-	EXPECT_TRUE((arr+velocities.get_velocities()).norm() < 1e-4);
+  velocities = vec - velocities;
+  EXPECT_TRUE((arr + velocities.get_velocities()).norm() < 1e-4);
 }
 
-TEST(TestTorquesOperatorsWithEigen, PositiveNos)
-{
-	Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-	StateRepresentation::JointTorques torques("test", 6);
-	torques = vec;
-	EXPECT_TRUE((vec-torques.get_torques()).norm() < 1e-4);
-	torques = vec.array();
-	EXPECT_TRUE((vec-torques.get_torques()).norm() < 1e-4);
+TEST(TestTorquesOperatorsWithEigen, PositiveNos) {
+  Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
+  StateRepresentation::JointTorques torques("test", 6);
+  torques = vec;
+  EXPECT_TRUE((vec - torques.get_torques()).norm() < 1e-4);
+  torques = vec.array();
+  EXPECT_TRUE((vec - torques.get_torques()).norm() < 1e-4);
 
-	torques += vec;
-	EXPECT_TRUE((2 * vec-torques.get_torques()).norm() < 1e-4);
+  torques += vec;
+  EXPECT_TRUE((2 * vec - torques.get_torques()).norm() < 1e-4);
 
-	Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
-	torques = torques + arr;
+  Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
+  torques = torques + arr;
 
-	EXPECT_TRUE(((2 * vec + arr)-torques.get_torques()).norm() < 1e-4);
+  EXPECT_TRUE(((2 * vec + arr) - torques.get_torques()).norm() < 1e-4);
 
-	torques = arr + torques;
-	EXPECT_TRUE(((2 * vec + 2 * arr)-torques.get_torques()).norm() < 1e-4);
+  torques = arr + torques;
+  EXPECT_TRUE(((2 * vec + 2 * arr) - torques.get_torques()).norm() < 1e-4);
 
-	torques -= arr;
-	EXPECT_TRUE(((2 * vec + arr)-torques.get_torques()).norm() < 1e-4);
+  torques -= arr;
+  EXPECT_TRUE(((2 * vec + arr) - torques.get_torques()).norm() < 1e-4);
 
-	torques = torques - vec;
-	EXPECT_TRUE(((vec + arr)-torques.get_torques()).norm() < 1e-4);
+  torques = torques - vec;
+  EXPECT_TRUE(((vec + arr) - torques.get_torques()).norm() < 1e-4);
 
-	torques = vec - torques;
-	EXPECT_TRUE((arr+torques.get_torques()).norm() < 1e-4);
+  torques = vec - torques;
+  EXPECT_TRUE((arr + torques.get_torques()).norm() < 1e-4);
 }
 
-int main(int argc, char **argv) {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -67,64 +67,6 @@ TEST(MultiplyByArray, PositiveNos) {
   }
 }
 
-TEST(TestVelocitiesOperatorsWithEigen, PositiveNos) {
-  Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-  StateRepresentation::JointVelocities velocities("test", 6);
-  velocities = vec;
-  EXPECT_TRUE((vec - velocities.get_velocities()).norm() < 1e-4);
-  velocities = vec.array();
-  EXPECT_TRUE((vec - velocities.get_velocities()).norm() < 1e-4);
-
-  velocities += vec;
-  EXPECT_TRUE((2 * vec - velocities.get_velocities()).norm() < 1e-4);
-
-  Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
-  velocities = velocities + arr;
-
-  EXPECT_TRUE(((2 * vec + arr) - velocities.get_velocities()).norm() < 1e-4);
-
-  velocities = arr + velocities;
-  EXPECT_TRUE(((2 * vec + 2 * arr) - velocities.get_velocities()).norm() < 1e-4);
-
-  velocities -= arr;
-  EXPECT_TRUE(((2 * vec + arr) - velocities.get_velocities()).norm() < 1e-4);
-
-  velocities = velocities - vec;
-  EXPECT_TRUE(((vec + arr) - velocities.get_velocities()).norm() < 1e-4);
-
-  velocities = vec - velocities;
-  EXPECT_TRUE((arr + velocities.get_velocities()).norm() < 1e-4);
-}
-
-TEST(TestTorquesOperatorsWithEigen, PositiveNos) {
-  Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-  StateRepresentation::JointTorques torques("test", 6);
-  torques = vec;
-  EXPECT_TRUE((vec - torques.get_torques()).norm() < 1e-4);
-  torques = vec.array();
-  EXPECT_TRUE((vec - torques.get_torques()).norm() < 1e-4);
-
-  torques += vec;
-  EXPECT_TRUE((2 * vec - torques.get_torques()).norm() < 1e-4);
-
-  Eigen::Matrix<double, 6, 1> arr = Eigen::Matrix<double, 6, 1>::Random();
-  torques = torques + arr;
-
-  EXPECT_TRUE(((2 * vec + arr) - torques.get_torques()).norm() < 1e-4);
-
-  torques = arr + torques;
-  EXPECT_TRUE(((2 * vec + 2 * arr) - torques.get_torques()).norm() < 1e-4);
-
-  torques -= arr;
-  EXPECT_TRUE(((2 * vec + arr) - torques.get_torques()).norm() < 1e-4);
-
-  torques = torques - vec;
-  EXPECT_TRUE(((vec + arr) - torques.get_torques()).norm() < 1e-4);
-
-  torques = vec - torques;
-  EXPECT_TRUE((arr + torques.get_torques()).norm() < 1e-4);
-}
-
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Again a massive PR, sorry for that. But essentially it is doing exactly the same as the refactor of CartesianState. This includes:

- correct indentations and code style according to standards
- move the operators to the JointState class
- clean all subclass operators to avoid code duplication
- remove all operators with plain Eigen vectors as those where confusing

For the operator* with a matrix of gains, the behavior is slightly different from what it used to be. By default, a JointState multiplied by a gain matrix now applies the gain to all joints and state variables (positions, velocities, accelerations and torques)  using Matrix multiplication. Hence, expected dimensions of the gain matrix is now (nb_joints*4 x nb_joints*4). One can use the multiplication with an Eigen Array to consider the diagonal elements only. For subclasses, the gain matrix is expected to be applied only on the relevant state variable of the class. Hence, expected dimensions of the gain matrix is (nb_joints x nb_joints) in that case.