### PR TITLE
Add a README for CartesianState

### DIFF
--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -24,7 +24,8 @@ s1.set_orientation(Eigen::Quaterniond(0, 1, 0, 0));
 By default, quaternions are normalized on setting, therefore:
 
 ```cpp
-s2.set_orientation(Eigen::Quaterniond(1, 1, 0, 0)); // will be rendered as Eigen::Quaterniond(0.70710678, 0.70710678, 0. , 0.)
+// will be rendered as Eigen::Quaterniond(0.70710678, 0.70710678, 0. , 0.)
+s2.set_orientation(Eigen::Quaterniond(1, 1, 0, 0));
 ```
 
 The state variables are also grouped in `pose` (`position` and `orientation`), `twist` (`linear_velocity` and `angular_velocity`), `accelerations` (`linear_acceleration` and `angular_acceleration`) and `wrench` (`force` and `torque`).
@@ -48,7 +49,8 @@ Basic operations between frames such as addition, substractions, scaling are def
 StateRepresentation::CartesianState s1("a"); // reference frame is world by default
 StateRepresentation::CartesianState s2("b");
 
-// for this operation to be valid both s1 and s2 should be expressed in the same reference frame
+// for this operation to be valid both s1 and s2
+// should be expressed in the same reference frame
 StateRepresentation::CartesianState ssum = s1 + s2;
 ```
 
@@ -56,7 +58,8 @@ StateRepresentation::CartesianState ssum = s1 + s2;
 StateRepresentation::CartesianState s1("a"); // reference frame is world by default
 StateRepresentation::CartesianState s2("b");
 
-// for this operation to be valid both s1 and s2 should be expressed in the same reference frame
+// for this operation to be valid both s1 and s2
+// should be expressed in the same reference frame
 StateRepresentation::CartesianState sdiff = s1 - s2;
 ```
 
@@ -76,7 +79,8 @@ StateRepresentation::CartesianState wSa("a"); // reference frame is world by def
 StateRepresentation::CartesianState aSb("b", "a");
 
 // for this operation to be valid aSb should be expressed in a (wSa)
-StateRepresentation::CartesianState wSb = wSa + aSb; // the result is b expressed in world
+// the result is b expressed in world
+StateRepresentation::CartesianState wSb = wSa + aSb; 
 ```
 
 Not only does that apply a changing of reference frame but it also express all the state variables of `aSb` in the desired reference frame (here `world`), taking into account the dynamic of the frame `wSa`, i.e. if `wSa` has a `twist` or `acceleration` it will affect the state variables of `wSb`.
@@ -84,20 +88,22 @@ Not only does that apply a changing of reference frame but it also express all t
 ### Specific state variables
 
 Full `CartesianState` can be difficult to handle as they contain all the dynamics of the frame when, sometime, you just want to express a `pose` without `twist`, `accelerations` or `wrench`. Therefore, extra classes representing only those specific state variables have been defined, `CartesianPose`, `CartesianTwist` and `CartesianWrench`.
-Effectively, they all extend from `CartesianState` hence they can be interwined as will.
+Effectively, they all extend from `CartesianState` hence they can be intertwined as will.
 
 ```cpp
 StateRepresentation::CartesianPose wPa("a");
 StateRepresentation::CartesianState aSb("b", "a");
 
-StateRepresentation::CartesianState wSa = wPa + aSb; // the result is state b espressed in world
+// the result is state b expressed in world
+StateRepresentation::CartesianState wSa = wPa + aSb;
 ```
 
 ```cpp
 StateRepresentation::CartesianPose wPa("a");
 StateRepresentation::CartesianTwist aVb("b", "a");
 
-StateRepresentation::CartesianTwist wVa = wPa + aVb; // the result is twist b espressed in world
+// the result is twist b expressed in world
+StateRepresentation::CartesianTwist wVa = wPa + aVb;
 ```
 
 ### Conversion between state variables
@@ -110,7 +116,8 @@ auto period = 1h;
 
 CartesianPose wPa("a", Eigen::Vector3d(1,0,0))
 
-CartesianTwist wVa = wPa / period; // the result is a twist of 1m/h in x direction converted in m/s
+// the result is a twist of 1m/h in x direction converted in m/s
+CartesianTwist wVa = wPa / period;
 ```
 
 Conversely, multiplying a `CartesianTwist` (by default expressed internally in `m/s` and `rad/s`) to a `CartesianPose` is simply multiplying it by a time period:

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -1,8 +1,8 @@
 # state_representation
 
 This library provides a set of classes to represent **states** in **cartesian** or **joint** spaces, **parameters**, or **geometrical shapes** that can be used as obstacles.
