### PR TITLE
Refactor CartesianState Random & Identity initializers

### DIFF
--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
@@ -62,7 +62,7 @@ public:
   /**
    * @brief Constructor for the identity pose
    * @param name the name of the state
-   * @param the name of the reference frame
+   * @param reference the name of the reference frame
    * @return CartesianPose identity pose
    */
   static CartesianPose Identity(const std::string& name, const std::string& reference = "world");
@@ -70,7 +70,7 @@ public:
   /**
    * @brief Constructor for a random pose
    * @param name the name of the state
-   * @param the name of the reference frame
+   * @param reference the name of the reference frame
    * @return CartesianPose random pose
    */
   static CartesianPose Random(const std::string& name, const std::string& reference = "world");

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -44,7 +44,9 @@ enum class CartesianStateVariable {
  * the distance on. Default ALL for full distance across all dimensions
  * @return the distance beteen the two states
  */
-double dist(const CartesianState& s1, const CartesianState& s2, const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL);
+double dist(const CartesianState& s1,
+            const CartesianState& s2,
+            const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL);
 
 /**
  * @class CartesianState
@@ -81,7 +83,9 @@ private:
    * @param angular_state_variable the angular part of the state variable to fill
    * @param new_value the new value of the state variable
    */
-  void set_state_variable(Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable, const Eigen::Matrix<double, 6, 1>& new_value);
+  void set_state_variable(Eigen::Vector3d& linear_state_variable,
+                          Eigen::Vector3d& angular_state_variable,
+                          const Eigen::Matrix<double, 6, 1>& new_value);
 
   /**
    * @brief Set new_value in the provided state_variable (twist, accelerations or wrench)
@@ -89,7 +93,9 @@ private:
    * @param angular_state_variable the angular part of the state variable to fill
    * @param new_value the new value of the state variable
    */
-  void set_state_variable(Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable, const std::vector<double>& new_value);
+  void set_state_variable(Eigen::Vector3d& linear_state_variable,
+                          Eigen::Vector3d& angular_state_variable,
+                          const std::vector<double>& new_value);
 
 protected:
   /**
@@ -125,27 +131,30 @@ public:
   CartesianState(const CartesianState& state);
 
   /**
- * @brief Constructor for the identity CartesianState (identity pose and 0 for the rest)
- * @param name the name of the state
- * @param reference the name of the reference frame
- * @return CartesianState identity state
- */
+   * @brief Constructor for the identity CartesianState (identity pose and 0 for the rest)
+   * @param name the name of the state
+   * @param reference the name of the reference frame
+   * @return CartesianState identity state
+   */
   static CartesianState Identity(const std::string& name, const std::string& reference = "world");
 
   /**
- * @brief Constructor for a random state
- * @param name the name of the state
- * @param reference the name of the reference frame
- * @return CartesianState random state
- */
+   * @brief Constructor for a random state
+   * @param name the name of the state
+   * @param reference the name of the reference frame
+   * @return CartesianState random state
+   */
   static CartesianState Random(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
    */
   CartesianState& operator=(const CartesianState& state);
 
   /**
-   * @brief Getter of the posistion attribute
+   * @brief Getter of the position attribute
    */
   const Eigen::Vector3d& get_position() const;
 
@@ -335,7 +344,9 @@ public:
    * @param noise_ratio if provided, this value will be used to apply a deadzone under which
    * the velocity will be set to 0
    */
-  void clamp_state_variable(double max_value, const CartesianStateVariable& state_variable_type, double noise_ratio = 0);
+  void clamp_state_variable(double max_value,
+                            const CartesianStateVariable& state_variable_type,
+                            double noise_ratio = 0);
 
   /**
    * @brief Return a copy of the CartesianState
@@ -425,7 +436,8 @@ public:
    * the distance on. Default ALL for full distance across all dimensions
    * @return dist the distance value as a double
    */
-  double dist(const CartesianState& state, const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
+  double dist(const CartesianState& state,
+              const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -483,7 +495,10 @@ inline const Eigen::Quaterniond& CartesianState::get_orientation() const {
 }
 
 inline Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
-  return Eigen::Vector4d(this->get_orientation().w(), this->get_orientation().x(), this->get_orientation().y(), this->get_orientation().z());
+  return Eigen::Vector4d(this->get_orientation().w(),
+                         this->get_orientation().x(),
+                         this->get_orientation().y(),
+                         this->get_orientation().z());
 }
 
 inline Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {
@@ -596,12 +611,16 @@ inline void CartesianState::set_state_variable(Eigen::Vector3d& state_variable, 
   this->set_state_variable(state_variable, Eigen::Vector3d::Map(new_value.data(), new_value.size()));
 }
 
-inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable, const Eigen::Matrix<double, 6, 1>& new_value) {
+inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable,
+                                               Eigen::Vector3d& angular_state_variable,
+                                               const Eigen::Matrix<double, 6, 1>& new_value) {
   this->set_state_variable(linear_state_variable, new_value.head(3));
   this->set_state_variable(angular_state_variable, new_value.tail(3));
 }
 
-inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable, const std::vector<double>& new_value) {
+inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable,
+                                               Eigen::Vector3d& angular_state_variable,
+                                               const std::vector<double>& new_value) {
   this->set_state_variable(linear_state_variable, std::vector<double>(new_value.begin(), new_value.begin() + 3));
   this->set_state_variable(angular_state_variable, std::vector<double>(new_value.begin() + 3, new_value.end()));
 }
@@ -628,7 +647,9 @@ inline void CartesianState::set_orientation(const Eigen::Vector4d& orientation) 
 }
 
 inline void CartesianState::set_orientation(const std::vector<double>& orientation) {
-  if (orientation.size() != 4) throw Exceptions::IncompatibleSizeException("The input vector is not of size 4 required for orientation");
+  if (orientation.size() != 4) {
+    throw Exceptions::IncompatibleSizeException("The input vector is not of size 4 required for orientation");
+  }
   this->set_orientation(Eigen::Vector4d::Map(orientation.data(), orientation.size()));
 }
 
@@ -643,7 +664,9 @@ inline void CartesianState::set_pose(const Eigen::Matrix<double, 7, 1>& pose) {
 }
 
 inline void CartesianState::set_pose(const std::vector<double>& pose) {
-  if (pose.size() != 7) throw Exceptions::IncompatibleSizeException("The input vector is not of size 7 required for pose");
+  if (pose.size() != 7) {
+    throw Exceptions::IncompatibleSizeException("The input vector is not of size 7 required for pose");
+  }
   this->set_position(std::vector<double>(pose.begin(), pose.begin() + 3));
   this->set_orientation(std::vector<double>(pose.begin() + 3, pose.end()));
 }
@@ -684,7 +707,8 @@ inline void CartesianState::set_wrench(const Eigen::Matrix<double, 6, 1>& wrench
   this->set_state_variable(this->force, this->torque, wrench);
 }
 
-inline void CartesianState::set_state_variable(const Eigen::VectorXd& new_value, const CartesianStateVariable& state_variable_type) {
+inline void CartesianState::set_state_variable(const Eigen::VectorXd& new_value,
+                                               const CartesianStateVariable& state_variable_type) {
   switch (state_variable_type) {
     case CartesianStateVariable::POSITION:
       this->set_position(new_value);

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -125,7 +125,20 @@ public:
   CartesianState(const CartesianState& state);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+ * @brief Constructor for the identity CartesianState (identity pose and 0 for the rest)
+ * @param name the name of the state
+ * @param reference the name of the reference frame
+ * @return CartesianState identity state
+ */
+  static CartesianState Identity(const std::string& name, const std::string& reference = "world");
+
+  /**
+ * @brief Constructor for a random state
+ * @param name the name of the state
+ * @param reference the name of the reference frame
+ * @return CartesianState random state
+ */
+  static CartesianState Random(const std::string& name, const std::string& reference = "world");
    * @param state the state with value to assign
    * @return reference to the current state with new values
    */

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianTwist.hpp
@@ -60,7 +60,7 @@ public:
   /**
    * @brief Constructor for the zero twist
    * @param name the name of the state
-   * @param the name of the reference frame
+   * @param reference the name of the reference frame
    * @return CartesianTwist with zero values
    */
   static CartesianTwist Zero(const std::string& name, const std::string& reference = "world");
@@ -68,7 +68,7 @@ public:
   /**
    * @brief Constructor for a random twist
    * @param name the name of the state
-   * @param the name of the reference frame
+   * @param reference the name of the reference frame
    * @return CartesianTwist random twist
    */
   static CartesianTwist Random(const std::string& name, const std::string& reference = "world");

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianWrench.hpp
@@ -52,7 +52,7 @@ public:
   /**
    * @brief Constructor for the zero wrench
    * @param name the name of the state
-   * @param the name of the reference frame
+   * @param reference the name of the reference frame
    * @return CartesianWrench with zero values
    */
   static CartesianWrench Zero(const std::string& name, const std::string& reference = "world");
@@ -60,7 +60,7 @@ public:
   /**
    * @brief Constructor for a random wrench
    * @param name the name of the state
-   * @param the name of the reference frame
+   * @param reference the name of the reference frame
    * @return CartesianWrench random wrench
    */
   static CartesianWrench Random(const std::string& name, const std::string& reference = "world");

--- a/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
@@ -1,8 +1,6 @@
 #include "state_representation/Space/Cartesian/CartesianPose.hpp"
 #include "state_representation/Exceptions/EmptyStateException.hpp"
-#include "state_representation/Exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/Exceptions/IncompatibleSizeException.hpp"
-#include "state_representation/Exceptions/IncompatibleStatesException.hpp"
 
 using namespace StateRepresentation::Exceptions;
 
@@ -31,7 +29,7 @@ CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state
 CartesianPose::CartesianPose(const CartesianTwist& twist) : CartesianState(std::chrono::seconds(1) * twist) {}
 
 CartesianPose CartesianPose::Identity(const std::string& name, const std::string& reference) {
-  return CartesianPose(name, Eigen::Vector3d::Zero(), Eigen::Quaterniond::Identity(), reference);
+  return CartesianState::Identity(name, reference);
 }
 
 CartesianPose CartesianPose::Random(const std::string& name, const std::string& reference) {

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -36,6 +36,21 @@ void CartesianState::set_zero() {
   this->torque.setZero();
 }
 
+CartesianState CartesianState::Identity(const std::string& name, const std::string& reference) {
+  CartesianState identity = CartesianState(name, reference);
+  // as opposed to the constructor specify this state to be filled
+  identity.set_filled();
+  return identity;
+}
+
+CartesianState CartesianState::Random(const std::string& name, const std::string& reference){
+  CartesianState random = CartesianState(name, reference);
+  // set all the state variables to random
+  random.set_state_variable(Eigen::VectorXd::Random(25),
+                            CartesianStateVariable::ALL);
+  return random;
+}
+
 CartesianState& CartesianState::operator*=(double lambda) {
   // sanity check
   if (this->is_empty()) throw EmptyStateException(this->get_name() + " state is empty");

--- a/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianTwist.cpp
@@ -30,9 +30,7 @@ CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(sta
 CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianState(pose / std::chrono::seconds(1)) {}
 
 CartesianTwist CartesianTwist::Zero(const std::string& name, const std::string& reference) {
-  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
-  Eigen::Matrix<double, 6, 1> zero = Eigen::Matrix<double, 6, 1>::Zero();
-  return CartesianTwist(name, zero, reference);
+  return CartesianState::Identity(name, reference);
 }
 
 CartesianTwist CartesianTwist::Random(const std::string& name, const std::string& reference) {

--- a/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianWrench.cpp
@@ -28,9 +28,7 @@ CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianState
 CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(state) {}
 
 CartesianWrench CartesianWrench::Zero(const std::string& name, const std::string& reference) {
-  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
-  Eigen::Matrix<double, 6, 1> zero = Eigen::Matrix<double, 6, 1>::Zero();
-  return CartesianWrench(name, zero, reference);
+  return CartesianState::Identity(name, reference);
 }
 
 CartesianWrench CartesianWrench::Random(const std::string& name, const std::string& reference) {

--- a/source/state_representation/tests/testCartesianState.cpp
+++ b/source/state_representation/tests/testCartesianState.cpp
@@ -7,6 +7,67 @@
 
 using namespace StateRepresentation;
 
+TEST(IdentityInitialization, PositiveNos) {
+  CartesianState identity = CartesianState::Identity("test");
+  // the joint state should not be considered empty (as it is properly initialized)
+  EXPECT_FALSE(identity.is_empty());
+  // all data should be zero except for orientation that should be identity
+  EXPECT_TRUE(identity.get_position().norm() == 0);
+  EXPECT_TRUE(identity.get_orientation().norm() == 1);
+  EXPECT_TRUE(identity.get_orientation().w() == 1);
+  EXPECT_TRUE(identity.get_twist().norm() == 0);
+  EXPECT_TRUE(identity.get_accelerations().norm() == 0);
+  EXPECT_TRUE(identity.get_wrench().norm() == 0);
+}
+
+TEST(RandomStateInitialization, PositiveNos) {
+  CartesianState random = CartesianState::Random("test");
+  // all data should be random (non 0)
+  EXPECT_TRUE(random.get_position().norm() > 0);
+  EXPECT_TRUE(abs(random.get_orientation().w()) > 0);
+  EXPECT_TRUE(abs(random.get_orientation().x()) > 0);
+  EXPECT_TRUE(abs(random.get_orientation().y()) > 0);
+  EXPECT_TRUE(abs(random.get_orientation().z()) > 0);
+  EXPECT_TRUE(random.get_twist().norm() > 0);
+  EXPECT_TRUE(random.get_accelerations().norm() > 0);
+  EXPECT_TRUE(random.get_wrench().norm() > 0);
+}
+
+TEST(RandomPoseInitialization, PositiveNos) {
+  CartesianPose random = CartesianPose::Random("test");
+  // only position should be random
+  EXPECT_TRUE(random.get_position().norm() > 0);
+  EXPECT_TRUE(abs(random.get_orientation().w()) > 0);
+  EXPECT_TRUE(abs(random.get_orientation().x()) > 0);
+  EXPECT_TRUE(abs(random.get_orientation().y()) > 0);
+  EXPECT_TRUE(abs(random.get_orientation().z()) > 0);
+  EXPECT_TRUE(random.get_twist().norm() == 0);
+  EXPECT_TRUE(random.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random.get_wrench().norm() == 0);
+}
+
+TEST(RandomTwistInitialization, PositiveNos) {
+  CartesianTwist random = CartesianTwist::Random("test");
+  // only position should be random
+  EXPECT_TRUE(random.get_position().norm() == 0);
+  EXPECT_TRUE(random.get_orientation().norm() == 1);
+  EXPECT_TRUE(random.get_orientation().w() == 1);
+  EXPECT_TRUE(random.get_twist().norm() > 0);
+  EXPECT_TRUE(random.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random.get_wrench().norm() == 0);
+}
+
+TEST(RandomWrenchInitialization, PositiveNos) {
+  CartesianWrench random = CartesianWrench::Random("test");
+  // only position should be random
+  EXPECT_TRUE(random.get_position().norm() == 0);
+  EXPECT_TRUE(random.get_orientation().norm() == 1);
+  EXPECT_TRUE(random.get_orientation().w() == 1);
+  EXPECT_TRUE(random.get_twist().norm() == 0);
+  EXPECT_TRUE(random.get_accelerations().norm() == 0);
+  EXPECT_TRUE(random.get_wrench().norm() > 0);
+}
+
 TEST(NegateQuaternion, PositiveNos) {
   Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
   Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());


### PR DESCRIPTION
This PR refactors the `Random` and `Identity` initializers from `CartesianState` to have the same behavior as those from `JointState`. It also adds the same test in `testCartesianState`. Some docstring cleaning also appears here as this is a refactor PR I see fit to have them here as well.