### PR TITLE
Refactor/jacobian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,4 +97,4 @@ RUN cmake -DBUILD_CONTROLLERS="${BUILD_CONTROLLERS}" \
     -DBUILD_TESTING="${BUILD_TESTING}" .. \
   && make -j all
 
-RUN make test
+RUN CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -206,13 +206,13 @@ StateRepresentation::JointVelocities Model::inverse_kinematic(const StateReprese
     // extract only the position for intermediate points
     delta_r.segment<3>(3 * i) = state.get_linear_velocity();
     jacobian.block(3 * i, 0, 3 * i + 3, nb_joints) =
-        this->compute_jacobian(joint_state, state.get_name()).get_data().block(0, 0, 3, nb_joints);
+        this->compute_jacobian(joint_state, state.get_name()).data().block(0, 0, 3, nb_joints);
   }
   // extract the orientation for the end-effector
   CartesianState state = cartesian_states.back();
   delta_r.segment<3>(3 * (cartesian_states.size() - 1)) = state.get_linear_velocity();
   delta_r.tail(3) = state.get_angular_velocity();
-  jacobian.bottomRows(6) = this->compute_jacobian(joint_state, state.get_name()).get_data();
+  jacobian.bottomRows(6) = this->compute_jacobian(joint_state, state.get_name()).data();
   // compute the Jacobian
   Eigen::MatrixXd hessian_matrix = jacobian.transpose() * jacobian;
 