-Those are set of helpers functions to handle common concepts in robotics such as transformations between frames and the link between then and the robot state.
-This description covers most of the functionalities starting from the spatial tranformations.
+Those are a set of helpers functions to handle common concepts in robotics such as transformations between frames and the link between them and the robot state.
+This description covers most of the functionalities starting from the spatial transformations.
 
 ## Cartesian state
 
@@ -21,7 +21,7 @@ s1.set_position(Eigen::Vector3d(0, 1, 0)); // 1 meter in y direction
 s1.set_orientation(Eigen::Quaterniond(0, 1, 0, 0));
 ```
 
-By default, quaternions are nomarlized on setting, therefore:
+By default, quaternions are normalized on setting, therefore:
 
 ```cpp
 s2.set_orientation(Eigen::Quaterniond(1, 1, 0, 0)); // will be rendered as Eigen::Quaterniond(0.70710678, 0.70710678, 0. , 0.)
@@ -75,8 +75,8 @@ One of the most useful operation is the multiplication between two states that c
 StateRepresentation::CartesianState wSa("a"); // reference frame is world by default
 StateRepresentation::CartesianState aSb("b", "a");
 
-// for this operation to be valid s2 should be expressed a (s1)
-StateRepresentation::CartesianState wSb = wSa + aSb; // the result is b espressed in world
+// for this operation to be valid aSb should be expressed in a (wSa)
+StateRepresentation::CartesianState wSb = wSa + aSb; // the result is b expressed in world
 ```
 
 Not only does that apply a changing of reference frame but it also express all the state variables of `aSb` in the desired reference frame (here `world`), taking into account the dynamic of the frame `wSa`, i.e. if `wSa` has a `twist` or `acceleration` it will affect the state variables of `wSb`.

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -28,45 +28,33 @@ By default, quaternions are normalized on setting, therefore:
 s2.set_orientation(Eigen::Quaterniond(1, 1, 0, 0));
 ```
 
-The state variables are also grouped in `pose` (`position` and `orientation`), `twist` (`linear_velocity` and `angular_velocity`), `accelerations` (`linear_acceleration` and `angular_acceleration`) and `wrench` (`force` and `torque`).
+The state variables are also grouped in `pose` (`position` and `orientation`), `twist` (`linear_velocity` and
+`angular_velocity`), `accelerations` (`linear_acceleration` and `angular_acceleration`) and `wrench` (`force` and `torque`).
 Getter and setters are also implemented to do those bulk operations.
 
 ```cpp
-s2.set_twist(Eigen::VectorXd::Random(6))
+s2.set_twist(Eigen::VectorXd::Random(6));
 ```
 
 Note that for `pose`, it will be a `7d` vector (3 for `position` and 4 for `orientation`):
 
 ```cpp
-s2.set_pose(Eigen::VectorXd::Random(7))
+s2.set_pose(Eigen::VectorXd::Random(7));
 ```
 
 ### States operations
 
-Basic operations between frames such as addition, substractions, scaling are defined, and applied on all the state variables.
+Basic operations between frames such as addition, subtractions, scaling are defined, and applied on all the state variables.
 
 ```cpp
 StateRepresentation::CartesianState s1("a"); // reference frame is world by default
 StateRepresentation::CartesianState s2("b");
-
-// for this operation to be valid both s1 and s2
-// should be expressed in the same reference frame
-StateRepresentation::CartesianState ssum = s1 + s2;
-```
-
-```cpp
-StateRepresentation::CartesianState s1("a"); // reference frame is world by default
-StateRepresentation::CartesianState s2("b");
-
-// for this operation to be valid both s1 and s2
-// should be expressed in the same reference frame
-StateRepresentation::CartesianState sdiff = s1 - s2;
-```
-
-```cpp
-StateRepresentation::CartesianState s1("a"); // reference frame is world by default
 double lamda = 0.5
 
+// for those operation to be valid both s1 and s2
+// should be expressed in the same reference frame
+StateRepresentation::CartesianState ssum = s1 + s2;
+StateRepresentation::CartesianState sdiff = s1 - s2;
 StateRepresentation::CartesianState sscaled = lambda * s1;
 ```
 
