### PR TITLE
Fix JointVelocities conversion

### DIFF
--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -94,7 +94,7 @@ JointVelocities JointPositions::operator/(const std::chrono::nanoseconds& dt) co
   // convert the period to a double with the second as reference
   double period = dt.count();
   period /= 1e9;
-  // multiply the positions by this period value and assign it as velocity
+  // divide the positions by this period value and assign it as velocities
   velocities.set_velocities(this->get_positions() / period);
   return velocities;
 }

--- a/source/state_representation/src/Robot/JointVelocities.cpp
+++ b/source/state_representation/src/Robot/JointVelocities.cpp
@@ -94,8 +94,8 @@ JointPositions JointVelocities::operator*(const std::chrono::nanoseconds& dt) co
   // convert the period to a double with the second as reference
   double period = dt.count();
   period /= 1e9;
-  // multiply the positions by this period value
-  displacement *= period;
+  // multiply the velocities by this period value and assign it as position
+  displacement.set_positions(period * this->get_velocities());
   return displacement;
 }
 


### PR DESCRIPTION
Fix a silly bug in the `JointVelocities` conversion to `JointPositions` (`operator*` with `std::chrono_literals`) where the conversion was actually not happening and even leading to an empty state exception. This type of error definitely shows that the test coverage is inefficient at the moment. Also correct the comment in the `JointPositions` conversion which was stating the opposite operation