### PR TITLE
Do not compute the damping in case of null velocity

### DIFF
--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -155,8 +155,8 @@ public:
 
 template<class S>
 Dissipative<S>::Dissipative(const ComputationalSpaceType& computational_space, unsigned int nb_dimensions) :
-    Impedance<S>(Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions),
-                 Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions),
+    Impedance<S>(Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions),
+                 Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions),
                  Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions)),
     computational_space_(computational_space),
     nb_dimensions_(nb_dimensions),

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -243,33 +243,53 @@ Eigen::MatrixXd Dissipative<S>::compute_orthonormal_basis(const Eigen::MatrixXd&
 
 template<class S>
 void Dissipative<S>::compute_damping(const Eigen::VectorXd& desired_velocity) {
+  double tolerance = 1e-4;
   Eigen::MatrixXd updated_basis = Eigen::MatrixXd::Zero(this->nb_dimensions_, this->nb_dimensions_);
   switch (this->computational_space_) {
-    case ComputationalSpaceType::LINEAR:
+    case ComputationalSpaceType::LINEAR: {
+      Eigen::Vector3d linear_velocity = desired_velocity.segment(0, 3);
+      // only update the damping if the commanded linear velocity is non null
+      if (linear_velocity.norm() < tolerance) { return; }
       //return only the linear block
       updated_basis.block<3, 3>(0, 0) =
-          this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0),
-                                          desired_velocity.segment(0, 3));
+          this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0), linear_velocity);
       break;
-    case ComputationalSpaceType::ANGULAR:
+    }
+    case ComputationalSpaceType::ANGULAR: {
+      Eigen::Vector3d angular_velocity = desired_velocity.segment(3, 3);
+      // only update the damping if the commanded angular velocity is non null
+      if (angular_velocity.norm() < tolerance) { return; }
       // return only the angular block
       updated_basis.block<3, 3>(3, 3) =
-          this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3),
-                                          desired_velocity.segment(3, 3));
+          this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3), angular_velocity);
       break;
-    case ComputationalSpaceType::DECOUPLED_TWIST:
+    }
+    case ComputationalSpaceType::DECOUPLED_TWIST: {
       // compute per block
-      updated_basis.block<3, 3>(0, 0) =
-          this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0),
-                                          desired_velocity.segment(0, 3));
-      updated_basis.block<3, 3>(3, 3) =
-          this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3),
-                                          desired_velocity.segment(3, 3));
+      bool updated = false;
+      Eigen::Vector3d linear_velocity = desired_velocity.segment(0, 3);
+      Eigen::Vector3d angular_velocity = desired_velocity.segment(3, 3);
+      if (linear_velocity.norm() > tolerance) {
+        updated_basis.block<3, 3>(0, 0) =
+            this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0), linear_velocity);
+        updated = true;
+      }
+      if (angular_velocity.norm() > tolerance) {
+        updated_basis.block<3, 3>(3, 3) =
+            this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3), angular_velocity);
+        updated = true;
+      }
+      // at least the linear or angular parts have been updated
+      if (!updated) { return; }
       break;