@@ -83,11 +71,16 @@ StateRepresentation::CartesianState aSb("b", "a");
 StateRepresentation::CartesianState wSb = wSa + aSb; 
 ```
 
-Not only does that apply a changing of reference frame but it also express all the state variables of `aSb` in the desired reference frame (here `world`), taking into account the dynamic of the frame `wSa`, i.e. if `wSa` has a `twist` or `acceleration` it will affect the state variables of `wSb`.
+Not only does that apply a changing of reference frame but it also express all the state variables of `aSb`
+in the desired reference frame (here `world`), taking into account the dynamic of the frame `wSa`,
+i.e. if `wSa` has a `twist` or `acceleration` it will affect the state variables of `wSb`.
 
 ### Specific state variables
 
-Full `CartesianState` can be difficult to handle as they contain all the dynamics of the frame when, sometime, you just want to express a `pose` without `twist`, `accelerations` or `wrench`. Therefore, extra classes representing only those specific state variables have been defined, `CartesianPose`, `CartesianTwist` and `CartesianWrench`.
+Full `CartesianState` can be difficult to handle as they contain all the dynamics of the frame when, sometime,
+you just want to express a `pose` without `twist`, `accelerations` or `wrench`.
+Therefore, extra classes representing only those specific state variables have been defined, `CartesianPose`,
+`CartesianTwist` and `CartesianWrench`.
 Effectively, they all extend from `CartesianState` hence they can be intertwined as will.
 
 ```cpp
@@ -108,16 +101,17 @@ StateRepresentation::CartesianTwist wVa = wPa + aVb;
 
 ### Conversion between state variables
 
-The distinction with those specific extra variables allows to define some extra conversion operations. Therefore, dividing a `CartesianPose` by a time (`std::chrono_literals`) returns a `CartesianTwist`:
+The distinction with those specific extra variables allows to define some extra conversion operations.
+Therefore, dividing a `CartesianPose` by a time (`std::chrono_literals`) returns a `CartesianTwist`:
 
 ```cpp
 using namespace std::chrono_literals;
 auto period = 1h;
 
-CartesianPose wPa("a", Eigen::Vector3d(1,0,0))
+StateRepresentation::CartesianPose wPa("a", Eigen::Vector3d(1,0,0));
 
 // the result is a twist of 1m/h in x direction converted in m/s
-CartesianTwist wVa = wPa / period;
+StateRepresentation::CartesianTwist wVa = wPa / period;
 ```
 
 Conversely, multiplying a `CartesianTwist` (by default expressed internally in `m/s` and `rad/s`) to a `CartesianPose` is simply multiplying it by a time period:
@@ -126,9 +120,9 @@ Conversely, multiplying a `CartesianTwist` (by default expressed internally in `
 using namespace std::chrono_literals;
 auto period = 10s;
 
-CartesianTwist wVa("a", Eigen::Vector3d(1,0,0))
+StateRepresentation::CartesianTwist wVa("a", Eigen::Vector3d(1,0,0));
 
-CartesianPose wPa = period * wVa // note that wVa * period is also implemented
+StateRepresentation::CartesianPose wPa = period * wVa; // note that wVa * period is also implemented
 ```
 
 ## Joint state

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -42,9 +42,10 @@ Note that for `pose`, it will be a `7d` vector (3 for `position` and 4 for `orie
 s2.set_pose(Eigen::VectorXd::Random(7));
 ```
 
-### States operations
+### State operations
 
 Basic operations between frames such as addition, subtractions, scaling are defined, and applied on all the state variables.
+It is very important to note that those operations are only valid if both states are expressed in the same reference frame.
 
 ```cpp
 StateRepresentation::CartesianState s1("a"); // reference frame is world by default
@@ -56,6 +57,23 @@ double lamda = 0.5
 StateRepresentation::CartesianState ssum = s1 + s2;
 StateRepresentation::CartesianState sdiff = s1 - s2;
 StateRepresentation::CartesianState sscaled = lambda * s1;
+```
+
+Also, despite common mathematical interpretation, the `+` operator is **not commutative** due to the orientation part of the state.
+The addition `s1 + s2` corresponds to the transformation from the `world` frame to frame `a` followed by the transformation
+from `world` frame to frame `b`.
+If both frames have the same orientation then the `+` operator is commutative.
+
+```cpp
+StateRepresentation::CartesianState s1("a");
+StateRepresentation::CartesianState s2("b");
+s1.set_orientation(Eigen::Quaterniond(0,1,0,0));
+s2.set_orientation(Eigen::Quaterniond::UnitRandom());
+
+StateRepresentation::CartesianState ssum1 = s1 + s2;
+StateRepresentation::CartesianState ssum2 = s2 + s1;
+
+ssum1 != ssum2;
 ```
 
 ### Changing of reference frame

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -68,7 +68,7 @@ StateRepresentation::CartesianState aSb("b", "a");
 
 // for this operation to be valid aSb should be expressed in a (wSa)
 // the result is b expressed in world
-StateRepresentation::CartesianState wSb = wSa + aSb; 
+StateRepresentation::CartesianState wSb = wSa * aSb;
 ```
 
 Not only does that apply a changing of reference frame but it also express all the state variables of `aSb`


### PR DESCRIPTION
This PR starts the documentation for `state_representation` with `CartesianState`. It explains the concepts and provides example for the main operations. It will be followed by the `JointState` one. 