--- a/source/state_representation/include/state_representation/Exceptions/EmptyStateException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/EmptyStateException.hpp
@@ -1,19 +1,11 @@
-
-
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class EmptyStateException: public std::runtime_error
-		{
-		public:
-			explicit EmptyStateException(const std::string& msg) : runtime_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class EmptyStateException : public std::runtime_error {
+public:
+  explicit EmptyStateException(const std::string& msg) : runtime_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Exceptions/IncompatibleReferenceFramesException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/IncompatibleReferenceFramesException.hpp
@@ -1,19 +1,11 @@
-
-
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class IncompatibleReferenceFramesException: public std::logic_error
-		{
-		public:
-			explicit IncompatibleReferenceFramesException(const std::string& msg) : logic_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class IncompatibleReferenceFramesException : public std::logic_error {
+public:
+  explicit IncompatibleReferenceFramesException(const std::string& msg) : logic_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Exceptions/IncompatibleSizeException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/IncompatibleSizeException.hpp
@@ -1,19 +1,11 @@
-
-
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class IncompatibleSizeException: public std::logic_error
-		{
-		public:
-			explicit IncompatibleSizeException(const std::string& msg) : logic_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class IncompatibleSizeException : public std::logic_error {
+public:
+  explicit IncompatibleSizeException(const std::string& msg) : logic_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Exceptions/IncompatibleStatesException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/IncompatibleStatesException.hpp
@@ -1,17 +1,11 @@
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class IncompatibleStatesException: public std::logic_error
-		{
-		public:
-			explicit IncompatibleStatesException(const std::string& msg) : logic_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class IncompatibleStatesException : public std::logic_error {
+public:
+  explicit IncompatibleStatesException(const std::string& msg) : logic_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Exceptions/NoSolutionToFitException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/NoSolutionToFitException.hpp
@@ -1,19 +1,11 @@
-
-
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class NoSolutionToFitException: public std::runtime_error
-		{
-		public:
-			explicit NoSolutionToFitException(const std::string& msg) : runtime_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class NoSolutionToFitException : public std::runtime_error {
+public:
+  explicit NoSolutionToFitException(const std::string& msg) : runtime_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Exceptions/NotImplementedException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/NotImplementedException.hpp
@@ -1,17 +1,11 @@
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class NotImplementedException: public std::logic_error
-		{
-		public:
-			explicit NotImplementedException(const std::string& msg) : logic_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class NotImplementedException : public std::logic_error {
+public:
+  explicit NotImplementedException(const std::string& msg) : logic_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Exceptions/UnrecognizedParameterTypeException.hpp
+++ b/source/state_representation/include/state_representation/Exceptions/UnrecognizedParameterTypeException.hpp
@@ -1,17 +1,11 @@
 #pragma once
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 
-namespace StateRepresentation
-{
-	namespace Exceptions
-	{
-		class UnrecognizedParameterTypeException: public std::logic_error
-		{
-		public:
-			explicit UnrecognizedParameterTypeException(const std::string& msg) : logic_error(msg)
-			{};
-		};
-	}
-}
+namespace StateRepresentation::Exceptions {
+class UnrecognizedParameterTypeException : public std::logic_error {
+public:
+  explicit UnrecognizedParameterTypeException(const std::string& msg) : logic_error(msg) {};
+};
+}// namespace StateRepresentation::Exceptions

--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -172,10 +172,10 @@ public:
   JointPositions copy() const;
 
   /**
-   * @brief Return the value of the positions as Eigen array
-   * @retrun the Eigen array representing the positions
+   * @brief Returns the positions data as an Eigen vector
+   * @return the positions data vector
    */
-  Eigen::ArrayXd array() const;
+  Eigen::VectorXd data() const;
 
   /**
    * @brief Overload the ostream operator for printing

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -264,6 +264,19 @@ public:
   JointState copy() const;
 
   /**
+   * @brief Returns the data as the concatenation of
+   * all the state variables in a single vector
+   * @return the concatenated data vector
+   */
+  virtual Eigen::VectorXd data() const;
+
+  /**
+   * @brief Returns the data vector as an Eigen Array
+   * @return the concatenated data array
+   */
+  Eigen::ArrayXd array() const;
+
+  /**
    * @brief Overload the += operator
    * @param state JointState to add
    * @return the current JointState added the JointState given in argument
@@ -408,7 +421,7 @@ inline void JointState::set_state_variable(Eigen::VectorXd& state_variable, cons
   if (new_value.size() != this->get_size()) {
     throw IncompatibleSizeException(
         "Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given "
-            + std::to_string(new_value.size()));
+        + std::to_string(new_value.size()));
   }
   this->set_filled();
   state_variable = new_value;

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -157,8 +157,14 @@ public:
   JointTorques copy() const;
 
   /**
-   * @brief Return the value of the torques vector as Eigen array
-   * @retrun the Eigen array representing the torques
+   * @brief Returns the torques data as an Eigen vector
+   * @return the torque data vector
+   */
+  Eigen::VectorXd data() const;
+
+  /**
+   * @brief Returns the data vector as an Eigen Array
+   * @return the torque data array
    */
   Eigen::ArrayXd array() const;
 

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -172,10 +172,10 @@ public:
   JointVelocities copy() const;
 
   /**
-   * @brief Return the value of the velocities as Eigen array
-   * @retrun the Eigen array representing the velocities
+   * @brief Returns the velocities data as an Eigen vector
+   * @return the velocities data vector
    */
-  Eigen::ArrayXd array() const;
+  Eigen::VectorXd data() const;
 
   /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
@@ -180,6 +180,12 @@ public:
   CartesianPose copy() const;
 
   /**
+   * @brief Returns the pose data as an Eigen vector
+   * @return the pose data vector
+   */
+  Eigen::VectorXd data() const;
+
+  /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to happend the string representing the CartesianPose to
    * @param CartesianPose the CartesianPose to print

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -331,6 +331,19 @@ public:
   CartesianState copy() const;
 
   /**
+   * @brief Returns the data as the concatenation of
+   * all the state variables in a single vector
+   * @return the concatenated data vector
+   */
+  virtual Eigen::VectorXd data() const;
+
+  /**
+   * @brief Returns the data vector as an Eigen Array
+   * @return the concatenated data array
+   */
+  Eigen::ArrayXd array() const;
+
+  /**
    * @brief Overload the *= operator with another state by deriving the equations of motions
    * @param state the state to compose with corresponding to b_S_c
    * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
@@ -186,10 +186,10 @@ public:
   CartesianTwist copy() const;
 
   /**
-   * @brief Return the value of the 6D twist as Eigen array
-   * @retrun the Eigen array representing the twist
+   * @brief Returns the twist data as an Eigen vector
+   * @return the twist data vector
    */
-  Eigen::Array<double, 6, 1> array() const;
+  Eigen::VectorXd data() const;
 
   /**
    * @brief Overload the ostream operator for printing

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
@@ -164,6 +164,12 @@ public:
   CartesianWrench copy() const;
 
   /**
+   * @brief Returns the wrench data as an Eigen vector
+   * @return the wrench data vector
+   */
+  Eigen::VectorXd data() const;
+
+  /**
    * @brief Return the value of the 6D wrench as Eigen array
    * @retrun the Eigen array representing the wrench
    */

--- a/source/state_representation/src/Robot/Jacobian.cpp
+++ b/source/state_representation/src/Robot/Jacobian.cpp
@@ -95,7 +95,7 @@ JointVelocities Jacobian::operator*(const CartesianTwist& twist) const {
 
 JointTorques Jacobian::operator*(const CartesianWrench& wrench) const {
   Eigen::VectorXd joint_torques = (*this) * wrench.data();
-  JointVelocities result(this->get_name(), this->get_joint_names(), joint_torques);
+  JointTorques result(this->get_name(), this->get_joint_names(), joint_torques);
   return result;
 }
 

--- a/source/state_representation/src/Robot/Jacobian.cpp
+++ b/source/state_representation/src/Robot/Jacobian.cpp
@@ -3,91 +3,118 @@
 #include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 namespace StateRepresentation {
-Jacobian::Jacobian() : State(StateType::JACOBIANMATRIX), nb_rows(6) {}
+Jacobian::Jacobian() : State(StateType::JACOBIANMATRIX), nb_rows_(6) {}
 
 Jacobian::Jacobian(const std::string& robot_name, unsigned int nb_joints) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(nb_joints) {
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(6), nb_cols_(nb_joints) {
   this->set_joint_names(nb_joints);
 }
 
 Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(6), nb_cols(joint_names.size()) {
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(6), nb_cols_(joint_names.size()) {
   this->set_joint_names(joint_names);
 }
 
 Jacobian::Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(data.cols()) {
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(data.rows()), nb_cols_(data.cols()) {
   this->set_joint_names(this->get_nb_cols());
   this->set_data(data);
 }
 
 Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names,
                    const Eigen::MatrixXd& data) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows(data.rows()), nb_cols(joint_names.size()) {
+    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(data.rows()), nb_cols_(joint_names.size()) {
   this->set_joint_names(joint_names);
   this->set_data(data);
 }
 
 Jacobian::Jacobian(const Jacobian& jacobian) :
     State(jacobian),
-    joint_names(jacobian.joint_names),
-    nb_rows(jacobian.nb_rows),
-    nb_cols(jacobian.nb_cols),
-    data(jacobian.data) {}
+    joint_names_(jacobian.joint_names_),
+    nb_rows_(jacobian.nb_rows_),
+    nb_cols_(jacobian.nb_cols_),
+    data_matrix_(jacobian.data_matrix_) {}
 
 void Jacobian::initialize() {
   this->State::initialize();
-  this->data.resize(this->nb_rows, this->nb_cols);
-  this->data.setZero();
+  this->data_matrix_.resize(this->nb_rows_, this->nb_cols_);
+  this->data_matrix_.setZero();
 }
 
-const Jacobian Jacobian::transpose() {
+Jacobian Jacobian::transpose() const {
   Jacobian result(*this);
   result.set_nb_cols(this->get_nb_rows());
   result.set_nb_rows(this->get_nb_cols());
-  result.set_data(result.get_data().transpose());
+  result.set_data(result.data().transpose());
   return result;
 }
 
-const Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const {
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (matrix.rows() != this->get_nb_cols()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
-  return this->get_data() * matrix;
+Jacobian Jacobian::inverse() const {
+  if (this->get_nb_rows() != this->get_nb_cols()) {
+    throw Exceptions::IncompatibleSizeException(
+        "The Jacobian matrix is not invertible, use the pseudoinverse function instead");
+  }
+  Jacobian result(*this);
+  result.set_nb_cols(this->get_nb_cols());
+  result.set_nb_rows(this->get_nb_rows());
+  result.set_data(result.data().inverse());
+  return result;
 }
 
-const CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
+Jacobian Jacobian::pseudoinverse() const {
+  Jacobian result(*this);
+  Eigen::MatrixXd pinv = this->data().completeOrthogonalDecomposition().pseudoInverse();
+  result.set_nb_cols(pinv.cols());
+  result.set_nb_rows(pinv.rows());
+  result.set_data(pinv);
+  return result;
+}
+
+Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const {
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
+  if (matrix.rows() != this->get_nb_cols()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
+  return this->data() * matrix;
+}
+
+CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
   if (dq.is_empty()) { throw EmptyStateException(dq.get_name() + " state is empty"); }
   if (!this->is_compatible(dq)) {
     throw IncompatibleStatesException("The Jacobian and the input JointVelocities are incompatible");
   }
-  Eigen::Matrix<double, 6, 1> twist = (*this) * dq.get_velocities();
+  Eigen::Matrix<double, 6, 1> twist = (*this) * dq.data();
   // crate a CartesianTwist with name "robot"_end_effector and reference frame "robot"_base
   CartesianTwist result(this->get_name() + "_end_effector", twist, this->get_name() + "_base");
   return result;
 }
 
-const Eigen::MatrixXd Jacobian::solve(const Eigen::MatrixXd& matrix) const {
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (this->get_nb_rows() != matrix.rows()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
-  return this->get_data().colPivHouseholderQr().solve(matrix);
+JointVelocities Jacobian::operator*(const CartesianTwist& twist) const {
+  Eigen::VectorXd joint_velocities = (*this) * twist.data();
+  JointVelocities result(this->get_name(), this->get_joint_names(), joint_velocities);
+  return result;
 }
 
-const JointVelocities Jacobian::solve(const CartesianTwist& dX) const {
-  if (dX.is_empty()) { throw EmptyStateException(dX.get_name() + " state is empty"); }
-  // extract the velocity as a 6d vector
-  auto twist = dX.get_twist();
+JointTorques Jacobian::operator*(const CartesianWrench& wrench) const {
+  Eigen::VectorXd joint_torques = (*this) * wrench.data();
+  JointVelocities result(this->get_name(), this->get_joint_names(), joint_torques);
+  return result;
+}
+
+Eigen::MatrixXd Jacobian::solve(const Eigen::MatrixXd& matrix) const {
+  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
+  if (this->get_nb_rows() != matrix.rows()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
+  return this->data().colPivHouseholderQr().solve(matrix);
+}
+
+JointVelocities Jacobian::solve(const CartesianTwist& twist) const {
+  if (twist.is_empty()) { throw EmptyStateException(twist.get_name() + " state is empty"); }
   // this use the solve operation instead of using the inverse or pseudo-inverse of the jacobian
-  Eigen::VectorXd joint_velocities = (*this).solve(twist);
+  Eigen::VectorXd joint_velocities = this->solve(twist.data());
   // return a JointVelocities state
   JointVelocities result(this->get_name(), this->get_joint_names(), joint_velocities);
   return result;
 }
 
-const JointVelocities Jacobian::operator*(const CartesianTwist& dX) const {
-  return this->solve(dX);
-}
-
-const Jacobian Jacobian::copy() const {
+Jacobian Jacobian::copy() const {
   Jacobian result(*this);
   return result;
 }

--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -104,8 +104,8 @@ JointPositions JointPositions::copy() const {
   return result;
 }
 
-Eigen::ArrayXd JointPositions::array() const {
-  return this->get_positions().array();
+Eigen::VectorXd JointPositions::data() const {
+  return this->get_positions();
 }
 
 std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {

--- a/source/state_representation/src/Robot/JointState.cpp
+++ b/source/state_representation/src/Robot/JointState.cpp
@@ -146,6 +146,14 @@ JointState JointState::copy() const {
   return result;
 }
 
+Eigen::VectorXd JointState::data() const {
+  return this->get_all_state_variables();
+}
+
+Eigen::ArrayXd JointState::array() const {
+  return this->data().array();
+}
+
 void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
                                       const JointStateVariable& state_variable_type,
                                       const Eigen::ArrayXd& noise_ratio_array) {
@@ -259,11 +267,11 @@ JointState operator*(const Eigen::ArrayXd& lambda, const JointState& state) {
 }
 
 std::vector<double> JointState::to_std_vector() const {
-  throw (NotImplementedException("to_std_vector() is not implemented for the base JointState class"));
+  throw NotImplementedException("to_std_vector() is not implemented for the base JointState class");
   return std::vector<double>();
 }
 
 void JointState::from_std_vector(const std::vector<double>&) {
-  throw (NotImplementedException("from_std_vector() is not implemented for the base JointState class"));
+  throw NotImplementedException("from_std_vector() is not implemented for the base JointState class");
 }
 }// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -89,8 +89,8 @@ JointTorques JointTorques::copy() const {
   return result;
 }
 
-Eigen::ArrayXd JointTorques::array() const {
-  return this->get_torques().array();
+Eigen::VectorXd JointTorques::data() const {
+  return this->get_torques();
 }
 
 void JointTorques::clamp(double max_absolute_value, double noise_ratio) {

--- a/source/state_representation/src/Robot/JointVelocities.cpp
+++ b/source/state_representation/src/Robot/JointVelocities.cpp
@@ -104,8 +104,8 @@ JointVelocities JointVelocities::copy() const {
   return result;
 }
 
-Eigen::ArrayXd JointVelocities::array() const {
-  return this->get_velocities().array();
+Eigen::VectorXd JointVelocities::data() const {
+  return this->get_velocities();
 }
 
 void JointVelocities::clamp(double max_absolute_value, double noise_ratio) {

--- a/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
@@ -105,6 +105,10 @@ CartesianPose CartesianPose::copy() const {
   return result;
 }
 
+Eigen::VectorXd CartesianPose::data() const {
+  return this->get_pose();
+}
+
 std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
   if (pose.is_empty()) {
     os << "Empty CartesianPose";

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -63,6 +63,14 @@ CartesianState CartesianState::copy() const {
   return result;
 }
 
+Eigen::VectorXd CartesianState::data() const {
+  return this->get_state_variable(CartesianStateVariable::ALL);
+}
+
+Eigen::ArrayXd CartesianState::array() const {
+  return this->data().array();
+}
+
 CartesianState& CartesianState::operator*=(const CartesianState& state) {
   // sanity check
   if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -130,8 +130,8 @@ CartesianTwist CartesianTwist::copy() const {
   return result;
 }
 
-Eigen::Array<double, 6, 1> CartesianTwist::array() const {
-  return this->get_twist().array();
+Eigen::VectorXd CartesianTwist::data() const {
+  return this->get_twist();
 }
 
 std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -98,6 +98,10 @@ CartesianWrench CartesianWrench::copy() const {
   return result;
 }
 
+Eigen::VectorXd CartesianWrench::data() const {
+  return this->get_wrench();
+}
+
 Eigen::Array<double, 6, 1> CartesianWrench::array() const {
   return this->get_wrench().array();
 }

--- a/source/state_representation/tests/testJacobian.cpp
+++ b/source/state_representation/tests/testJacobian.cpp
@@ -1,145 +1,117 @@
 #include "state_representation/Robot/Jacobian.hpp"
-#include <gtest/gtest.h>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <unistd.h>
 
-TEST(TestCreate, PositiveNos)
-{
-	StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6,7));
+TEST(TestCreate, PositiveNos) {
+  StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6, 7));
 
-	EXPECT_TRUE(jac.get_nb_rows() == 6);
-	EXPECT_TRUE(jac.get_nb_cols() == 7);
+  EXPECT_TRUE(jac.get_nb_rows() == 6);
+  EXPECT_TRUE(jac.get_nb_cols() == 7);
 
-	bool except_thrown = false;
-	try
-	{
-		jac.set_data(Eigen::MatrixXd::Random(7,6));
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown = true;
-	}
-	EXPECT_TRUE(except_thrown);
+  bool except_thrown = false;
+  try {
+    jac.set_data(Eigen::MatrixXd::Random(7, 6));
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown = true;
+  }
+  EXPECT_TRUE(except_thrown);
 }
 
-TEST(TestTranspose, PositiveNos)
-{
-	StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6,7));
-	jac = jac.transpose();
+TEST(TestTranspose, PositiveNos) {
+  StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6, 7));
+  jac = jac.transpose();
 
-	EXPECT_TRUE(jac.get_nb_rows() == 7);
-	EXPECT_TRUE(jac.get_nb_cols() == 6);
+  EXPECT_TRUE(jac.get_nb_rows() == 7);
+  EXPECT_TRUE(jac.get_nb_cols() == 6);
 
-	bool except_thrown = false;
-	try
-	{
-		jac.set_data(Eigen::MatrixXd::Random(7,6));
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown = true;
-	}
-	EXPECT_FALSE(except_thrown);
+  bool except_thrown = false;
+  try {
+    jac.set_data(Eigen::MatrixXd::Random(7, 6));
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown = true;
+  }
+  EXPECT_FALSE(except_thrown);
 }
 
-TEST(TestMutltiplyWithEigen, PositiveNos)
-{
-	StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6,7));
-	Eigen::MatrixXd mat1 = Eigen::VectorXd::Random(7,1);
-	Eigen::MatrixXd res1 = jac * mat1;
+TEST(TestMutltiplyWithEigen, PositiveNos) {
+  StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6, 7));
+  Eigen::MatrixXd mat1 = Eigen::VectorXd::Random(7, 1);
+  Eigen::MatrixXd res1 = jac * mat1;
 
-	EXPECT_TRUE(res1.rows() == 6);
-	EXPECT_TRUE(res1.cols() == 1);
+  EXPECT_TRUE(res1.rows() == 6);
+  EXPECT_TRUE(res1.cols() == 1);
 
-	Eigen::MatrixXd mat2 = Eigen::VectorXd::Random(6,1);
-	bool except_thrown = false;
-	try
-	{
-		Eigen::MatrixXd res2 = jac * mat2;
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown = true;
-	}
-	EXPECT_TRUE(except_thrown);
+  Eigen::MatrixXd mat2 = Eigen::VectorXd::Random(6, 1);
+  bool except_thrown = false;
+  try {
+    Eigen::MatrixXd res2 = jac * mat2;
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown = true;
+  }
+  EXPECT_TRUE(except_thrown);
 
-	Eigen::MatrixXd res2 = jac.transpose() * mat2;
-	EXPECT_TRUE(res2.rows() == 7);
-	EXPECT_TRUE(res2.cols() == 1);
+  Eigen::MatrixXd res2 = jac.transpose() * mat2;
+  EXPECT_TRUE(res2.rows() == 7);
+  EXPECT_TRUE(res2.cols() == 1);
 }
 
-TEST(TestSolve, PositiveNos)
-{
-	StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6,7));
-	Eigen::MatrixXd mat1 = Eigen::VectorXd::Random(7,1);
-	bool except_thrown = false;
-	try
-	{
-		Eigen::MatrixXd res1 = jac.solve(mat1);
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown = true;
-	}
-	EXPECT_TRUE(except_thrown);
+TEST(TestSolve, PositiveNos) {
+  StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6, 7));
+  Eigen::MatrixXd mat1 = Eigen::VectorXd::Random(7, 1);
+  bool except_thrown = false;
+  try {
+    Eigen::MatrixXd res1 = jac.solve(mat1);
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown = true;
+  }
+  EXPECT_TRUE(except_thrown);
 
-	Eigen::MatrixXd mat2 = Eigen::VectorXd::Random(6,1);
-	Eigen::MatrixXd res2 = jac.solve(mat2);
+  Eigen::MatrixXd mat2 = Eigen::VectorXd::Random(6, 1);
+  Eigen::MatrixXd res2 = jac.solve(mat2);
 
-	EXPECT_TRUE(res2.rows() == 7);
-	EXPECT_TRUE(res2.cols() == 1);
+  EXPECT_TRUE(res2.rows() == 7);
+  EXPECT_TRUE(res2.cols() == 1);
 }
 
-TEST(TestJointToCartesian, PositiveNos)
-{
-	StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6,7));
-	StateRepresentation::JointVelocities jvel("robot", Eigen::VectorXd::Random(7));
+TEST(TestJointToCartesian, PositiveNos) {
+  StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6, 7));
+  StateRepresentation::JointVelocities jvel("robot", Eigen::VectorXd::Random(7));
 
-	bool except_thrown = false;
-	try
-	{
-		StateRepresentation::CartesianTwist cvel = jac * jvel;
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown = true;
-	}
-	EXPECT_FALSE(except_thrown);
+  bool except_thrown = false;
+  try {
+    StateRepresentation::CartesianTwist cvel = jac * jvel;
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown = true;
+  }
+  EXPECT_FALSE(except_thrown);
 }
 
-TEST(TestCartesianToJoint, PositiveNos)
-{
-	StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6,7));
-	Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
-	StateRepresentation::CartesianTwist cvel("robot", vec);
+TEST(TestCartesianToJoint, PositiveNos) {
+  StateRepresentation::Jacobian jac("robot", Eigen::MatrixXd::Random(6, 7));
+  Eigen::Matrix<double, 6, 1> vec = Eigen::Matrix<double, 6, 1>::Random();
+  StateRepresentation::CartesianTwist cvel("robot", vec);
 
-	StateRepresentation::JointVelocities jvel1;
-	bool except_thrown1 = false;
-	try
-	{
-		jvel1 = jac.solve(cvel);
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown1 = true;
-	}
-	EXPECT_FALSE(except_thrown1);
+  StateRepresentation::JointVelocities jvel1;
+  bool except_thrown1 = false;
+  try {
+    jvel1 = jac.solve(cvel);
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown1 = true;
+  }
+  EXPECT_FALSE(except_thrown1);
 
-	StateRepresentation::JointVelocities jvel2;
-	bool except_thrown2 = false;
-	try
-	{
-		jvel2 = jac * cvel;
-	}
-	catch(const IncompatibleSizeException& e)
-	{
-		except_thrown2 = true;
-	}
-	EXPECT_FALSE(except_thrown2);
-	EXPECT_TRUE((jvel1.get_velocities() - jvel2.get_velocities()).norm() < 10e-4);
+  StateRepresentation::JointVelocities jvel2;
+  bool except_thrown2 = false;
+  try {
+    jvel2 = jac.pseudoinverse() * cvel;
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown2 = true;
+  }
+  EXPECT_FALSE(except_thrown2);
 }
 
-int main(int argc, char **argv) {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Again a refactor PR but smaller than the previous one. I wanted to change a bit the behavior of the Jacobian class as I need it in the Impedance. Changes include:

- as usual remove const, correct some identations, ...
- changes the behavior of the operators, especially the `operator*(CartesianTwist)` that was hiding a call to solve function. I don't think this was desirable. I prefer an explicit line such as `JointVelocities = Jacobian.pseudoinverse() * CartesianTwist`
- add the `inverse` and `pseudoinverse` functions.
- change `get_data` to `data`. This was made to have some consistency with Eigen library. The `data` functions has also been added to all the other classes.