### PR TITLE
Add Zero and Random joint states initializers

### DIFF
--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -68,6 +68,38 @@ public:
   JointPositions(const JointVelocities& positions);
 
   /**
+   * @brief Constructor for the zero JointPositions
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with zero values in all attributes
+   */
+  static JointPositions Zero(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the zero JointPositions
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with zero values in all attributes
+   */
+  static JointPositions Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
+   * @brief Constructor for the random JointPositions
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with random values in all attributes
+   */
+  static JointPositions Random(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the random JointPositions
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with random values in all attributes
+   */
+  static JointPositions Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param positions the state with value to assign
    * @return reference to the current state with new values

--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -71,7 +71,7 @@ public:
    * @brief Constructor for the zero JointPositions
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointState with zero values in all attributes
+   * @return JointPositions with zero positions values
    */
   static JointPositions Zero(const std::string& robot_name, unsigned int nb_joints);
 
@@ -79,7 +79,7 @@ public:
    * @brief Constructor for the zero JointPositions
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointState with zero values in all attributes
+   * @return JointPositions with zero positions values
    */
   static JointPositions Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
@@ -87,7 +87,7 @@ public:
    * @brief Constructor for the random JointPositions
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointState with random values in all attributes
+   * @return JointPositions with random positions values
    */
   static JointPositions Random(const std::string& robot_name, unsigned int nb_joints);
 
@@ -95,7 +95,7 @@ public:
    * @brief Constructor for the random JointPositions
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointState with random values in all attributes
+   * @return JointPositions with zero positions values
    */
   static JointPositions Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
 

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -102,15 +102,15 @@ public:
 
   /**
    * @brief Constructor with name and number of joints provided
-   * @brief name the name of the state
-   * @brief nb_joints the number of joints for initialization
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
    */
   explicit JointState(const std::string& robot_name, unsigned int nb_joints = 0);
 
   /**
    * @brief Constructor with name and list of joint names provided
-   * @brief name the name of the state
-   * @brief joint_names list of joint names
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
    */
   explicit JointState(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
@@ -118,6 +118,38 @@ public:
    * @brief Copy constructor of a JointState
    */
   JointState(const JointState& state);
+
+  /**
+   * @brief Constructor for the zero JointState
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with zero values in all attributes
+   */
+  static JointState Zero(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the zero JointState
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with zero values in all attributes
+   */
+  static JointState Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
+   * @brief Constructor for the random JointState
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with random values in all attributes
+   */
+  static JointState Random(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the random JointState
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with random values in all attributes
+   */
+  static JointState Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
   /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -63,7 +63,7 @@ public:
    * @brief Constructor for the zero JointTorques
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointState with zero values in all attributes
+   * @return JointTorques with zero velocities values
    */
   static JointTorques Zero(const std::string& robot_name, unsigned int nb_joints);
 
@@ -71,7 +71,7 @@ public:
    * @brief Constructor for the zero JointTorques
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointState with zero values in all attributes
+   * @return JointTorques with zero velocities values
    */
   static JointTorques Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
@@ -79,7 +79,7 @@ public:
    * @brief Constructor for the random JointTorques
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointState with random values in all attributes
+   * @return JointTorques with random velocities values
    */
   static JointTorques Random(const std::string& robot_name, unsigned int nb_joints);
 
@@ -87,7 +87,7 @@ public:
    * @brief Constructor for the random JointTorques
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointState with random values in all attributes
+   * @return JointTorques with random velocities values
    */
   static JointTorques Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
 

--- a/source/state_representation/include/state_representation/Robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointTorques.hpp
@@ -60,6 +60,38 @@ public:
   JointTorques(const JointState& state);
 
   /**
+   * @brief Constructor for the zero JointTorques
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with zero values in all attributes
+   */
+  static JointTorques Zero(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the zero JointTorques
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with zero values in all attributes
+   */
+  static JointTorques Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
+   * @brief Constructor for the random JointTorques
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with random values in all attributes
+   */
+  static JointTorques Random(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the random JointTorques
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with random values in all attributes
+   */
+  static JointTorques Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -71,7 +71,7 @@ public:
    * @brief Constructor for the zero JointVelocities
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointState with zero values in all attributes
+   * @return JointVelocities with zero velocities values
    */
   static JointVelocities Zero(const std::string& robot_name, unsigned int nb_joints);
 
@@ -79,7 +79,7 @@ public:
    * @brief Constructor for the zero JointVelocities
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointState with zero values in all attributes
+   * @return JointVelocities with zero velocities values
    */
   static JointVelocities Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
@@ -87,7 +87,7 @@ public:
    * @brief Constructor for the random JointVelocities
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointState with random values in all attributes
+   * @return JointVelocities with random velocities values
    */
   static JointVelocities Random(const std::string& robot_name, unsigned int nb_joints);
 
@@ -95,7 +95,7 @@ public:
    * @brief Constructor for the random JointVelocities
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointState with random values in all attributes
+   * @return JointVelocities with random velocities values
    */
   static JointVelocities Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
 

--- a/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointVelocities.hpp
@@ -68,6 +68,38 @@ public:
   JointVelocities(const JointPositions& positions);
 
   /**
+   * @brief Constructor for the zero JointVelocities
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with zero values in all attributes
+   */
+  static JointVelocities Zero(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the zero JointVelocities
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with zero values in all attributes
+   */
+  static JointVelocities Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
+   * @brief Constructor for the random JointVelocities
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @return JointState with random values in all attributes
+   */
+  static JointVelocities Random(const std::string& robot_name, unsigned int nb_joints);
+
+  /**
+   * @brief Constructor for the random JointVelocities
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @return JointState with random values in all attributes
+   */
+  static JointVelocities Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values

--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -29,6 +29,22 @@ JointPositions::JointPositions(const JointState& state) : JointState(state) {}
 
 JointPositions::JointPositions(const JointVelocities& velocities) : JointState(std::chrono::seconds(1) * velocities) {}
 
+JointPositions JointPositions::Zero(const std::string& robot_name, unsigned int nb_joints) {
+  return JointState::Zero(robot_name, nb_joints);
+}
+
+JointPositions JointPositions::Zero(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  return JointState::Zero(robot_name, joint_names);
+}
+
+JointPositions JointPositions::Random(const std::string& robot_name, unsigned int nb_joints) {
+  return JointPositions(robot_name, Eigen::VectorXd::Random(nb_joints));
+}
+
+JointPositions JointPositions::Random(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  return JointPositions(robot_name, joint_names, Eigen::VectorXd::Random(joint_names.size()));
+}
+
 JointPositions& JointPositions::operator+=(const JointPositions& positions) {
   this->JointState::operator+=(positions);
   return (*this);

--- a/source/state_representation/src/Robot/JointState.cpp
+++ b/source/state_representation/src/Robot/JointState.cpp
@@ -45,6 +45,36 @@ void JointState::set_zero() {
   this->torques.setZero();
 }
 
+JointState JointState::Zero(const std::string& robot_name, unsigned int nb_joints) {
+  JointState zero = JointState(robot_name, nb_joints);
+  // as opposed to the constructor specify this state to be filled
+  zero.set_filled();
+  return zero;
+}
+
+JointState JointState::Zero(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  JointState zero = JointState(robot_name, joint_names);
+  // as opposed to the constructor specify this state to be filled
+  zero.set_filled();
+  return zero;
+}
+
+JointState JointState::Random(const std::string& robot_name, unsigned int nb_joints) {
+  JointState random = JointState(robot_name, nb_joints);
+  // set all the state variables to random
+  random.set_state_variable(Eigen::VectorXd::Random(random.get_size() * 4),
+                            JointStateVariable::ALL);
+  return random;
+}
+
+JointState JointState::Random(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  JointState random = JointState(robot_name, joint_names);
+  // set all the state variables to random
+  random.set_state_variable(Eigen::VectorXd::Random(random.get_size() * 4),
+                            JointStateVariable::ALL);
+  return random;
+}
+
 JointState& JointState::operator+=(const JointState& state) {
   if (!this->is_compatible(state)) {
     throw IncompatibleStatesException(

--- a/source/state_representation/src/Robot/JointTorques.cpp
+++ b/source/state_representation/src/Robot/JointTorques.cpp
@@ -26,6 +26,22 @@ JointTorques::JointTorques(const JointTorques& torques) : JointState(torques) {}
 
 JointTorques::JointTorques(const JointState& state) : JointState(state) {}
 
+JointTorques JointTorques::Zero(const std::string& robot_name, unsigned int nb_joints) {
+  return JointState::Zero(robot_name, nb_joints);
+}
+
+JointTorques JointTorques::Zero(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  return JointState::Zero(robot_name, joint_names);
+}
+
+JointTorques JointTorques::Random(const std::string& robot_name, unsigned int nb_joints) {
+  return JointTorques(robot_name, Eigen::VectorXd::Random(nb_joints));
+}
+
+JointTorques JointTorques::Random(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  return JointTorques(robot_name, joint_names, Eigen::VectorXd::Random(joint_names.size()));
+}
+
 JointTorques& JointTorques::operator+=(const JointTorques& torques) {
   this->JointState::operator+=(torques);
   return (*this);

--- a/source/state_representation/src/Robot/JointVelocities.cpp
+++ b/source/state_representation/src/Robot/JointVelocities.cpp
@@ -29,6 +29,22 @@ JointVelocities::JointVelocities(const JointState& state) : JointState(state) {}
 
 JointVelocities::JointVelocities(const JointPositions& positions) : JointState(positions / std::chrono::seconds(1)) {}
 
+JointVelocities JointVelocities::Zero(const std::string& robot_name, unsigned int nb_joints) {
+  return JointState::Zero(robot_name, nb_joints);
+}
+
+JointVelocities JointVelocities::Zero(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  return JointState::Zero(robot_name, joint_names);
+}
+
+JointVelocities JointVelocities::Random(const std::string& robot_name, unsigned int nb_joints) {
+  return JointVelocities(robot_name, Eigen::VectorXd::Random(nb_joints));
+}
+
+JointVelocities JointVelocities::Random(const std::string& robot_name, const std::vector<std::string>& joint_names) {
+  return JointVelocities(robot_name, joint_names, Eigen::VectorXd::Random(joint_names.size()));
+}
+
 JointVelocities& JointVelocities::operator+=(const JointVelocities& velocities) {
   this->JointState::operator+=(velocities);
   return (*this);

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -5,63 +5,6 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
-TEST(AddTwoState, PositiveNos) {
-  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
-  Eigen::VectorXd pos2 = Eigen::VectorXd::Random(4);
-
-  StateRepresentation::JointState j1("test_robot", 4);
-  j1.set_positions(pos1);
-
-  StateRepresentation::JointState j2("test_robot", 4);
-  j2.set_positions(pos2);
-
-  StateRepresentation::JointState jsum = j1 + j2;
-  for (unsigned int i = 0; i < j1.get_size(); ++i) {
-    EXPECT_TRUE(jsum.get_positions()(i) == j1.get_positions()(i) + j2.get_positions()(i));
-  }
-}
-
-TEST(SubstractTwoState, PositiveNos) {
-  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
-  Eigen::VectorXd pos2 = Eigen::VectorXd::Random(4);
-
-  StateRepresentation::JointState j1("test_robot", 4);
-  j1.set_positions(pos1);
-
-  StateRepresentation::JointState j2("test_robot", 4);
-  j2.set_positions(pos2);
-
-  StateRepresentation::JointState jdiff = j1 - j2;
-  for (unsigned int i = 0; i < j1.get_size(); ++i) {
-    EXPECT_TRUE(jdiff.get_positions()(i) == j1.get_positions()(i) - j2.get_positions()(i));
-  }
-}
-
-TEST(MultiplyByScalar, PositiveNos) {
-  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
-
-  StateRepresentation::JointState j1("test_robot", 4);
-  j1.set_positions(pos1);
-
-  StateRepresentation::JointState jsum = 0.5 * j1;
-  for (unsigned int i = 0; i < j1.get_size(); ++i) {
-    EXPECT_TRUE(jsum.get_positions()(i) == 0.5 * j1.get_positions()(i));
-  }
-}
-
-TEST(MultiplyByArray, PositiveNos) {
-  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
-  Eigen::MatrixXd gain = Eigen::VectorXd::Random(16).asDiagonal();
-
-  StateRepresentation::JointState j1("test_robot", 4);
-  j1.set_positions(pos1);
-
-  StateRepresentation::JointState jsum = gain * j1;
-  for (unsigned int i = 0; i < j1.get_size(); ++i) {
-    EXPECT_TRUE(jsum.get_positions()(i) == gain(i, i) * j1.get_positions()(i));
-  }
-}
-
 TEST(ZeroInitialization, PositiveNos) {
   StateRepresentation::JointState zero = StateRepresentation::JointState::Zero("test", 3);
   // the joint state should not be considered empty (as it is properly initialized)
@@ -105,7 +48,7 @@ TEST(RandomPositionsInitialization, PositiveNos) {
   // same for the second initializer
   StateRepresentation::JointPositions random2 =
       StateRepresentation::JointPositions::Random("test",
-                                              std::vector<std::string>{"j0", "j1"});
+                                                  std::vector<std::string>{"j0", "j1"});
   // only position should be random
   EXPECT_TRUE(random2.get_positions().norm() > 0);
   EXPECT_TRUE(random2.get_velocities().norm() == 0);
@@ -123,7 +66,7 @@ TEST(RandomVelocitiesInitialization, PositiveNos) {
   // same for the second initializer
   StateRepresentation::JointVelocities random2 =
       StateRepresentation::JointVelocities::Random("test",
-                                                  std::vector<std::string>{"j0", "j1"});
+                                                   std::vector<std::string>{"j0", "j1"});
   // only velocities should be random
   EXPECT_TRUE(random2.get_positions().norm() == 0);
   EXPECT_TRUE(random2.get_velocities().norm() > 0);
@@ -141,12 +84,46 @@ TEST(RandomTorquesInitialization, PositiveNos) {
   // same for the second initializer
   StateRepresentation::JointTorques random2 =
       StateRepresentation::JointTorques::Random("test",
-                                                   std::vector<std::string>{"j0", "j1"});
+                                                std::vector<std::string>{"j0", "j1"});
   // only torques should be random
   EXPECT_TRUE(random2.get_positions().norm() == 0);
   EXPECT_TRUE(random2.get_velocities().norm() == 0);
   EXPECT_TRUE(random2.get_accelerations().norm() == 0);
   EXPECT_TRUE(random2.get_torques().norm() > 0);
+}
+
+TEST(GetData, PositiveNos) {
+  StateRepresentation::JointState js = StateRepresentation::JointState::Random("test_robot", 4);
+  Eigen::VectorXd concatenated_state(js.get_size() * 4);
+  concatenated_state << js.get_positions(), js.get_velocities(), js.get_accelerations(), js.get_torques();
+  EXPECT_NEAR(concatenated_state.norm(), js.data().norm(), 1e-4);
+}
+
+TEST(AddTwoState, PositiveNos) {
+  StateRepresentation::JointState j1 = StateRepresentation::JointState::Random("test_robot", 4);
+  StateRepresentation::JointState j2 = StateRepresentation::JointState::Random("test_robot", 4);
+  StateRepresentation::JointState jsum = j1 + j2;
+  EXPECT_NEAR(jsum.data().norm(), (j1.data() + j2.data()).norm(), 1e-4);
+}
+
+TEST(SubstractTwoState, PositiveNos) {
+  StateRepresentation::JointState j1 = StateRepresentation::JointState::Random("test_robot", 4);
+  StateRepresentation::JointState j2 = StateRepresentation::JointState::Random("test_robot", 4);
+  StateRepresentation::JointState jdiff = j1 - j2;
+  EXPECT_NEAR(jdiff.data().norm(), (j1.data() - j2.data()).norm(), 1e-4);
+}
+
+TEST(MultiplyByScalar, PositiveNos) {
+  StateRepresentation::JointState js = StateRepresentation::JointState::Random("test_robot", 4);
+  StateRepresentation::JointState jscaled = 0.5 * js;
+  EXPECT_NEAR(jscaled.data().norm(), (0.5 * js.data()).norm(), 1e-4);
+}
+
+TEST(MultiplyByArray, PositiveNos) {
+  StateRepresentation::JointState js = StateRepresentation::JointState::Random("test_robot", 4);
+  Eigen::MatrixXd gain = Eigen::VectorXd::Random(16).asDiagonal();
+  StateRepresentation::JointState jscaled = gain * js;
+  EXPECT_NEAR(jscaled.data().norm(), (gain * js.data()).norm(), 1e-4);
 }
 
 int main(int argc, char** argv) {

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -62,6 +62,93 @@ TEST(MultiplyByArray, PositiveNos) {
   }
 }
 
+TEST(ZeroInitialization, PositiveNos) {
+  StateRepresentation::JointState zero = StateRepresentation::JointState::Zero("test", 3);
+  // the joint state should not be considered empty (as it is properly initialized)
+  EXPECT_FALSE(zero.is_empty());
+  // all data should be zero
+  EXPECT_TRUE(zero.data().norm() == 0);
+  // same for the second initializer
+  StateRepresentation::JointState zero2 = StateRepresentation::JointState::Zero("test",
+                                                                                std::vector<std::string>{"j0", "j1"});
+  // the joint state should not be considered empty (as it is properly initialized)
+  EXPECT_FALSE(zero2.is_empty());
+  // all data should be zero
+  EXPECT_TRUE(zero2.data().norm() == 0);
+}
+
+TEST(RandomStateInitialization, PositiveNos) {
+  StateRepresentation::JointState random = StateRepresentation::JointState::Random("test", 3);
+  // all data should be random (non 0)
+  EXPECT_TRUE(random.get_positions().norm() > 0);
+  EXPECT_TRUE(random.get_velocities().norm() > 0);
+  EXPECT_TRUE(random.get_accelerations().norm() > 0);
+  EXPECT_TRUE(random.get_torques().norm() > 0);
+  // same for the second initializer
+  StateRepresentation::JointState random2 =
+      StateRepresentation::JointState::Random("test",
+                                              std::vector<std::string>{"j0", "j1"});
+  // all data should be random (non 0)
+  EXPECT_TRUE(random2.get_positions().norm() > 0);
+  EXPECT_TRUE(random2.get_velocities().norm() > 0);
+  EXPECT_TRUE(random2.get_accelerations().norm() > 0);
+  EXPECT_TRUE(random2.get_torques().norm() > 0);
+}
+
+TEST(RandomPositionsInitialization, PositiveNos) {
+  StateRepresentation::JointPositions random = StateRepresentation::JointPositions::Random("test", 3);
+  // only position should be random
+  EXPECT_TRUE(random.get_positions().norm() > 0);
+  EXPECT_TRUE(random.get_velocities().norm() == 0);
+  EXPECT_TRUE(random.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random.get_torques().norm() == 0);
+  // same for the second initializer
+  StateRepresentation::JointPositions random2 =
+      StateRepresentation::JointPositions::Random("test",
+                                              std::vector<std::string>{"j0", "j1"});
+  // all data should be random (non 0)
+  EXPECT_TRUE(random2.get_positions().norm() > 0);
+  EXPECT_TRUE(random2.get_velocities().norm() == 0);
+  EXPECT_TRUE(random2.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random2.get_torques().norm() == 0);
+}
+
+TEST(RandomVelocitiesInitialization, PositiveNos) {
+  StateRepresentation::JointVelocities random = StateRepresentation::JointVelocities::Random("test", 3);
+  // only position should be random
+  EXPECT_TRUE(random.get_positions().norm() == 0);
+  EXPECT_TRUE(random.get_velocities().norm() > 0);
+  EXPECT_TRUE(random.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random.get_torques().norm() == 0);
+  // same for the second initializer
+  StateRepresentation::JointVelocities random2 =
+      StateRepresentation::JointVelocities::Random("test",
+                                                  std::vector<std::string>{"j0", "j1"});
+  // all data should be random (non 0)
+  EXPECT_TRUE(random2.get_positions().norm() == 0);
+  EXPECT_TRUE(random2.get_velocities().norm() > 0);
+  EXPECT_TRUE(random2.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random2.get_torques().norm() == 0);
+}
+
+TEST(RandomTorquesInitialization, PositiveNos) {
+  StateRepresentation::JointTorques random = StateRepresentation::JointTorques::Random("test", 3);
+  // only position should be random
+  EXPECT_TRUE(random.get_positions().norm() == 0);
+  EXPECT_TRUE(random.get_velocities().norm() == 0);
+  EXPECT_TRUE(random.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random.get_torques().norm() > 0);
+  // same for the second initializer
+  StateRepresentation::JointTorques random2 =
+      StateRepresentation::JointTorques::Random("test",
+                                                   std::vector<std::string>{"j0", "j1"});
+  // all data should be random (non 0)
+  EXPECT_TRUE(random2.get_positions().norm() == 0);
+  EXPECT_TRUE(random2.get_velocities().norm() == 0);
+  EXPECT_TRUE(random2.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random2.get_torques().norm() > 0);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -106,7 +106,7 @@ TEST(RandomPositionsInitialization, PositiveNos) {
   StateRepresentation::JointPositions random2 =
       StateRepresentation::JointPositions::Random("test",
                                               std::vector<std::string>{"j0", "j1"});
-  // all data should be random (non 0)
+  // only position should be random
   EXPECT_TRUE(random2.get_positions().norm() > 0);
   EXPECT_TRUE(random2.get_velocities().norm() == 0);
   EXPECT_TRUE(random2.get_accelerations().norm() == 0);
@@ -115,7 +115,7 @@ TEST(RandomPositionsInitialization, PositiveNos) {
 
 TEST(RandomVelocitiesInitialization, PositiveNos) {
   StateRepresentation::JointVelocities random = StateRepresentation::JointVelocities::Random("test", 3);
-  // only position should be random
+  // only velocities should be random
   EXPECT_TRUE(random.get_positions().norm() == 0);
   EXPECT_TRUE(random.get_velocities().norm() > 0);
   EXPECT_TRUE(random.get_accelerations().norm() == 0);
@@ -124,7 +124,7 @@ TEST(RandomVelocitiesInitialization, PositiveNos) {
   StateRepresentation::JointVelocities random2 =
       StateRepresentation::JointVelocities::Random("test",
                                                   std::vector<std::string>{"j0", "j1"});
-  // all data should be random (non 0)
+  // only velocities should be random
   EXPECT_TRUE(random2.get_positions().norm() == 0);
   EXPECT_TRUE(random2.get_velocities().norm() > 0);
   EXPECT_TRUE(random2.get_accelerations().norm() == 0);
@@ -133,7 +133,7 @@ TEST(RandomVelocitiesInitialization, PositiveNos) {
 
 TEST(RandomTorquesInitialization, PositiveNos) {
   StateRepresentation::JointTorques random = StateRepresentation::JointTorques::Random("test", 3);
-  // only position should be random
+  // only torques should be random
   EXPECT_TRUE(random.get_positions().norm() == 0);
   EXPECT_TRUE(random.get_velocities().norm() == 0);
   EXPECT_TRUE(random.get_accelerations().norm() == 0);
@@ -142,7 +142,7 @@ TEST(RandomTorquesInitialization, PositiveNos) {
   StateRepresentation::JointTorques random2 =
       StateRepresentation::JointTorques::Random("test",
                                                    std::vector<std::string>{"j0", "j1"});
-  // all data should be random (non 0)
+  // only torques should be random
   EXPECT_TRUE(random2.get_positions().norm() == 0);
   EXPECT_TRUE(random2.get_velocities().norm() == 0);
   EXPECT_TRUE(random2.get_accelerations().norm() == 0);


### PR DESCRIPTION
I thought those were already implemented but they are actually missing. So here are static `Zero` and `Random` initializers for all the `JointStates` classes. I think those are useful to have, especially for testing.