### PR TITLE
Add github action and workflow for CI building and testing

### DIFF
--- a/.github/actions/build-test/Dockerfile
+++ b/.github/actions/build-test/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest
+
+# Copy and set the entrypoint commands to execute when the container starst
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -1,0 +1,5 @@
+name: 'Build and Test'
+description: 'Build the project sources and run all unit tests'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/build-test/entrypoint.sh
+++ b/.github/actions/build-test/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -l
+
+cd /github/workspace/source && mkdir build && cd build || exit 1
+
+echo "Configuring cmake"
+cmake -DBUILD_CONTROLLERS=ON -DBUILD_DYNAMICAL_SYSTEMS=ON -DBUILD_ROBOT_MODEL=ON -DBUILD_TESTING=ON ..
+
+echo "Building project"
+make -j all
+
+echo "Running all test stages"
+CTEST_OUTPUT_ON_FAILURE=1 make test
+
+echo "Test stages completed successfully!"
+exit 0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,23 @@
+name: Build and Test
+
+# Run workflow on pushes to main and develop branches, on any pull request, or by manual dispatch
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+# Define the build test job
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    name: Build the source code and run all unit tests
+    steps:
+      # First check out the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Load the repository build-test action
+      - name: Build and Test
+        uses: ./.github/actions/build-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,11 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp/osqp_build
 RUN git clone --recursive https://github.com/oxfordcontrol/osqp \
     && cd osqp && mkdir build && cd build && cmake -G "Unix Makefiles" .. && cmake --build . --target install
-  # install osqp eigen wrapper
-WORKDIR /tmp/osqp_build
+
 RUN git clone https://github.com/robotology/osqp-eigen.git \
     && cd osqp-eigen && mkdir build && cd build && cmake .. && make -j && make install
+
+RUN rm -rf /tmp/*
 
 
 FROM project-dependencies as development-dependencies
@@ -62,7 +63,9 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp/gtest_build
 RUN cmake /usr/src/gtest \
   && make \
-  && cp lib/* /usr/local/lib
+  && cp lib/* /usr/local/lib || cp *.a /usr/local/lib
+
+RUN rm -rf /tmp/*
 
 
 FROM development-dependencies as remote-development

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+Main branch status: ![Main branch status](https://github.com/epfl-lasa/control_libraries/actions/workflows/build-test.yml/badge.svg) \
+Development branch status: ![Development branch status](https://github.com/epfl-lasa/control_libraries/actions/workflows/build-test.yml/badge.svg?branch=develop)
+
 # control_libraries
 Set of libraries to facilitate the creation of control loop algorithms


### PR DESCRIPTION
My fellow collaborators, the time has come! Here I am adding the necessary files to enable automatic build and testing to occur on a push to main or develop, on opening a PR, or when manually triggered. I also show the main and develop build and test status with badges in the README.

To verify that the workflow was working correctly, I forked this repo and pushed to my local main. I had to fix some bugs along the way, but I got it working in the end. 

You may view the results of my testing here:
https://github.com/eeberhard/control_libraries/runs/1989608708?check_suite_focus=true