### PR TITLE
Remove modulo joint positions

### DIFF
--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -483,8 +483,6 @@ inline const Eigen::VectorXd& JointState::get_positions() const {
 
 inline void JointState::set_positions(const Eigen::VectorXd& positions) {
   this->set_state_variable(this->positions, positions);
-  // positions are angles between -pi and pi
-  this->positions = positions.unaryExpr([](double x) { return atan2(sin(x), cos(x)); });
 }
 
 inline void JointState::set_positions(const std::vector<double>& positions) {

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -5,31 +5,6 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
-TEST(SetPositonsWithModulo, PositiveNos) {
-  Eigen::VectorXd positions(4);
-  positions << 1, 2, 3, 4;
-
-  StateRepresentation::JointState j1("test_robot", 4);
-  j1.set_positions(positions);
-
-  std::cerr << j1 << std::endl;
-
-  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(-M_PI < j1.get_positions()(i) && j1.get_positions()(i) < M_PI);
-}
-
-TEST(SetPositonsWithModuloAndNegativeNumbers, PositiveNos) {
-  Eigen::VectorXd positions(4);
-  positions << -1, -2, -3, -4;
-
-  StateRepresentation::JointState j1("test_robot", 4);
-  j1.set_positions(positions);
-
-  std::cerr << j1 << std::endl;
-
-  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(-M_PI < j1.get_positions()(i) && j1.get_positions()(i) < M_PI);
-  EXPECT_TRUE(j1.get_positions()(0) < 0 && j1.get_positions()(3) > 0);
-}
-
 TEST(AddTwoState, PositiveNos) {
   Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
   Eigen::VectorXd pos2 = Eigen::VectorXd::Random(4);
@@ -41,7 +16,25 @@ TEST(AddTwoState, PositiveNos) {
   j2.set_positions(pos2);
 
   StateRepresentation::JointState jsum = j1 + j2;
-  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(j1.get_positions()(i) + j2.get_positions()(i)), cos(j1.get_positions()(i) + j2.get_positions()(i))));
+  for (unsigned int i = 0; i < j1.get_size(); ++i) {
+    EXPECT_TRUE(jsum.get_positions()(i) == j1.get_positions()(i) + j2.get_positions()(i));
+  }
+}
+
+TEST(SubstractTwoState, PositiveNos) {
+  Eigen::VectorXd pos1 = Eigen::VectorXd::Random(4);
+  Eigen::VectorXd pos2 = Eigen::VectorXd::Random(4);
+
+  StateRepresentation::JointState j1("test_robot", 4);
+  j1.set_positions(pos1);
+
+  StateRepresentation::JointState j2("test_robot", 4);
+  j2.set_positions(pos2);
+
+  StateRepresentation::JointState jdiff = j1 - j2;
+  for (unsigned int i = 0; i < j1.get_size(); ++i) {
+    EXPECT_TRUE(jdiff.get_positions()(i) == j1.get_positions()(i) - j2.get_positions()(i));
+  }
 }
 
 TEST(MultiplyByScalar, PositiveNos) {
@@ -51,7 +44,9 @@ TEST(MultiplyByScalar, PositiveNos) {
   j1.set_positions(pos1);
 
   StateRepresentation::JointState jsum = 0.5 * j1;
-  for (unsigned int i = 0; i < j1.get_size(); ++i) EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(0.5 * j1.get_positions()(i)), cos(0.5 * j1.get_positions()(i))));
+  for (unsigned int i = 0; i < j1.get_size(); ++i) {
+    EXPECT_TRUE(jsum.get_positions()(i) == 0.5 * j1.get_positions()(i));
+  }
 }
 
 TEST(MultiplyByArray, PositiveNos) {
@@ -63,7 +58,7 @@ TEST(MultiplyByArray, PositiveNos) {
 
   StateRepresentation::JointState jsum = gain * j1;
   for (unsigned int i = 0; i < j1.get_size(); ++i) {
-    EXPECT_TRUE(jsum.get_positions()(i) == atan2(sin(gain(i, i) * j1.get_positions()(i)), cos(gain(i, i) * j1.get_positions()(i))));
+    EXPECT_TRUE(jsum.get_positions()(i) == gain(i, i) * j1.get_positions()(i));
   }
 }
 


### PR DESCRIPTION
@domire8 this one is for you. Simple, remove the joint positions limitation and adapt the test appropriately. I have also added a test on the `operator-` because the `+` and `*` were there but not the `-`. Those tests need refining anyway using the random states from #38 for example.