### PR TITLE
Refactor dynamical systems

### DIFF
--- a/source/dynamical_systems/include/dynamical_systems/Blending.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Blending.hpp
@@ -7,166 +7,151 @@
 #pragma once
 
 #include "dynamical_systems/DynamicalSystem.hpp"
-#include "state_representation/Space/Cartesian/CartesianState.hpp"
-#include "state_representation/Space/Cartesian/CartesianPose.hpp"
-#include "state_representation/Space/Cartesian/CartesianTwist.hpp"
-#include "state_representation/Robot/JointState.hpp"
 #include "dynamical_systems/Exceptions/NotImplementedException.hpp"
+#include "state_representation/Robot/JointState.hpp"
+#include "state_representation/Space/Cartesian/CartesianPose.hpp"
+#include "state_representation/Space/Cartesian/CartesianState.hpp"
+#include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 
-namespace DynamicalSystems
-{
-	/**
-	 * @class Blended
-	 * @brief Represent a blend of several dynamical systems where the output is the weighted sum of the output of each system
-	 * @tparam S the type of space of the dynamical system (e.g. Cartesian or Joint)
-	 */
-	template<class S>
-	class Blending: public DynamicalSystem<S>
-	{
-	private:
-		std::vector<std::shared_ptr<DynamicalSystem<S>>> systems_; ///< pointer to the individual systmes
-		std::shared_ptr<StateRepresentation::Parameter<std::vector<double>>> weights_; ///< weights of each system
+namespace DynamicalSystems {
+/**
+ * @class Blended
+ * @brief Represent a blend of several dynamical systems where the output is the weighted sum of the output of each system
+ * @tparam S the type of space of the dynamical system (e.g. Cartesian or Joint)
+ */
+template <class S>
+class Blending : public DynamicalSystem<S> {
+private:
+  std::vector<std::shared_ptr<DynamicalSystem<S>>> systems_;                    ///< pointer to the individual systmes
+  std::shared_ptr<StateRepresentation::Parameter<std::vector<double>>> weights_;///< weights of each system
 
-		/**
-		 * @brief Normalize the weight vector
-		 */
-		void normalize_weights();
+  /**
+   * @brief Normalize the weight vector
+   */
+  void normalize_weights();
 
-	protected:
-		/**
-		 * @brief Compute the dynamics of the input state.
-		 * Internal function, to be redefined based on the 
-		 * type of dynamical system, called by the evaluate
-		 * function
-		 * @param state the input state
-		 * @return the output state
-		 */
-		const S compute_dynamics(const S& state) const;
+protected:
+  /**
+   * @brief Compute the dynamics of the input state.
+   * Internal function, to be redefined based on the
+   * type of dynamical system, called by the evaluate
+   * function
+   * @param state the input state
+   * @return the output state
+   */
+  S compute_dynamics(const S& state) const;
 
-	public:
-		/**
-		 * @brief Empty coinstructor 
-		 */
-		explicit Blending();
+public:
+  /**
+   * @brief Empty coinstructor
+   */
+  explicit Blending();
 
-		/**
-		 * @brief Getter of the dynamical system vector
-		 * @return the dynamical system vector
-		 */
-		const std::vector<std::shared_ptr<DynamicalSystem<S>>>& get_dynamical_systems() const;
+  /**
+   * @brief Getter of the dynamical system vector
+   * @return the dynamical system vector
+   */
+  const std::vector<std::shared_ptr<DynamicalSystem<S>>>& get_dynamical_systems() const;
 
-		/**
-		 * @brief Getter of the dynamical system at desired index
-		 * @param idx the index of the dynamical system
-		 * @return the desired dynamical system
-		 */
-		const std::shared_ptr<DynamicalSystem<S>> get_dynamical_systems(unsigned int idx) const;
+  /**
+   * @brief Getter of the dynamical system at desired index
+   * @param idx the index of the dynamical system
+   * @return the desired dynamical system
+   */
+  const std::shared_ptr<DynamicalSystem<S>>& get_dynamical_systems(unsigned int idx) const;
 
-		/**
-		 * @brief Add a dynamical system to the blending
-		 * @param ds the dynamical system to add
-		 * @weight the weight associated to the ds
-		 * @normalize_weights if true normalize the weight vector after adding the system
-		 */
-		void add_dynamical_system(const std::shared_ptr<DynamicalSystem<S>> ds, double weight, bool normalize_weights=true);
+  /**
+   * @brief Add a dynamical system to the blending
+   * @param ds the dynamical system to add
+   * @weight the weight associated to the ds
+   * @normalize_weights if true normalize the weight vector after adding the system
+   */
+  void add_dynamical_system(const std::shared_ptr<DynamicalSystem<S>> ds, double weight, bool normalize_weights = true);
 
-		/**
-		 * @brief Add several dynamical system to the blending
-		 * @param ds the dynamical systems to add
-		 * @param weights the weight associated to the ds
-		 * @normalize_weights if true normalize the weight vector after adding the system
-		 */
-		void add_dynamical_systems(const std::vector<std::shared_ptr<DynamicalSystem<S>>>& ds, const std::vector<double>& weight, bool normalize_weights=true);
-	
-		/**
-		 * @brief Set the weight of the dynamical system at desired index
-		 * @param idx index of the dynamical system
-		 * @param weight the new weight value
-		 * @normalize_weights if true normalize the weight vector after adding the system
-		 */
-		void set_weight(unsigned int idx, double weight, bool normalize_weights=true);
+  /**
+   * @brief Add several dynamical system to the blending
+   * @param ds the dynamical systems to add
+   * @param weights the weight associated to the ds
+   * @normalize_weights if true normalize the weight vector after adding the system
+   */
+  void add_dynamical_systems(const std::vector<std::shared_ptr<DynamicalSystem<S>>>& ds, const std::vector<double>& weight, bool normalize_weights = true);
 
-		/**
-		 * @brief Set the weights of the dynamical system at desired indexes
-		 * @param idx indexes of the dynamical system
-		 * @param weights the new weight value
-		 * @normalize_weights if true normalize the weight vector after adding the system
-		 */
-		void set_weights(const std::vector<unsigned int>& idx, const std::vector<double>& weights, bool normalize_weights=true);
-	};
+  /**
+   * @brief Set the weight of the dynamical system at desired index
+   * @param idx index of the dynamical system
+   * @param weight the new weight value
+   * @normalize_weights if true normalize the weight vector after adding the system
+   */
+  void set_weight(unsigned int idx, double weight, bool normalize_weights = true);
 
-	template <class S>
-	Blending<S>::Blending():
-	DynamicalSystem<S>()
-	{}
+  /**
+   * @brief Set the weights of the dynamical system at desired indexes
+   * @param idx indexes of the dynamical system
+   * @param weights the new weight value
+   * @normalize_weights if true normalize the weight vector after adding the system
+   */
+  void set_weights(const std::vector<unsigned int>& idx, const std::vector<double>& weights, bool normalize_weights = true);
+};
 
-	template <class S>
-	void Blending<S>::normalize_weights()
-	{
-		double mod = 0.0;
-    	for (const auto& w: this->weights_->get_value()) mod += w * w;
-    	double mag = std::sqrt(mod);
-    	for (auto& w: this->weights_->get_value()) w /= mag;
-	}
+template <class S>
+Blending<S>::Blending() : DynamicalSystem<S>() {}
 
-	template <class S>
-	inline const std::vector<std::shared_ptr<DynamicalSystem<S>>>& Blending<S>::get_dynamical_systems() const
-	{
-		return this->systems_;
-	}
-
-	template <class S>
-	const std::shared_ptr<DynamicalSystem<S>> Blending<S>::get_dynamical_systems(unsigned int idx) const
-	{
-		return this->systems_[idx];
-	}
-
-	template <class S>
-	void Blending<S>::add_dynamical_system(const std::shared_ptr<DynamicalSystem<S>> ds, double weight, bool normalize_weights=true)
-	{
-		this->systems_.push_back(ds);
-		this->weights_->get_value().push_back(weight);
-		if (normalize_weights) this->normalize_weights();
-	}
-
-	template <class S>
-	void Blending<S>::add_dynamical_systems(const std::vector<std::shared_ptr<DynamicalSystem<S>>>& ds, const std::vector<double>& weights, bool normalize_weights=true)
-	{
-		if (ds.size() != weights.size()) throw IncompatibleSizeException("The dynamical system and the weight vector have different sizes");
-		for (unsigned int i=0; i<ds.size(); ++i)
-		{
-			this->systems_.push_back(ds);
-			this->weights_->get_value().push_back(weight);
-		}
-		if (normalize_weights) this->normalize_weights();
-	}
-
-	template <class S>
-	void Blending<S>::set_weight(unsigned int idx, double weight, bool normalize_weights=true)
-	{
-		this->weights_->get_value()[idx] = weight;
-		if (normalize_weights) this->normalize_weights();
-	}
-
-	template <class S>
-	void Blending<S>::set_weights(const std::vector<unsigned int>& idx, const std::vector<double>& weights, bool normalize_weights=true)
-	{
-		if (idx.size() != weights.size()) throw IncompatibleSizeException("The index vector and the weight vector have different sizes");
-		for (unsigned int i=0; i<idx.size(); ++i)
-		{
-			this->weights_->get_value()[idx[i]] = weights[i];
-		}
-		if (normalize_weights) this->normalize_weights();
-	}
-
-	template <class S>
-	const S Blending<S>::compute_dynamics(const S& state) const
-	{
-		S output;
-		for (unsigned int i=0; i<ds.size(); ++i)
-		{
-			S += (this->weights_->get_value()[i] * this->systems_[i]->evaluate(state));
-		}
-		return output;
-	}
+template <class S>
+void Blending<S>::normalize_weights() {
+  double mod = 0.0;
+  for (const auto& w : this->weights_->get_value()) mod += w * w;
+  double mag = std::sqrt(mod);
+  for (auto& w : this->weights_->get_value()) w /= mag;
 }
+
+template <class S>
+inline const std::vector<std::shared_ptr<DynamicalSystem<S>>>& Blending<S>::get_dynamical_systems() const {
+  return this->systems_;
+}
+
+template <class S>
+const std::shared_ptr<DynamicalSystem<S>>& Blending<S>::get_dynamical_systems(unsigned int idx) const {
+  return this->systems_[idx];
+}
+
+template <class S>
+void Blending<S>::add_dynamical_system(const std::shared_ptr<DynamicalSystem<S>> ds, double weight, bool normalize_weights = true) {
+  this->systems_.push_back(ds);
+  this->weights_->get_value().push_back(weight);
+  if (normalize_weights) this->normalize_weights();
+}
+
+template <class S>
+void Blending<S>::add_dynamical_systems(const std::vector<std::shared_ptr<DynamicalSystem<S>>>& ds, const std::vector<double>& weights, bool normalize_weights = true) {
+  if (ds.size() != weights.size()) throw IncompatibleSizeException("The dynamical system and the weight vector have different sizes");
+  for (unsigned int i = 0; i < ds.size(); ++i) {
+    this->systems_.push_back(ds);
+    this->weights_->get_value().push_back(weight);
+  }
+  if (normalize_weights) this->normalize_weights();
+}
+
+template <class S>
+void Blending<S>::set_weight(unsigned int idx, double weight, bool normalize_weights = true) {
+  this->weights_->get_value()[idx] = weight;
+  if (normalize_weights) this->normalize_weights();
+}
+
+template <class S>
+void Blending<S>::set_weights(const std::vector<unsigned int>& idx, const std::vector<double>& weights, bool normalize_weights = true) {
+  if (idx.size() != weights.size()) throw IncompatibleSizeException("The index vector and the weight vector have different sizes");
+  for (unsigned int i = 0; i < idx.size(); ++i) {
+    this->weights_->get_value()[idx[i]] = weights[i];
+  }
+  if (normalize_weights) this->normalize_weights();
+}
+
+template <class S>
+const S Blending<S>::compute_dynamics(const S& state) const {
+  S output;
+  for (unsigned int i = 0; i < ds.size(); ++i) {
+    S += (this->weights_->get_value()[i] * this->systems_[i]->evaluate(state));
+  }
+  return output;
+}
+}// namespace DynamicalSystems

--- a/source/dynamical_systems/include/dynamical_systems/Circular.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Circular.hpp
@@ -5,14 +5,14 @@
 
 #pragma once
 
+#include "dynamical_systems/DynamicalSystem.hpp"
+#include "state_representation/Geometry/Ellipsoid.hpp"
+#include "state_representation/Parameters/Parameter.hpp"
+#include "state_representation/Space/Cartesian/CartesianPose.hpp"
+#include "state_representation/Space/Cartesian/CartesianState.hpp"
+#include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 #include <cmath>
 #include <vector>
-#include "dynamical_systems/DynamicalSystem.hpp"
-#include "state_representation/Parameters/Parameter.hpp"
-#include "state_representation/Space/Cartesian/CartesianState.hpp"
-#include "state_representation/Space/Cartesian/CartesianPose.hpp"
-#include "state_representation/Space/Cartesian/CartesianTwist.hpp"
-#include "state_representation/Geometry/Ellipsoid.hpp"
 
 namespace DynamicalSystems {
 /**
@@ -22,13 +22,13 @@ namespace DynamicalSystems {
 class Circular : public DynamicalSystem<StateRepresentation::CartesianState> {
 private:
   std::shared_ptr<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>
-      limit_cycle_; ///< limit_cycle of the dynamical system
+      limit_cycle_;///< limit_cycle of the dynamical system
   std::shared_ptr<StateRepresentation::Parameter<double>>
-      planar_gain_; ///< gain associate to the system in the plane of the circle
+      planar_gain_;///< gain associate to the system in the plane of the circle
   std::shared_ptr<StateRepresentation::Parameter<double>>
-      normal_gain_; ///< gain associate to the system normal to the plane of the circle
+      normal_gain_;///< gain associate to the system normal to the plane of the circle
   std::shared_ptr<StateRepresentation::Parameter<double>>
-      circular_velocity_; ///< velocity at wich to navigate the limit cycle
+      circular_velocity_;///< velocity at wich to navigate the limit cycle
 
 protected:
   /**
@@ -39,7 +39,7 @@ protected:
    * @param state the input state
    * @return the output state
    */
-  const StateRepresentation::CartesianState compute_dynamics(const StateRepresentation::CartesianState& state) const;
+  StateRepresentation::CartesianState compute_dynamics(const StateRepresentation::CartesianState& state) const;
 
 public:
   /**
@@ -163,7 +163,7 @@ public:
    * @brief Return a list of all the parameters of the dynamical system
    * @return the list of parameters
    */
-  const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const override;
+  std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const override;
 };
 
 inline const StateRepresentation::CartesianPose& Circular::get_center() const {
@@ -230,4 +230,4 @@ inline const StateRepresentation::Ellipsoid& Circular::get_limit_cycle() const {
 inline void Circular::set_limit_cycle(const StateRepresentation::Ellipsoid& limit_cycle) {
   this->limit_cycle_->set_value(limit_cycle);
 }
-}
+}// namespace DynamicalSystems

--- a/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
@@ -29,7 +29,7 @@ protected:
    * @param state the input state
    * @return the output state
    */
-  virtual const S compute_dynamics(const S& state) const = 0;
+  virtual S compute_dynamics(const S& state) const = 0;
 
 public:
   /**
@@ -48,13 +48,13 @@ public:
    * @param state state at wich to perform the evaluation
    * @return the state (velocity) to move toward the attractor
    */
-  const S evaluate(const S& state) const;
+  S evaluate(const S& state) const;
 
   /**
    * @brief Return a list of all the parameters of the dynamical system
    * @return the list of parameters
    */
-  virtual const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
+  virtual std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
 
   const S& get_reference_frame() const;
 
@@ -65,7 +65,7 @@ template <class S>
 DynamicalSystem<S>::DynamicalSystem(const S& reference_frame) : reference_frame_(reference_frame) {}
 
 template <class S>
-const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> DynamicalSystem<S>::get_parameters() const {
+std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> DynamicalSystem<S>::get_parameters() const {
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
   return param_list;
 }

--- a/source/dynamical_systems/include/dynamical_systems/Linear.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Linear.hpp
@@ -7,128 +7,122 @@
 #pragma once
 
 #include "dynamical_systems/DynamicalSystem.hpp"
-#include "state_representation/Parameters/Parameter.hpp"
-#include "state_representation/Space/Cartesian/CartesianState.hpp"
-#include "state_representation/Space/Cartesian/CartesianPose.hpp"
-#include "state_representation/Space/Cartesian/CartesianTwist.hpp"
-#include "state_representation/Robot/JointState.hpp"
-#include "state_representation/Robot/JointPositions.hpp"
 #include "dynamical_systems/Exceptions/IncompatibleSizeException.hpp"
+#include "state_representation/Parameters/Parameter.hpp"
+#include "state_representation/Robot/JointPositions.hpp"
+#include "state_representation/Robot/JointState.hpp"
+#include "state_representation/Space/Cartesian/CartesianPose.hpp"
+#include "state_representation/Space/Cartesian/CartesianState.hpp"
+#include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 
-namespace DynamicalSystems
-{
-	/**
-	 * @class Linear
-	 * @brief Represent a Linear dynamical system to move toward an attractor
-	 * @tparam S the type of space of the dynamical system (e.g. Cartesian or Joint)
-	 */
-	template<class S>
-	class Linear: public DynamicalSystem<S>
-	{
-	private:
-		std::shared_ptr<StateRepresentation::Parameter<S>> attractor_; ///< attractor of the dynamical system in the space
-		std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>> gain_; ///< gain associate to the system
-	
-	protected:
-		/**
-		 * @brief Compute the dynamics of the input state.
-		 * Internal function, to be redefined based on the 
-		 * type of dynamical system, called by the evaluate
-		 * function
-		 * @param state the input state
-		 * @return the output state
-		 */
-		const S compute_dynamics(const S& state) const;
+namespace DynamicalSystems {
+/**
+ * @class Linear
+ * @brief Represent a Linear dynamical system to move toward an attractor
+ * @tparam S the type of space of the dynamical system (e.g. Cartesian or Joint)
+ */
+template <class S>
+class Linear : public DynamicalSystem<S> {
+private:
+  std::shared_ptr<StateRepresentation::Parameter<S>> attractor_;         ///< attractor of the dynamical system in the space
+  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>> gain_;///< gain associate to the system
 
-	public:
-		/**
-		 * @brief Constructor with specified attractor and iso gain
-		 * @param attractor the attractor of the linear system
-		 * @param iso_gain the iso gain of the system
-		 */
-		explicit Linear(const S& attractor, double iso_gain=1.0);
+protected:
+  /**
+   * @brief Compute the dynamics of the input state.
+   * Internal function, to be redefined based on the
+   * type of dynamical system, called by the evaluate
+   * function
+   * @param state the input state
+   * @return the output state
+   */
+  S compute_dynamics(const S& state) const;
 
-		/**
-		 * @brief Constructor with specified attractor and different gains specified as diagonal coefficients
-		 * @param attractor the attractor of the linear system
-		 * @param diagonal_coefficients the gains values specified as diagonal coefficients
-		 */
-		explicit Linear(const S& attractor, const std::vector<double>& diagonal_coefficients);
+public:
+  /**
+   * @brief Constructor with specified attractor and iso gain
+   * @param attractor the attractor of the linear system
+   * @param iso_gain the iso gain of the system
+   */
+  explicit Linear(const S& attractor, double iso_gain = 1.0);
 
-		/**
-		 * @brief Constructor with specified attractor and different gains specified as full gain matrix
-		 * @param attractor the attractor of the linear system
-		 * @param gain_matrix the gains values specified as a full matrix
-		 */
-		explicit Linear(const S& attractor, const Eigen::MatrixXd& gain_matrix);
+  /**
+   * @brief Constructor with specified attractor and different gains specified as diagonal coefficients
+   * @param attractor the attractor of the linear system
+   * @param diagonal_coefficients the gains values specified as diagonal coefficients
+   */
+  explicit Linear(const S& attractor, const std::vector<double>& diagonal_coefficients);
 
-		/**
-		 * @brief Getter of the attractor
-		 * @return the attractor as a const reference
-		 */
-		const S& get_attractor() const;
+  /**
+   * @brief Constructor with specified attractor and different gains specified as full gain matrix
+   * @param attractor the attractor of the linear system
+   * @param gain_matrix the gains values specified as a full matrix
+   */
+  explicit Linear(const S& attractor, const Eigen::MatrixXd& gain_matrix);
 
-		/**
-		 * @brief Setter of the attractor as a new value
-		 * @param attractor the new attractor
-		 */
-		void set_attractor(const S& attractor);
+  /**
+   * @brief Getter of the attractor
+   * @return the attractor as a const reference
+   */
+  const S& get_attractor() const;
 
-		/**
-		 * @brief Getter of the gain attribute
-		 * @return The gain value 
-		 */
-		const Eigen::MatrixXd& get_gain() const;
+  /**
+   * @brief Setter of the attractor as a new value
+   * @param attractor the new attractor
+   */
+  void set_attractor(const S& attractor);
 
-		/**
-		 * @brief Setter of the gain attribute
-		 * @param iso_gain the gain value as an iso coefficient
-		 */
-		void set_gain(double iso_gain);
+  /**
+   * @brief Getter of the gain attribute
+   * @return The gain value
+   */
+  const Eigen::MatrixXd& get_gain() const;
 
-		/**
-		 * @brief Setter of the gain attribute
-		 * @param diagonal_coefficients the gain values as diagonal coefficients
-		 */
-		void set_gain(const std::vector<double>& diagonal_coefficients);
+  /**
+   * @brief Setter of the gain attribute
+   * @param iso_gain the gain value as an iso coefficient
+   */
+  void set_gain(double iso_gain);
 
-		/**
-		 * @brief Setter of the gain attribute
-		 * @param gain_matrix the gain values as a full gain matrix
-		 */
-		void set_gain(const Eigen::MatrixXd& gain_matrix);
+  /**
+   * @brief Setter of the gain attribute
+   * @param diagonal_coefficients the gain values as diagonal coefficients
+   */
+  void set_gain(const std::vector<double>& diagonal_coefficients);
 
-		/**
-		 * @brief Return a list of all the parameters of the dynamical system
-		 * @return the list of parameters
-		 */
-		const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
-	};
+  /**
+   * @brief Setter of the gain attribute
+   * @param gain_matrix the gain values as a full gain matrix
+   */
+  void set_gain(const Eigen::MatrixXd& gain_matrix);
 
-	template<class S>
-	inline const S& Linear<S>::get_attractor() const
-	{
-		return this->attractor_->get_value();
-	}
+  /**
+   * @brief Return a list of all the parameters of the dynamical system
+   * @return the list of parameters
+   */
+  std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
+};
 
-	template<class S>
-	inline void Linear<S>::set_attractor(const S& attractor)
-	{
-		this->attractor_->set_value(attractor);
-	}
-
-	template<class S>
-	inline const Eigen::MatrixXd& Linear<S>::get_gain() const
-	{
-		return this->gain_->get_value();
-	}
-
-	template<class S>
-	const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Linear<S>::get_parameters() const
-	{
-		std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
-		param_list.push_back(this->attractor_);
-		param_list.push_back(this->gain_);
-		return param_list;
-	}
+template <class S>
+inline const S& Linear<S>::get_attractor() const {
+  return this->attractor_->get_value();
 }
+
+template <class S>
+inline void Linear<S>::set_attractor(const S& attractor) {
+  this->attractor_->set_value(attractor);
+}
+
+template <class S>
+inline const Eigen::MatrixXd& Linear<S>::get_gain() const {
+  return this->gain_->get_value();
+}
+
+template <class S>
+std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Linear<S>::get_parameters() const {
+  std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
+  param_list.push_back(this->attractor_);
+  param_list.push_back(this->gain_);
+  return param_list;
+}
+}// namespace DynamicalSystems

--- a/source/dynamical_systems/src/Circular.cpp
+++ b/source/dynamical_systems/src/Circular.cpp
@@ -4,28 +4,26 @@ namespace DynamicalSystems {
 Circular::Circular(const StateRepresentation::CartesianState& center,
                    double radius,
                    double gain,
-                   double circular_velocity) :
-    DynamicalSystem(StateRepresentation::CartesianPose::Identity(center.get_reference_frame())),
-    limit_cycle_(std::make_shared < StateRepresentation::Parameter < StateRepresentation::Ellipsoid >> ("limit_cycle",
-        StateRepresentation::Ellipsoid(center.get_name(), center.get_reference_frame()))),
-    planar_gain_(std::make_shared < StateRepresentation::Parameter < double >> ("planar_gain", gain)),
-    normal_gain_(std::make_shared < StateRepresentation::Parameter < double >> ("normal_gain", gain)),
-    circular_velocity_(std::make_shared < StateRepresentation::Parameter < double >> ("circular_velocity",
-        circular_velocity)) {
+                   double circular_velocity) : DynamicalSystem(StateRepresentation::CartesianPose::Identity(center.get_reference_frame())),
+                                               limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>("limit_cycle",
+                                                                                                                                             StateRepresentation::Ellipsoid(center.get_name(), center.get_reference_frame()))),
+                                               planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("planar_gain", gain)),
+                                               normal_gain_(std::make_shared<StateRepresentation::Parameter<double>>("normal_gain", gain)),
+                                               circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
+                                                                                                                           circular_velocity)) {
   this->limit_cycle_->get_value().set_center_state(center);
   this->limit_cycle_->get_value().set_axis_lengths({radius, radius});
 }
 