-    case ComputationalSpaceType::FULL:
+    }
+    case ComputationalSpaceType::FULL: {
+      // only update the damping if the commanded velocity is non null
+      if (desired_velocity.norm() < tolerance) { return; }
       // return the full damping matrix
       updated_basis = this->compute_orthonormal_basis(this->basis_, desired_velocity);
       break;
+    }
   }
   this->basis_ = updated_basis;
   this->set_damping(this->basis_ * this->get_diagonal_eigenvalues() * this->basis_.transpose());

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -249,7 +249,9 @@ void Dissipative<S>::compute_damping(const Eigen::VectorXd& desired_velocity) {
     case ComputationalSpaceType::LINEAR: {
       Eigen::Vector3d linear_velocity = desired_velocity.segment(0, 3);
       // only update the damping if the commanded linear velocity is non null
-      if (linear_velocity.norm() < tolerance) { return; }
+      if (linear_velocity.norm() < tolerance) {
+        return;
+      }
       //return only the linear block
       updated_basis.block<3, 3>(0, 0) =
           this->compute_orthonormal_basis(this->basis_.block<3, 3>(0, 0), linear_velocity);
@@ -258,7 +260,9 @@ void Dissipative<S>::compute_damping(const Eigen::VectorXd& desired_velocity) {
     case ComputationalSpaceType::ANGULAR: {
       Eigen::Vector3d angular_velocity = desired_velocity.segment(3, 3);
       // only update the damping if the commanded angular velocity is non null
-      if (angular_velocity.norm() < tolerance) { return; }
+      if (angular_velocity.norm() < tolerance) {
+        return;
+      }
       // return only the angular block
       updated_basis.block<3, 3>(3, 3) =
           this->compute_orthonormal_basis(this->basis_.block<3, 3>(3, 3), angular_velocity);
@@ -280,12 +284,16 @@ void Dissipative<S>::compute_damping(const Eigen::VectorXd& desired_velocity) {
         updated = true;
       }
       // at least the linear or angular parts have been updated
-      if (!updated) { return; }
+      if (!updated) {
+        return;
+      }
       break;
     }
     case ComputationalSpaceType::FULL: {
       // only update the damping if the commanded velocity is non null
-      if (desired_velocity.norm() < tolerance) { return; }
+      if (desired_velocity.norm() < tolerance) {
+        return;
+      }
       // return the full damping matrix
       updated_basis = this->compute_orthonormal_basis(this->basis_, desired_velocity);
       break;

--- a/source/controllers/tests/testDissipativeImpedanceController.cpp
+++ b/source/controllers/tests/testDissipativeImpedanceController.cpp
@@ -70,7 +70,10 @@ TEST_F(DissipativeImpedanceControllerTest, TestOrthonormalize) {
 TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingLinear) {
   Eigen::MatrixXd damping;
   Eigen::Matrix3d identity3 = Eigen::Matrix3d::Identity();
-  Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
+  Eigen::VectorXd eigenvector;
+  do {
+    eigenvector = Eigen::VectorXd::Random(6);
+  } while(eigenvector.norm() < 1e-4);
   Eigen::Matrix3d block;
   // case LINEAR
   set_controller_space(ComputationalSpaceType::LINEAR);
@@ -95,7 +98,10 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingLinear) {
 TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingAngular) {
   Eigen::MatrixXd damping;
   Eigen::Matrix3d identity3 = Eigen::Matrix3d::Identity();
-  Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
+  Eigen::VectorXd eigenvector;
+  do {
+    eigenvector = Eigen::VectorXd::Random(6);
+  } while(eigenvector.norm() < 1e-4);
   Eigen::Matrix3d block;
   set_controller_space(ComputationalSpaceType::ANGULAR);
   task_controller_.compute_damping(eigenvector);
@@ -119,7 +125,10 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingAngular) {
 TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingDecoupledTwist) {
   Eigen::MatrixXd damping;
   Eigen::MatrixXd identity6 = Eigen::MatrixXd::Identity(6, 6);
-  Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
+  Eigen::VectorXd eigenvector;
+  do {
+    eigenvector = Eigen::VectorXd::Random(6);
+  } while(eigenvector.norm() < 1e-4);
   // case DECOUPLED_TWIST
   set_controller_space(ComputationalSpaceType::DECOUPLED_TWIST);
   task_controller_.compute_damping(eigenvector);
@@ -135,7 +144,10 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingDecoupledTwist) {
 TEST_F(DissipativeImpedanceControllerTest, TestComputeDampingFull) {
   Eigen::MatrixXd damping;
   Eigen::MatrixXd identity6 = Eigen::MatrixXd::Identity(6, 6);
-  Eigen::VectorXd eigenvector = Eigen::VectorXd::Random(6);
+  Eigen::VectorXd eigenvector;
+  do {
+    eigenvector = Eigen::VectorXd::Random(6);
+  } while(eigenvector.norm() < 1e-4);
   // case TWIST
   set_controller_space(ComputationalSpaceType::FULL);
   task_controller_.compute_damping(eigenvector);


### PR DESCRIPTION
Something I totally forgot is that the damping matrix is not valid if you set the first eigenvector to 0. Therefore, I have added all the checking condition to ensure not computing that when this arrives.

Also doing so I realized a silly mistake in the `Dissipative` constructor (the power of testing) where the stiffness matrix was set to `Identity` instead of the damping one.