### PR TITLE
Change from double spaces (different In and Out) to single space

### DIFF
--- a/source/controllers/include/controllers/Controller.hpp
+++ b/source/controllers/include/controllers/Controller.hpp
@@ -2,6 +2,7 @@
 
 #include "controllers/exceptions/NotImplementedException.hpp"
 #include "state_representation/Parameters/ParameterInterface.hpp"
+#include "state_representation/Robot/Jacobian.hpp"
 #include <list>
 #include <memory>
 
@@ -12,7 +13,7 @@ namespace controllers {
  * @tparam SIn the input state type of the controller
  * @tparam SOut the output command type of the controller
  */
-template <class SIn, class SOut>
+template<class S>
 class Controller {
 public:
   /**
@@ -26,7 +27,7 @@ public:
    * @param state the input state of the system. This function accept any number of extra arguments.
    * @return the output command at the input state
    */
-  virtual SOut compute_command(const SIn& state, ...);
+  virtual S compute_command(const S& state, ...);
 
   /**
    * @brief Compute the command based on the desired state and a feedback state in a non const fashion
@@ -35,7 +36,19 @@ public:
    * @param feedback_state the real state of the system as read from feedback loop
    * @return the output command at the input state
    */
-  virtual SOut compute_command(const SIn& desired_state, const SIn& feedback_state);
+  virtual S compute_command(const S& desired_state, const S& feedback_state);
+
+  /**
+   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * To be redefined based on the actual controller implementation.
+   * @param desired_state the desired state of the system.
+   * @param feedback_state the real state of the system as read from feedback loop
+   * @param jacobian the Jacobian matrix of the robot to convert from one state to the other
+   * @return the output command at the input state
+   */
+  virtual StateRepresentation::JointState compute_command(const S& desired_state,
+                                                          const S& feedback_state,
+                                                          const StateRepresentation::Jacobian& jacobian);
 
   /**
    * @brief Return a list of all the parameters of the controller
@@ -44,22 +57,34 @@ public:
   virtual std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
 };
 
-template <class SIn, class SOut>
-Controller<SIn, SOut>::Controller() {}
+template<class S>
+Controller<S>::Controller() {}
 
-template <class SIn, class SOut>
-std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Controller<SIn, SOut>::get_parameters() const {
+template<class S>
+std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Controller<S>::get_parameters() const {
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
   return param_list;
 }
 
-template <class SIn, class SOut>
-SOut Controller<SIn, SOut>::compute_command(const SIn&, ...) {
+template<class S>
+S Controller<S>::compute_command(const S&, ...) {
   throw exceptions::NotImplementedException("compute_command(state, ...) not implemented for the base controller class");
+  return S();
 }
 
-template <class SIn, class SOut>
-SOut Controller<SIn, SOut>::compute_command(const SIn&, const SIn&) {
-  throw exceptions::NotImplementedException("compute_command(desired_state, feedback_state) not implemented for the base controller class");
+template<class S>
+S Controller<S>::compute_command(const S&, const S&) {
+  throw exceptions::NotImplementedException(
+      "compute_command(desired_state, feedback_state) not implemented for the base controller class");
+  return S();
+}
+
+template<class S>
+StateRepresentation::JointState Controller<S>::compute_command(const S&,
+                                                               const S&,
+                                                               const StateRepresentation::Jacobian&) {
+  throw exceptions::NotImplementedException(
+      "compute_command(desired_state, feedback_state) not implemented for the base controller class");
+  return StateRepresentation::JointState();
 }
 }// namespace controllers

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -55,11 +55,26 @@ public:
    */
   explicit Dissipative(unsigned int nb_dimensions);
 
+  /**
+   * @brief Copy constructor
+   * @param other the controller to copy
+   */
   Dissipative(const Dissipative<S>& other);
 
+  /**
+   * @brief Swap the values of the two controllers
+   * @tparam U space of the controller
+   * @param controller1 controller to be swapped with 2
+   * @param controller2 controller to be swapped with 1
+   */
   template<class U>
   friend void swap(Dissipative<U>& controller1, Dissipative<U>& controller2);
 
+  /**
+   * @param Assignment operator
+   * @param other the controller to copy
+   * @return reference to the controller with values from other
+   */
   Dissipative<S>& operator=(const Dissipative<S>& other);
 
   /**

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -13,42 +13,63 @@ namespace controllers::impedance {
  * LINEAR and ANGULAR only compute the command in linear and angular space
  * respectively, TWIST applies it on the full twist vector, and
  * DECOUPLED_TWIST (default) computes the damping matrix for the linear
- * and angular part separatly
+ * and angular part separately
  */
 enum class ComputationalSpaceType {
   LINEAR,
   ANGULAR,
-  TWIST,
-  DECOUPLED_TWIST
+  DECOUPLED_TWIST,
+  FULL
 };
 
 /**
  * @class Dissipative
  * @brief Definition of a dissipative impedance controller (PassiveDS) in task space
  */
-class Dissipative : public Impedance<StateRepresentation::CartesianState> {
+template<class S>
+class Dissipative : public Impedance<S> {
 private:
-  ComputationalSpaceType
-      computational_space_;///< the space in which to compute the command vector
-  Eigen::Matrix<double, 6, 6>
-      basis_;///< basis matrix used to compute the damping matrix
+  ComputationalSpaceType computational_space_;///< the space in which to compute the command vector
+  unsigned int nb_dimensions_;///< the number of dimensions of the input space
+  Eigen::MatrixXd basis_;///< basis matrix used to compute the damping matrix
   std::shared_ptr<StateRepresentation::Parameter<Eigen::VectorXd>>
       damping_eigenvalues_;///< coefficient of eigenvalues used in the damping matrix computation
+
+  /**
+   * @brief Constructor with specified computational space and number of dimensions. Both parameters are
+   * mutually exclusive and therefore initialized independently in other constructors
+   */
+  explicit Dissipative(const ComputationalSpaceType& computational_space, unsigned int nb_dimensions);
 
 public:
   /**
    * @brief Constructor with specified computational space. Default is DECOUPLED_TWIST
+   * @param computational_space the space in which to compute the command in LINEAR, ANGULAR, DECOUPLED_TWIST or FULL.
+   * Default is DECOUPLED_TWIST
    */
   explicit Dissipative(const ComputationalSpaceType& computational_space = ComputationalSpaceType::DECOUPLED_TWIST);
+
+  /**
+   * @brief Constructor with specified number of dimensions. Automatically use the full damping matrix.
+   * @param nb_dimensions the number of dimensions of the damping matrix
+   */
+  explicit Dissipative(unsigned int nb_dimensions);
+
+  Dissipative(const Dissipative<S>& other);
+
+  template<class U>
+  friend void swap(Dissipative<U>& controller1, Dissipative<U>& controller2);
+
+  Dissipative<S>& operator=(const Dissipative<S>& other);
 
   /**
    * @brief Compute the orthonormal basis based on the main eigenvector in parameter
    * @param basis the basis matrix to orthonormalize
    * @param main_eigenvector the main eigenvector used to compute the basis.
-   * Other eigenvectora are orthogonal and selected randomly
+   * Other eigenvectors are orthogonal and selected randomly
    */
-  Eigen::MatrixXd compute_orthonormal_basis(const Eigen::MatrixXd& basis,
-                                            const Eigen::VectorXd& main_eigenvector) const;
+  static Eigen::MatrixXd compute_orthonormal_basis(const Eigen::MatrixXd& basis,
+                                                   const Eigen::VectorXd& main_eigenvector);
 
   /**
    * @brief Compute the damping matrix as the orthonormal basis
@@ -62,7 +83,7 @@ public:
    * @brief Getter of the damping eigenvalues parameter
    * @return the eigenvalues as a Vetor6D
    */
-  Eigen::Matrix<double, 6, 1> get_damping_eigenvalues() const;
+  Eigen::VectorXd get_damping_eigenvalues() const;
 
   /**
    * @brief Getter of the damping eigenvalue corresponding to the specified index
@@ -75,7 +96,7 @@ public:
    * @brief Setter of the damping eigenvalues parameter
    * @param damping_eigenvalues the new values of the eigenvalue as a Vector6D
    */
-  void set_damping_eigenvalues(const Eigen::Matrix<double, 6, 1>& damping_eigenvalues);
+  void set_damping_eigenvalues(const Eigen::VectorXd& damping_eigenvalues);
 
   /**
    * @brief Setter of the damping eigenvalue corresponding to the specified index
@@ -87,7 +108,7 @@ public:
   /**
    * @brief Get the eigenvalues in a diagonal matrix form
    */
-  Eigen::DiagonalMatrix<double, 6, 6> get_diagonal_eigenvalues() const;
+  Eigen::MatrixXd get_diagonal_eigenvalues() const;
 
   /**
    * @brief Compute the force (task space) or torque (joint space) command based on the input state
@@ -96,8 +117,19 @@ public:
    * @param feedback_state the real state of the system as read from feedback loop
    * @return the output command at the input state
    */
-  StateRepresentation::CartesianState compute_command(const StateRepresentation::CartesianState& desired_state,
-                                                      const StateRepresentation::CartesianState& feedback_state);
+  S compute_command(const S& desired_state, const S& feedback_state) override;
+
+  /**
+   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * To be redefined based on the actual controller implementation.
+   * @param desired_state the desired state of the system.
+   * @param feedback_state the real state of the system as read from feedback loop
+   * @param jacobian the Jacobian matrix of the robot to convert from one state to the other
+   * @return the output command at the input state
+   */
+  StateRepresentation::JointState compute_command(const S& desired_state,
+                                                  const S& feedback_state,
+                                                  const StateRepresentation::Jacobian& jacobian) override;
 
   /**
    * @brief Return a list of all the parameters of the controller
@@ -106,32 +138,140 @@ public:
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
 };
 
-inline Eigen::Matrix<double, 6, 1> Dissipative::get_damping_eigenvalues() const {
+template<class S>
+Dissipative<S>::Dissipative(const ComputationalSpaceType& computational_space, unsigned int nb_dimensions) :
+    Impedance<S>(Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions),
+                 Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions),
+                 Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions)),
+    computational_space_(computational_space),
+    nb_dimensions_(nb_dimensions),
+    basis_(Eigen::MatrixXd::Random(nb_dimensions, nb_dimensions)),
+    damping_eigenvalues_(std::make_shared<StateRepresentation::Parameter<Eigen::VectorXd>>("damping_eigenvalues",
+                                                                                           Eigen::ArrayXd::Ones(
+                                                                                               nb_dimensions))) {}
+
+template<class S>
+Dissipative<S>::Dissipative(const Dissipative<S>& other):
+    Impedance<S>(other),
+    computational_space_(other.computational_space_),
+    nb_dimensions_(other.nb_dimensions_),
+    basis_(other.basis_),
+    damping_eigenvalues_(std::make_shared<StateRepresentation::Parameter<Eigen::VectorXd>>("damping_eigenvalues",
+                                                                                           other.get_damping_eigenvalues())) {}
+
+template<class U>
+inline void swap(Dissipative<U>& controller1, Dissipative<U>& controller2) {
+  swap(static_cast<Impedance<U>&>(controller1), static_cast<Impedance<U>&>(controller2));
+  std::swap(controller1.computational_space_, controller2.computational_space_);
+  std::swap(controller1.nb_dimensions_, controller2.nb_dimensions_);
+  std::swap(controller1.basis_, controller2.basis_);
+  std::swap(controller1.damping_eigenvalues_, controller2.damping_eigenvalues_);
+}
+
+template<class S>
+Dissipative<S>& Dissipative<S>::operator=(const Dissipative<S>& other) {
+  Dissipative<S> tmp(other);
+  swap(*this, tmp);
+  return *this;
+}
+
+template<class S>
+inline Eigen::VectorXd Dissipative<S>::get_damping_eigenvalues() const {
   return this->damping_eigenvalues_->get_value();
 }
 
-inline double Dissipative::get_damping_eigenvalue(unsigned int index) const {
-  Eigen::Matrix<double, 6, 1> eigenvalues = this->get_damping_eigenvalues();
+template<class S>
+inline double Dissipative<S>::get_damping_eigenvalue(unsigned int index) const {
+  Eigen::VectorXd eigenvalues = this->get_damping_eigenvalues();
   return eigenvalues(index);
 }
 
-inline void Dissipative::set_damping_eigenvalues(const Eigen::Matrix<double, 6, 1>& damping_eigenvalues) {
+template<class S>
+inline void Dissipative<S>::set_damping_eigenvalues(const Eigen::VectorXd& damping_eigenvalues) {
   this->damping_eigenvalues_->set_value(damping_eigenvalues);
 }
 
-inline void Dissipative::set_damping_eigenvalue(double damping_eigenvalue, unsigned int index) {
-  Eigen::Matrix<double, 6, 1> eigenvalues = this->get_damping_eigenvalues();
+template<class S>
+inline void Dissipative<S>::set_damping_eigenvalue(double damping_eigenvalue, unsigned int index) {
+  Eigen::VectorXd eigenvalues = this->get_damping_eigenvalues();
   eigenvalues(index) = damping_eigenvalue;
   this->set_damping_eigenvalues(eigenvalues);
 }
 
-inline Eigen::DiagonalMatrix<double, 6, 6> Dissipative::get_diagonal_eigenvalues() const {
+template<class S>
+inline Eigen::MatrixXd Dissipative<S>::get_diagonal_eigenvalues() const {
   return this->get_damping_eigenvalues().asDiagonal();
 }
 
-inline std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Dissipative::get_parameters() const {
+template<class S>
+inline std::list<std::shared_ptr<StateRepresentation::ParameterInterface>>
+Dissipative<S>::get_parameters() const {
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
   param_list.push_back(this->damping_eigenvalues_);
   return param_list;
+}
+
+template<class S>
+Eigen::MatrixXd Dissipative<S>::compute_orthonormal_basis(const Eigen::MatrixXd& basis,
+                                                          const Eigen::VectorXd& main_eigenvector) {
+  Eigen::MatrixXd orthonormal_basis = basis;
+  uint dim = basis.rows();
+  orthonormal_basis.col(0) = main_eigenvector.normalized();
+  for (uint i = 1; i < dim; i++) {
+    for (uint j = 0; j < i; j++) {
+      orthonormal_basis.col(i) -= orthonormal_basis.col(j).dot(orthonormal_basis.col(i)) * orthonormal_basis.col(j);
+    }
+    orthonormal_basis.col(i).normalize();
+  }
+  return orthonormal_basis;
+}
+
+template<class S>
+void Dissipative<S>::compute_damping(const Eigen::VectorXd& desired_velocity) {
+  Eigen::MatrixXd updated_basis = Eigen::MatrixXd::Zero(this->nb_dimensions_, this->nb_dimensions_);
+  switch (this->computational_space_) {
+    case ComputationalSpaceType::LINEAR:
+      //return only the linear block
+      updated_basis.block<3, 3>(0, 0) =
+          this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0),
+                                          desired_velocity.segment(0, 3));
+      break;
+    case ComputationalSpaceType::ANGULAR:
+      // return only the angular block
+      updated_basis.block<3, 3>(3, 3) =
+          this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3),
+                                          desired_velocity.segment(3, 3));
+      break;
+    case ComputationalSpaceType::DECOUPLED_TWIST:
+      // compute per block
+      updated_basis.block<3, 3>(0, 0) =
+          this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0),
+                                          desired_velocity.segment(0, 3));
+      updated_basis.block<3, 3>(3, 3) =
+          this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3),
+                                          desired_velocity.segment(3, 3));
+      break;
+    case ComputationalSpaceType::FULL:
+      // return the full damping matrix
+      updated_basis = this->compute_orthonormal_basis(this->basis_, desired_velocity);
+      break;
+  }
+  this->basis_ = updated_basis;
+  this->set_damping(this->basis_ * this->get_diagonal_eigenvalues() * this->basis_.transpose());
+}
+
+template<class S>
+S Dissipative<S>::compute_command(const S& desired_state, const S& feedback_state) {
+  // compute the damping matrix out of the desired_state twist
+  this->compute_damping(desired_state.data());
+  // apply the impedance control law
+  return this->Impedance<S>::compute_command(desired_state, feedback_state);
+}
+
+template<class S>
+StateRepresentation::JointState Dissipative<S>::compute_command(const S& desired_state,
+                                                                const S& feedback_state,
+                                                                const StateRepresentation::Jacobian& jacobian) {
+  return this->Impedance<S>::compute_command(desired_state, feedback_state, jacobian);
 }
 }// namespace controllers

--- a/source/controllers/include/controllers/impedance/Impedance.hpp
+++ b/source/controllers/include/controllers/impedance/Impedance.hpp
@@ -51,6 +51,7 @@ public:
    * @return reference to the controller with values from other
    */
   Impedance<S>& operator=(const Impedance<S>& other);
+
   /**
    * @brief Compute the force (task space) or torque (joint space) command based on the input state 
    * of the system as the error between the desired state and the real state.

--- a/source/controllers/include/controllers/impedance/Impedance.hpp
+++ b/source/controllers/include/controllers/impedance/Impedance.hpp
@@ -5,19 +5,21 @@
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
 
-namespace controllers {
-namespace impedance {
+namespace controllers::impedance {
 /**
  * @class Impedance
  * @brief Definition of an impedance controller in either joint or task space
  * @tparam S the space of the controller either CartesianState or JointState
  */
-template <class S>
-class Impedance : public Controller<S, S> {
+template<class S>
+class Impedance : public Controller<S> {
 private:
-  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>> stiffness_;///< stiffness matrix of the controller associated to position
-  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>> damping_;  ///< damping matrix of the controller associated to velocity
-  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>> inertia_;  ///< inertia matrix of the controller associated to acceleration
+  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>>
+      stiffness_;///< stiffness matrix of the controller associated to position
+  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>>
+      damping_;  ///< damping matrix of the controller associated to velocity
+  std::shared_ptr<StateRepresentation::Parameter<Eigen::MatrixXd>>
+      inertia_;  ///< inertia matrix of the controller associated to acceleration
 
 public:
   /**
@@ -28,6 +30,12 @@ public:
    */
   explicit Impedance(const Eigen::MatrixXd& stiffness, const Eigen::MatrixXd& damping, const Eigen::MatrixXd& inertia);
 
+  Impedance(const Impedance<S>& other);
+
+  template<class U>
+  friend void swap(Impedance<U>& controller1, Impedance<U>& controller2);
+
+  Impedance<S>& operator=(const Impedance<S>& other);
   /**
    * @brief Compute the force (task space) or torque (joint space) command based on the input state 
    * of the system as the error between the desired state and the real state.
@@ -36,6 +44,18 @@ public:
    * @return the output command at the input state
    */
   virtual S compute_command(const S& desired_state, const S& feedback_state);
+
+  /**
+   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * To be redefined based on the actual controller implementation.
+   * @param desired_state the desired state of the system.
+   * @param feedback_state the real state of the system as read from feedback loop
+   * @param jacobian the Jacobian matrix of the robot to convert from one state to the other
+   * @return the output command at the input state
+   */
+  virtual StateRepresentation::JointState compute_command(const S& desired_state,
+                                                          const S& feedback_state,
+                                                          const StateRepresentation::Jacobian& jacobian);
 
   /**
    * @brief Getter of the stiffness matrix
@@ -80,37 +100,60 @@ public:
   virtual std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const;
 };
 
-template <class S>
+template<class S>
+Impedance<S>::Impedance(const Impedance<S>& other):
+    stiffness_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("stiffness",
+                                                                                 other.get_stiffness())),
+    damping_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("damping",
+                                                                               other.get_damping())),
+    inertia_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("inertia",
+                                                                               other.get_inertia())) {}
+
+template<class U>
+inline void swap(Impedance<U>& controller1, Impedance<U>& controller2) {
+  std::swap(controller1.stiffness_, controller2.stiffness_);
+  std::swap(controller1.damping_, controller2.damping_);
+  std::swap(controller1.inertia_, controller2.inertia_);
+}
+
+template<class S>
+inline Impedance<S>& Impedance<S>::operator=(const Impedance<S>& other) {
+  Impedance<S> tmp(other);
+  swap(*this, tmp);
+  return *this;
+}
+
+template<class S>
 inline const Eigen::MatrixXd& Impedance<S>::get_stiffness() const {
   return this->stiffness_->get_value();
 }
 
-template <class S>
+template<class S>
 inline const Eigen::MatrixXd& Impedance<S>::get_damping() const {
   return this->damping_->get_value();
 }
 
-template <class S>
+template<class S>
 inline const Eigen::MatrixXd& Impedance<S>::get_inertia() const {
   return this->inertia_->get_value();
 }
 
-template <class S>
+template<class S>
 inline void Impedance<S>::set_stiffness(const Eigen::MatrixXd& stiffness) {
   this->stiffness_->set_value(stiffness);
 }
 
-template <class S>
+template<class S>
 inline void Impedance<S>::set_damping(const Eigen::MatrixXd& damping) {
   this->damping_->set_value(damping);
 }
 
-template <class S>
+template<class S>
 inline void Impedance<S>::set_inertia(const Eigen::MatrixXd& inertia) {
   this->inertia_->set_value(inertia);
 }
 
-template <class S>
+template<class S>
 std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Impedance<S>::get_parameters() const {
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
   param_list.push_back(this->stiffness_);
@@ -118,5 +161,4 @@ std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Impedance<S>
   param_list.push_back(this->inertia_);
   return param_list;
 }
-}// namespace impedance
 }// namespace controllers

--- a/source/controllers/include/controllers/impedance/Impedance.hpp
+++ b/source/controllers/include/controllers/impedance/Impedance.hpp
@@ -30,11 +30,26 @@ public:
    */
   explicit Impedance(const Eigen::MatrixXd& stiffness, const Eigen::MatrixXd& damping, const Eigen::MatrixXd& inertia);
 
+  /**
+   * @brief Copy constructor
+   * @param other the controller to copy
+   */
   Impedance(const Impedance<S>& other);
 
+  /**
+   * @brief Swap the values of the two controllers
+   * @tparam U space of the controller
+   * @param controller1 controller to be swapped with 2
+   * @param controller2 controller to be swapped with 1
+   */
   template<class U>
   friend void swap(Impedance<U>& controller1, Impedance<U>& controller2);
 
+  /**
+   * @param Assignment operator
+   * @param other the controller to copy
+   * @return reference to the controller with values from other
+   */
   Impedance<S>& operator=(const Impedance<S>& other);
   /**
    * @brief Compute the force (task space) or torque (joint space) command based on the input state 

--- a/source/controllers/include/controllers/impedance/Impedance.hpp
+++ b/source/controllers/include/controllers/impedance/Impedance.hpp
@@ -79,7 +79,7 @@ public:
   const Eigen::MatrixXd& get_stiffness() const;
 
   /**
-   * @brief Getter of the dmaping matrix
+   * @brief Getter of the damping matrix
    * @return the damping matrix
    */
   const Eigen::MatrixXd& get_damping() const;

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -4,44 +4,74 @@
 #include "state_representation/Space/Cartesian/CartesianState.hpp"
 #include "state_representation/Space/Cartesian/CartesianWrench.hpp"
 
-namespace controllers {
-namespace impedance {
+using namespace StateRepresentation;
 
-template <class S>
-Impedance<S>::Impedance(const Eigen::MatrixXd& stiffness, const Eigen::MatrixXd& damping, const Eigen::MatrixXd& inertia) : stiffness_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("stiffness", stiffness)),
-                                                                                                                            damping_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("damping", damping)),
-                                                                                                                            inertia_(std::make_shared<StateRepresentation::Parameter<Eigen::MatrixXd>>("inertia", inertia)) {}
+namespace controllers::impedance {
+template<class S>
+Impedance<S>::Impedance(const Eigen::MatrixXd& stiffness,
+                        const Eigen::MatrixXd& damping,
+                        const Eigen::MatrixXd& inertia)
+    : stiffness_(std::make_shared<Parameter<Eigen::MatrixXd>>("stiffness", stiffness)),
+      damping_(std::make_shared<Parameter<Eigen::MatrixXd>>("damping", damping)),
+      inertia_(std::make_shared<Parameter<Eigen::MatrixXd>>("inertia", inertia)) {}
 
-template Impedance<StateRepresentation::CartesianState>::Impedance(const Eigen::MatrixXd&, const Eigen::MatrixXd&, const Eigen::MatrixXd&);
-template Impedance<StateRepresentation::JointState>::Impedance(const Eigen::MatrixXd&, const Eigen::MatrixXd&, const Eigen::MatrixXd&);
+template Impedance<CartesianState>::Impedance(const Eigen::MatrixXd&,
+                                              const Eigen::MatrixXd&,
+                                              const Eigen::MatrixXd&);
+template Impedance<JointState>::Impedance(const Eigen::MatrixXd&,
+                                          const Eigen::MatrixXd&,
+                                          const Eigen::MatrixXd&);
 
-template <>
-StateRepresentation::CartesianState Impedance<StateRepresentation::CartesianState>::compute_command(const StateRepresentation::CartesianState& desired_state,
-                                                                                                    const StateRepresentation::CartesianState& feedback_state) {
-  StateRepresentation::CartesianState state_error = desired_state - feedback_state;
-  // compute the wrench using the forlmula W = K * e_pos + D * e_vel + I * acc_desired
-  StateRepresentation::CartesianWrench command(feedback_state.get_name(), feedback_state.get_reference_frame());
+template<class S>
+S Impedance<S>::compute_command(const S&, const S&) {
+  throw exceptions::NotImplementedException(
+      "compute_command(desired_state, feedback_state) not implemented for this input class");
+}
 
+template<>
+CartesianState Impedance<CartesianState>::compute_command(const CartesianState& desired_state,
+                                                          const CartesianState& feedback_state) {
+  CartesianState state_error = desired_state - feedback_state;
+  // compute the wrench using the formula W = K * e_pos + D * e_vel + I * acc_desired
+  CartesianWrench command(feedback_state.get_name(), feedback_state.get_reference_frame());
   // compute force
   command.set_force(this->get_stiffness().block<3, 3>(0, 0) * state_error.get_position()
-                    + this->get_damping().block<3, 3>(0, 0) * state_error.get_linear_velocity()
-                    + this->get_inertia().block<3, 3>(0, 0) * desired_state.get_linear_acceleration());
+                        + this->get_damping().block<3, 3>(0, 0) * state_error.get_linear_velocity()
+                        + this->get_inertia().block<3, 3>(0, 0) * desired_state.get_linear_acceleration());
   // compute torque (orientation requires special care)
   command.set_torque(this->get_stiffness().block<3, 3>(3, 3) * state_error.get_orientation().vec()
-                     + this->get_damping().block<3, 3>(3, 3) * state_error.get_angular_velocity()
-                     + this->get_inertia().block<3, 3>(3, 3) * desired_state.get_angular_acceleration());
+                         + this->get_damping().block<3, 3>(3, 3) * state_error.get_angular_velocity()
+                         + this->get_inertia().block<3, 3>(3, 3) * desired_state.get_angular_acceleration());
   return command;
 }
 
-template <>
-StateRepresentation::JointState Impedance<StateRepresentation::JointState>::compute_command(const StateRepresentation::JointState& desired_state,
-                                                                                            const StateRepresentation::JointState& feedback_state) {
-  StateRepresentation::JointState state_error = desired_state - feedback_state;
-  // compute the wrench using the forlmula W = K * e_pos + D * e_vel + I * acc_desired
-  StateRepresentation::JointTorques command(feedback_state.get_name(), feedback_state.get_names());
+template<>
+JointState Impedance<JointState>::compute_command(const JointState& desired_state,
+                                                  const JointState& feedback_state) {
+  JointState state_error = desired_state - feedback_state;
+  // compute the wrench using the formula W = K * e_pos + D * e_vel + I * acc_desired
+  JointTorques command(feedback_state.get_name(), feedback_state.get_names());
   // compute torques
-  command.set_torques(this->get_stiffness() * state_error.get_positions() + this->get_damping() * state_error.get_velocities() + this->get_inertia() * desired_state.get_accelerations());
+  command.set_torques(this->get_stiffness() * state_error.get_positions()
+                          + this->get_damping() * state_error.get_velocities()
+                          + this->get_inertia() * desired_state.get_accelerations());
   return command;
 }
-}// namespace impedance
+
+template<class S>
+JointState Impedance<S>::compute_command(const S&,
+                                         const S&,
+                                         const StateRepresentation::Jacobian&) {
+  throw exceptions::NotImplementedException(
+      "compute_command(desired_state, feedback_state) not implemented for this input class");
+  return JointState();
+}
+
+template<>
+StateRepresentation::JointState Impedance<CartesianState>::compute_command(const CartesianState& desired_state,
+                                                                           const CartesianState& feedback_state,
+                                                                           const Jacobian& jacobian) {
+  CartesianWrench command = compute_command(desired_state, feedback_state);
+  return jacobian.transpose() * command;
+}
 }// namespace controllers

--- a/source/controllers/tests/testDissipativeImpedanceController.cpp
+++ b/source/controllers/tests/testDissipativeImpedanceController.cpp
@@ -1,6 +1,8 @@
 #include "controllers/impedance/Dissipative.hpp"
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 #include "state_representation/Space/Cartesian/CartesianWrench.hpp"
+#include "state_representation/Robot/JointVelocities.hpp"
+#include "state_representation/Robot/JointTorques.hpp"
 #include <numeric>
 #include <gtest/gtest.h>
 
@@ -12,20 +14,46 @@ protected:
   void SetUp() override {}
 
   void set_controller_space(const ComputationalSpaceType& computational_space) {
-    controller_ = Dissipative(computational_space);
+    task_controller_ = Dissipative<CartesianState>(computational_space);
   }
 
-  Dissipative controller_;
+  Dissipative<CartesianState> task_controller_;
+  Dissipative<JointState> joint_controller_ = Dissipative<JointState>(4);
   double tolerance_ = 1e-4;
 };
+
+TEST_F(DissipativeImpedanceControllerTest, TestCopyConstructorCartesian) {
+  Dissipative<CartesianState> new_control = Dissipative<CartesianState>(ComputationalSpaceType::LINEAR);
+  new_control.set_damping_eigenvalue(50, 2);
+  Dissipative<CartesianState> copy(new_control);
+  double tolerance = 1e-4;
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(new_control.get_damping().col(i).norm(), copy.get_damping().col(i).norm(), tolerance);
+    EXPECT_NEAR(new_control.get_stiffness().col(i).norm(), copy.get_stiffness().col(i).norm(), tolerance);
+    EXPECT_NEAR(new_control.get_inertia().col(i).norm(), copy.get_inertia().col(i).norm(), tolerance);
+  }
+  EXPECT_NEAR(new_control.get_damping_eigenvalues().norm(), copy.get_damping_eigenvalues().norm(), tolerance);
+}
+
+TEST_F(DissipativeImpedanceControllerTest, TestAssignmentOperatorCartesian) {
+  Dissipative<CartesianState> new_control = Dissipative<CartesianState>(ComputationalSpaceType::LINEAR);
+  new_control.set_damping_eigenvalue(50, 2);
+  Dissipative<CartesianState> copy = new_control;
+  double tolerance = 1e-4;
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(new_control.get_damping().col(i).norm(), copy.get_damping().col(i).norm(), tolerance);
+    EXPECT_NEAR(new_control.get_stiffness().col(i).norm(), copy.get_stiffness().col(i).norm(), tolerance);
+    EXPECT_NEAR(new_control.get_inertia().col(i).norm(), copy.get_inertia().col(i).norm(), tolerance);
+  }
+  EXPECT_NEAR(new_control.get_damping_eigenvalues().norm(), copy.get_damping_eigenvalues().norm(), tolerance);
+}
 
 TEST_F(DissipativeImpedanceControllerTest, TestOrthonormalize) {
   Eigen::Matrix3d basis = Eigen::Matrix3d::Random();
   Eigen::Vector3d eigenvector = Eigen::Vector3d::Random();
-
   // compute the orthonormal basis
-  Eigen::Matrix3d orthonormal_basis = controller_.compute_orthonormal_basis(basis, eigenvector);
-
+  Eigen::Matrix3d orthonormal_basis = Dissipative<CartesianState>::compute_orthonormal_basis(basis,
+                                                                                             eigenvector);
   // first column should the normalized eigenvector
   Eigen::Vector3d err = orthonormal_basis.col(0) - eigenvector.normalized();
   for (int i = 0; i < 3; ++i) { EXPECT_NEAR(err(i), 0., tolerance_); }
@@ -46,9 +74,8 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingLinear) {
   Eigen::Matrix3d block;
   // case LINEAR
   set_controller_space(ComputationalSpaceType::LINEAR);
-  controller_.compute_damping(eigenvector);
-  damping = controller_.get_damping();
-
+  task_controller_.compute_damping(eigenvector);
+  damping = task_controller_.get_damping();
   // linear part is identity
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
@@ -71,8 +98,8 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingAngular) {
   Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
   Eigen::Matrix3d block;
   set_controller_space(ComputationalSpaceType::ANGULAR);
-  controller_.compute_damping(eigenvector);
-  damping = controller_.get_damping();
+  task_controller_.compute_damping(eigenvector);
+  damping = task_controller_.get_damping();
   // linear part is 0
   block = damping.block<3, 3>(0, 0);
   EXPECT_NEAR(std::accumulate(block.data(), block.data() + block.size(), 0.0), 0.0, tolerance_);
@@ -95,8 +122,8 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingDecoupledTwist) {
   Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
   // case DECOUPLED_TWIST
   set_controller_space(ComputationalSpaceType::DECOUPLED_TWIST);
-  controller_.compute_damping(eigenvector);
-  damping = controller_.get_damping();
+  task_controller_.compute_damping(eigenvector);
+  damping = task_controller_.get_damping();
   // identity 6
   for (int i = 0; i < 6; ++i) {
     for (int j = 0; j < 6; ++j) {
@@ -105,14 +132,14 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingDecoupledTwist) {
   }
 }
 
-TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingTwist) {
+TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingFull) {
   Eigen::MatrixXd damping;
   Eigen::MatrixXd identity6 = Eigen::MatrixXd::Identity(6, 6);
   Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
   // case TWIST
-  set_controller_space(ComputationalSpaceType::TWIST);
-  controller_.compute_damping(eigenvector);
-  damping = controller_.get_damping();
+  set_controller_space(ComputationalSpaceType::FULL);
+  task_controller_.compute_damping(eigenvector);
+  damping = task_controller_.get_damping();
   // identity 6
   for (int i = 0; i < 6; ++i) {
     for (int j = 0; j < 6; ++j) {
@@ -125,20 +152,43 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeCommandWithColinearVelocit
   set_controller_space(ComputationalSpaceType::LINEAR);
   // set different damping
   double e1 = 10;
-  controller_.set_damping_eigenvalue(e1, 0);
+  task_controller_.set_damping_eigenvalue(e1, 0);
   // set a desired and feeadback velocity
   CartesianTwist desired_twist("test", Eigen::Vector3d(1, 0, 0));
   CartesianTwist feedback_twist("test", Eigen::Vector3d(1, 1, 0));
   // first compute the command with a 0 feedback
-  CartesianWrench command = controller_.compute_command(desired_twist, CartesianTwist::Zero("test"));
+  CartesianWrench command = task_controller_.compute_command(desired_twist, CartesianTwist::Zero("test"));
   EXPECT_NEAR(command.get_force()(0), 10, tolerance_);
   EXPECT_NEAR(command.get_force()(1), 0, tolerance_);
   EXPECT_NEAR(command.get_force()(2), 0, tolerance_);
   // then compute it with respect to the feedback
-  command = controller_.compute_command(desired_twist, feedback_twist);
+  command = task_controller_.compute_command(desired_twist, feedback_twist);
   EXPECT_NEAR(command.get_force()(0), 0, tolerance_);
   EXPECT_NEAR(command.get_force()(1), -1, tolerance_);
   EXPECT_NEAR(command.get_force()(2), 0, tolerance_);
+}
+
+TEST_F(DissipativeImpedanceControllerTest, TestComputeTaskToJointCommand) {
+  // set a desired and feeadback velocity
+  CartesianTwist desired_twist("test", Eigen::Vector3d(1, 0, 0));
+  CartesianTwist feedback_twist("test", Eigen::Vector3d(1, 1, 0));
+  // set a Jacobian matrix
+  Jacobian jacobian("test_robot", 3);
+  jacobian.set_data(Eigen::MatrixXd::Random(6, 3));
+  // check command
+  JointTorques command = task_controller_.compute_command(desired_twist, feedback_twist, jacobian);
+  // expect some non null data
+  EXPECT_TRUE(command.data().norm() > 0.);
+}
+
+TEST_F(DissipativeImpedanceControllerTest, TestComputeJointCommand) {
+  // set a desired and feeadback velocity
+  JointVelocities desired_velocities("test", Eigen::Vector4d(1, 0, 0, 0));
+  JointVelocities feedback_velocities("test", Eigen::Vector4d(1, 1, 0, 0));
+  // check command
+  JointTorques command = joint_controller_.compute_command(desired_velocities, feedback_velocities);
+  // expect some non null data
+  EXPECT_TRUE(command.data().norm() > 0.);
 }
 
 int main(int argc, char** argv) {

--- a/source/controllers/tests/testImpedanceController.cpp
+++ b/source/controllers/tests/testImpedanceController.cpp
@@ -10,6 +10,32 @@
 using namespace controllers::impedance;
 using namespace StateRepresentation;
 
+TEST(TestCopyConstructor, PositiveNos) {
+  Impedance<CartesianState> impedance_controller(Eigen::MatrixXd::Random(6, 6),
+                                                 Eigen::MatrixXd::Random(6, 6),
+                                                 Eigen::MatrixXd::Random(6, 6));
+  Impedance<CartesianState> copy(impedance_controller);
+  double tolerance = 1e-4;
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(impedance_controller.get_damping().col(i).norm(), copy.get_damping().col(i).norm(), tolerance);
+    EXPECT_NEAR(impedance_controller.get_stiffness().col(i).norm(), copy.get_stiffness().col(i).norm(), tolerance);
+    EXPECT_NEAR(impedance_controller.get_inertia().col(i).norm(), copy.get_inertia().col(i).norm(), tolerance);
+  }
+}
+
+TEST(TestAssignmentOperator, PositiveNos) {
+  Impedance<CartesianState> impedance_controller(Eigen::MatrixXd::Random(6, 6),
+                                                 Eigen::MatrixXd::Random(6, 6),
+                                                 Eigen::MatrixXd::Random(6, 6));
+  Impedance<CartesianState> copy = impedance_controller;
+  double tolerance = 1e-4;
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(impedance_controller.get_damping().col(i).norm(), copy.get_damping().col(i).norm(), tolerance);
+    EXPECT_NEAR(impedance_controller.get_stiffness().col(i).norm(), copy.get_stiffness().col(i).norm(), tolerance);
+    EXPECT_NEAR(impedance_controller.get_inertia().col(i).norm(), copy.get_inertia().col(i).norm(), tolerance);
+  }
+}
+
 TEST(TestCartesianImpedance, PositiveNos) {
   Impedance<CartesianState> impedance_controller(Eigen::MatrixXd::Identity(6, 6),
                                                  Eigen::MatrixXd::Identity(6, 6),
@@ -23,8 +49,8 @@ TEST(TestCartesianImpedance, PositiveNos) {
   feedback_state.set_linear_velocity(Eigen::Vector3d(0.5, 0, 0));
   // check command
   CartesianWrench command = impedance_controller.compute_command(desired_state, feedback_state);
-
-  std::cerr << command << std::endl;
+  // expect some non null data
+  EXPECT_TRUE(command.data().norm() > 0.);
 }
 
 TEST(TestJointImpedance, PositiveNos) {
@@ -41,8 +67,28 @@ TEST(TestJointImpedance, PositiveNos) {
   feedback_state.set_velocities(Eigen::Vector3d(0.5, 0, 0));
   // check command
   JointTorques command = impedance_controller.compute_command(desired_state, feedback_state);
+  // expect some non null data
+  EXPECT_TRUE(command.data().norm() > 0.);
+}
 
-  std::cerr << command << std::endl;
+TEST(TestCartesianToJointImpedance, PositiveNos) {
+  Impedance<CartesianState> impedance_controller(Eigen::MatrixXd::Identity(6, 6),
+                                                 Eigen::MatrixXd::Identity(6, 6),
+                                                 Eigen::MatrixXd::Identity(6, 6));
+  // set up a desired state6d
+  CartesianState desired_state("test");
+  desired_state.set_linear_velocity(Eigen::Vector3d(1, 0, 0));
+  // set up a real state
+  CartesianState feedback_state("test");
+  feedback_state.set_orientation(Eigen::Quaterniond(0, 0, 1, 1));
+  feedback_state.set_linear_velocity(Eigen::Vector3d(0.5, 0, 0));
+  // set a Jacobian matrix
+  Jacobian jacobian("test_robot", 3);
+  jacobian.set_data(Eigen::MatrixXd::Random(6, 3));
+  // check command
+  JointTorques command = impedance_controller.compute_command(desired_state, feedback_state, jacobian);
+  // expect some non null data
+  EXPECT_TRUE(command.data().norm() > 0.);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
At the beginning, the controllers library was designed with double space (effectively double `template`) to allow things like:

```
Impedance<CartesianState, JointState> controller;
JointTorques command = controller.compute_command(CartesianTwist desired, CartesianTwist feedback, Jacobian jacobian)
```

This is interesting but has some inherent problems. It is very verbose, hard to implement and the solution to overcome some of the conversion between the different types effectively breaks the inheritance capabilities. Also, checking for the double type and ensuring that all conversions actually make sense is hard to maintain.

As I believe, the conversion to one space to the other requires always extra input (in the example above the Jacobian matrix) we can work around that by adding extra `compute_command` functions with said extra parameters, effectively removing the need for the double space.

This PR introduces a solution with single input space and such conversion functions. If you think it make sense, I propose we change to this paradigm. 

Development side note: When doing copy constructor, the compiler complains that the assigment operator (`operator=`) is not defined. I have implemented them using the copy swap idiom (https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Copy-and-swap) which is a very elegant solution to this. I think we can reuse that for later development / refactor. Note that I have used a `friend` swap paradigm as it seems to be the most accepted pattern now.