-Circular::Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gain, double circular_velocity) :
-    DynamicalSystem(StateRepresentation::CartesianPose::Identity(limit_cycle.get_center_pose().get_reference_frame())),
-    limit_cycle_(std::make_shared < StateRepresentation::Parameter < StateRepresentation::Ellipsoid >> ("limit_cycle",
-        limit_cycle)),
-    planar_gain_(std::make_shared < StateRepresentation::Parameter < double >> ("planar_gain", gain)),
-    normal_gain_(std::make_shared < StateRepresentation::Parameter < double >> ("normal_gain", gain)),
-    circular_velocity_(std::make_shared < StateRepresentation::Parameter < double >> ("circular_velocity",
-        circular_velocity)) {}
+Circular::Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gain, double circular_velocity) : DynamicalSystem(StateRepresentation::CartesianPose::Identity(limit_cycle.get_center_pose().get_reference_frame())),
+                                                                                                               limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>("limit_cycle",
+                                                                                                                                                                                                             limit_cycle)),
+                                                                                                               planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("planar_gain", gain)),
+                                                                                                               normal_gain_(std::make_shared<StateRepresentation::Parameter<double>>("normal_gain", gain)),
+                                                                                                               circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
+                                                                                                                                                                                           circular_velocity)) {}
 
-const StateRepresentation::CartesianState Circular::compute_dynamics(const StateRepresentation::CartesianState& state) const {
+StateRepresentation::CartesianState Circular::compute_dynamics(const StateRepresentation::CartesianState& state) const {
   // put the point in the reference of the center
   StateRepresentation::CartesianPose pose = static_cast<const StateRepresentation::CartesianPose&>(state);
   pose = this->get_limit_cycle().get_rotation().inverse() * this->get_center().inverse() * pose;
@@ -53,7 +51,7 @@ const StateRepresentation::CartesianState Circular::compute_dynamics(const State
   return velocity;
 }
 
-const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Circular::get_parameters() const {
+std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Circular::get_parameters() const {
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
   param_list.push_back(this->limit_cycle_);
   param_list.push_back(this->planar_gain_);
@@ -61,4 +59,4 @@ const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Circul
   param_list.push_back(this->circular_velocity_);
   return param_list;
 }
-}
+}// namespace DynamicalSystems

--- a/source/dynamical_systems/src/DynamicalSystem.cpp
+++ b/source/dynamical_systems/src/DynamicalSystem.cpp
@@ -1,44 +1,35 @@
 #include "dynamical_systems/DynamicalSystem.hpp"
 #include "state_representation/Robot/JointState.hpp"
-#include "state_representation/Space/Cartesian/CartesianState.hpp"
 #include "state_representation/Space/Cartesian/CartesianPose.hpp"
+#include "state_representation/Space/Cartesian/CartesianState.hpp"
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 
 using namespace StateRepresentation;
 
-namespace DynamicalSystems
-{
-	template<class S>
-	DynamicalSystem<S>::DynamicalSystem()
-	{}
+namespace DynamicalSystems {
+template <class S>
+DynamicalSystem<S>::DynamicalSystem() {}
 
-	template DynamicalSystem<JointState>::DynamicalSystem();
+template DynamicalSystem<JointState>::DynamicalSystem();
 
-	template <>
-	DynamicalSystem<CartesianState>::DynamicalSystem():
-	reference_frame_(CartesianPose::Identity("world"))
-	{}
+template <>
+DynamicalSystem<CartesianState>::DynamicalSystem() : reference_frame_(CartesianPose::Identity("world")) {}
 
-	template <class S>
-	const S DynamicalSystem<S>::evaluate(const S& state) const
-	{
-		return this->compute_dynamics(state);
-	}
-
-	template const JointState DynamicalSystem<JointState>::evaluate(const JointState& state) const;
-
-	template <>
-	const CartesianState DynamicalSystem<CartesianState>::evaluate(const CartesianState& state) const
-	{
-		if (this->get_reference_frame().get_name() != state.get_reference_frame())
-		{
-			CartesianState result = this->get_reference_frame().inverse() * state;
-			result = this->compute_dynamics(result);
-			return this->get_reference_frame() * result;
-		}
-		else
-		{
-			return this->compute_dynamics(state);
-		}
-	}
+template <class S>
+S DynamicalSystem<S>::evaluate(const S& state) const {
+  return this->compute_dynamics(state);
 }
+
+template JointState DynamicalSystem<JointState>::evaluate(const JointState& state) const;
+
+template <>
+CartesianState DynamicalSystem<CartesianState>::evaluate(const CartesianState& state) const {
+  if (this->get_reference_frame().get_name() != state.get_reference_frame()) {
+    CartesianState result = this->get_reference_frame().inverse() * state;
+    result = this->compute_dynamics(result);
+    return this->get_reference_frame() * result;
+  } else {
+    return this->compute_dynamics(state);
+  }
+}
+}// namespace DynamicalSystems

--- a/source/dynamical_systems/src/Linear.cpp
+++ b/source/dynamical_systems/src/Linear.cpp
@@ -1,133 +1,106 @@
 #include "dynamical_systems/Linear.hpp"
 
-namespace DynamicalSystems
-{
-	template<>
-	inline void Linear<StateRepresentation::CartesianState>::set_gain(double iso_gain)
-	{
-		this->gain_->set_value(iso_gain * Eigen::MatrixXd::Identity(6, 6));
-	}
-
-
-	template<>
-	inline void Linear<StateRepresentation::JointState>::set_gain(double iso_gain)
-	{
-		int nb_joints = this->get_attractor().get_size();
-		this->gain_->set_value(iso_gain * Eigen::MatrixXd::Identity(nb_joints, nb_joints));
-	}
-
-	template<>
-	inline void Linear<StateRepresentation::CartesianState>::set_gain(const std::vector<double>& diagonal_coefficients)
-	{
-		if(diagonal_coefficients.size() != 6)
-		{
-			throw Exceptions::IncompatibleSizeException("The provided diagonal coefficients do not correspond to the expected size of 6 elements");
-		}
-		Eigen::VectorXd diagonal = Eigen::VectorXd::Map(diagonal_coefficients.data(), 6);
-		this->gain_->set_value(diagonal.asDiagonal());
-	}
-
-	template<>
-	inline void Linear<StateRepresentation::JointState>::set_gain(const std::vector<double>& diagonal_coefficients)
-	{
-		size_t nb_joints = this->get_attractor().get_size();
-		if(diagonal_coefficients.size() != nb_joints)
-		{
-			throw Exceptions::IncompatibleSizeException("The provided diagonal coefficients do not correspond to the expected size of " + std::to_string(nb_joints) + " elements");
-		}
-		Eigen::VectorXd diagonal = Eigen::VectorXd::Map(diagonal_coefficients.data(), nb_joints);
-		this->gain_->set_value(diagonal.asDiagonal());
-	}
-
-	template<>
-	inline void Linear<StateRepresentation::CartesianState>::set_gain(const Eigen::MatrixXd& gain_matrix)
-	{
-		if(gain_matrix.rows() != 6 && gain_matrix.cols() != 6)
-		{
-			throw Exceptions::IncompatibleSizeException("The provided gain matrix do not have the expected size of 6x6 elements");
-		}
-		this->gain_->set_value(gain_matrix);
-	}
-
-	template<>
-	inline void Linear<StateRepresentation::JointState>::set_gain(const Eigen::MatrixXd& gain_matrix)
-	{
-		int nb_joints = this->get_attractor().get_size();
-		if(gain_matrix.rows() != nb_joints && gain_matrix.cols() != nb_joints)
-		{
-			throw Exceptions::IncompatibleSizeException("The provided gain matrix do not have the expected size of " + std::to_string(nb_joints) + "x" + std::to_string(nb_joints) + " elements");
-		}
-		this->gain_->set_value(gain_matrix);
-	}
-
-	template<>
-	Linear<StateRepresentation::CartesianState>::Linear(const StateRepresentation::CartesianState& attractor, double iso_gain):
-	DynamicalSystem<StateRepresentation::CartesianState>(StateRepresentation::CartesianPose::Identity(attractor.get_reference_frame())),
-	attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::CartesianState>>(StateRepresentation::Parameter<StateRepresentation::CartesianPose>("attractor", attractor))),
-	gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain"))
-	{
-		this->set_gain(iso_gain);
-	}
-
-	template<>
-	Linear<StateRepresentation::JointState>::Linear(const StateRepresentation::JointState& attractor, double iso_gain):
-	DynamicalSystem<StateRepresentation::JointState>(),
-	attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::JointState>>(StateRepresentation::Parameter<StateRepresentation::JointPositions>("attractor", attractor))),
-	gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain"))
-	{
-		this->set_gain(iso_gain);
-	}
-
-	template<>
-	Linear<StateRepresentation::CartesianState>::Linear(const StateRepresentation::CartesianState& attractor, const std::vector<double>& diagonal_coefficients):
-	DynamicalSystem<StateRepresentation::CartesianState>(StateRepresentation::CartesianPose::Identity(attractor.get_reference_frame())),
-	attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::CartesianState>>(StateRepresentation::Parameter<StateRepresentation::CartesianPose>("attractor", attractor))),
-	gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain"))
-	{
-		this->set_gain(diagonal_coefficients);
-	}
-
-	template<>
-	Linear<StateRepresentation::JointState>::Linear(const StateRepresentation::JointState& attractor, const std::vector<double>& diagonal_coefficients):
-	DynamicalSystem<StateRepresentation::JointState>(),
-	attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::JointState>>(StateRepresentation::Parameter<StateRepresentation::JointPositions>("attractor", attractor))),
-	gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain"))
-	{
-		this->set_gain(diagonal_coefficients);
-	}
-
-	template<>
-	Linear<StateRepresentation::CartesianState>::Linear(const StateRepresentation::CartesianState& attractor, const Eigen::MatrixXd& gain_matrix):
-	DynamicalSystem<StateRepresentation::CartesianState>(StateRepresentation::CartesianPose::Identity(attractor.get_reference_frame())),
-	attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::CartesianState>>(StateRepresentation::Parameter<StateRepresentation::CartesianPose>("attractor", attractor))),
-	gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain"))
-	{
-		this->set_gain(gain_matrix);
-	}
-
-	template<>
-	Linear<StateRepresentation::JointState>::Linear(const StateRepresentation::JointState& attractor, const Eigen::MatrixXd& gain_matrix):
-	DynamicalSystem<StateRepresentation::JointState>(),
-	attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::JointState>>(StateRepresentation::Parameter<StateRepresentation::JointPositions>("attractor", attractor))),
-	gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain"))
-	{
-		this->set_gain(gain_matrix);
-	}
-
-	template<>
-	const StateRepresentation::CartesianState Linear<StateRepresentation::CartesianState>::compute_dynamics(const StateRepresentation::CartesianState& state) const
-	{
-		StateRepresentation::CartesianTwist twist = static_cast<const StateRepresentation::CartesianPose&>(this->get_attractor()) - static_cast<const StateRepresentation::CartesianPose&>(state);
-		twist *= this->get_gain();
-		return twist;
-	}
-
-	template<>
-	const StateRepresentation::JointState Linear<StateRepresentation::JointState>::compute_dynamics(const StateRepresentation::JointState& state) const
-	{
-		StateRepresentation::JointState positions = - this->get_gain() * (state - this->get_attractor());
-		StateRepresentation::JointState velocities(state.get_name(), state.get_names());
-		velocities.set_velocities(positions.get_positions());
-		return velocities;
-	}
+namespace DynamicalSystems {
+template <>
+inline void Linear<StateRepresentation::CartesianState>::set_gain(double iso_gain) {
+  this->gain_->set_value(iso_gain * Eigen::MatrixXd::Identity(6, 6));
 }
+
+template <>
+inline void Linear<StateRepresentation::JointState>::set_gain(double iso_gain) {
+  int nb_joints = this->get_attractor().get_size();
+  this->gain_->set_value(iso_gain * Eigen::MatrixXd::Identity(nb_joints, nb_joints));
+}
+
+template <>
+inline void Linear<StateRepresentation::CartesianState>::set_gain(const std::vector<double>& diagonal_coefficients) {
+  if (diagonal_coefficients.size() != 6) {
+    throw Exceptions::IncompatibleSizeException("The provided diagonal coefficients do not correspond to the expected size of 6 elements");
+  }
+  Eigen::VectorXd diagonal = Eigen::VectorXd::Map(diagonal_coefficients.data(), 6);
+  this->gain_->set_value(diagonal.asDiagonal());
+}
+
+template <>
+inline void Linear<StateRepresentation::JointState>::set_gain(const std::vector<double>& diagonal_coefficients) {
+  size_t nb_joints = this->get_attractor().get_size();
+  if (diagonal_coefficients.size() != nb_joints) {
+    throw Exceptions::IncompatibleSizeException("The provided diagonal coefficients do not correspond to the expected size of " + std::to_string(nb_joints) + " elements");
+  }
+  Eigen::VectorXd diagonal = Eigen::VectorXd::Map(diagonal_coefficients.data(), nb_joints);
+  this->gain_->set_value(diagonal.asDiagonal());
+}
+
+template <>
+inline void Linear<StateRepresentation::CartesianState>::set_gain(const Eigen::MatrixXd& gain_matrix) {
+  if (gain_matrix.rows() != 6 && gain_matrix.cols() != 6) {
+    throw Exceptions::IncompatibleSizeException("The provided gain matrix do not have the expected size of 6x6 elements");
+  }
+  this->gain_->set_value(gain_matrix);
+}
+
+template <>
+inline void Linear<StateRepresentation::JointState>::set_gain(const Eigen::MatrixXd& gain_matrix) {
+  int nb_joints = this->get_attractor().get_size();
+  if (gain_matrix.rows() != nb_joints && gain_matrix.cols() != nb_joints) {
+    throw Exceptions::IncompatibleSizeException("The provided gain matrix do not have the expected size of " + std::to_string(nb_joints) + "x" + std::to_string(nb_joints) + " elements");
+  }
+  this->gain_->set_value(gain_matrix);
+}
+
+template <>
+Linear<StateRepresentation::CartesianState>::Linear(const StateRepresentation::CartesianState& attractor, double iso_gain) : DynamicalSystem<StateRepresentation::CartesianState>(StateRepresentation::CartesianPose::Identity(attractor.get_reference_frame())),
+                                                                                                                             attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::CartesianState>>(StateRepresentation::Parameter<StateRepresentation::CartesianPose>("attractor", attractor))),
+                                                                                                                             gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain")) {
+  this->set_gain(iso_gain);
+}
+
+template <>
+Linear<StateRepresentation::JointState>::Linear(const StateRepresentation::JointState& attractor, double iso_gain) : DynamicalSystem<StateRepresentation::JointState>(),
+                                                                                                                     attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::JointState>>(StateRepresentation::Parameter<StateRepresentation::JointPositions>("attractor", attractor))),
+                                                                                                                     gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain")) {
+  this->set_gain(iso_gain);
+}
+
+template <>
+Linear<StateRepresentation::CartesianState>::Linear(const StateRepresentation::CartesianState& attractor, const std::vector<double>& diagonal_coefficients) : DynamicalSystem<StateRepresentation::CartesianState>(StateRepresentation::CartesianPose::Identity(attractor.get_reference_frame())),
+                                                                                                                                                              attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::CartesianState>>(StateRepresentation::Parameter<StateRepresentation::CartesianPose>("attractor", attractor))),
+                                                                                                                                                              gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain")) {
+  this->set_gain(diagonal_coefficients);
+}
+
+template <>
+Linear<StateRepresentation::JointState>::Linear(const StateRepresentation::JointState& attractor, const std::vector<double>& diagonal_coefficients) : DynamicalSystem<StateRepresentation::JointState>(),
+                                                                                                                                                      attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::JointState>>(StateRepresentation::Parameter<StateRepresentation::JointPositions>("attractor", attractor))),
+                                                                                                                                                      gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain")) {
+  this->set_gain(diagonal_coefficients);
+}
+
+template <>
+Linear<StateRepresentation::CartesianState>::Linear(const StateRepresentation::CartesianState& attractor, const Eigen::MatrixXd& gain_matrix) : DynamicalSystem<StateRepresentation::CartesianState>(StateRepresentation::CartesianPose::Identity(attractor.get_reference_frame())),
+                                                                                                                                                attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::CartesianState>>(StateRepresentation::Parameter<StateRepresentation::CartesianPose>("attractor", attractor))),
+                                                                                                                                                gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain")) {
+  this->set_gain(gain_matrix);
+}
+
+template <>
+Linear<StateRepresentation::JointState>::Linear(const StateRepresentation::JointState& attractor, const Eigen::MatrixXd& gain_matrix) : DynamicalSystem<StateRepresentation::JointState>(),
+                                                                                                                                        attractor_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::JointState>>(StateRepresentation::Parameter<StateRepresentation::JointPositions>("attractor", attractor))),
+                                                                                                                                        gain_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("gain")) {
+  this->set_gain(gain_matrix);
+}
+
+template <>
+StateRepresentation::CartesianState Linear<StateRepresentation::CartesianState>::compute_dynamics(const StateRepresentation::CartesianState& state) const {
+  StateRepresentation::CartesianTwist twist = static_cast<const StateRepresentation::CartesianPose&>(this->get_attractor()) - static_cast<const StateRepresentation::CartesianPose&>(state);
+  twist *= this->get_gain();
+  return twist;
+}
+
+template <>
+StateRepresentation::JointState Linear<StateRepresentation::JointState>::compute_dynamics(const StateRepresentation::JointState& state) const {
+  StateRepresentation::JointVelocities velocities = static_cast<const StateRepresentation::JointPositions&>(this->get_attractor()) - static_cast<const StateRepresentation::JointPositions&>(state);
+  velocities *= this->get_gain();
+  return velocities;
+}
+}// namespace DynamicalSystems


### PR DESCRIPTION
Final PR of this series. Correct the identation for DynamicalSystems removing const as usual.

Also, formulation for Linear in JointState was using an old syntax. It is corrected to use the same syntax as in Cartesian. With this PR, all the refactor branches behave correctly and are ready for extensive testing.