### PR TITLE
Refactor to_std_vector function for CartesianState and JointState

### DIFF
--- a/source/state_representation/include/state_representation/Robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointPositions.hpp
@@ -239,12 +239,6 @@ public:
   friend JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& positions);
 
   /**
-   * @brief Return the joint positions as a std vector of floats
-   * @return std::vector<float> the joint positions vector as a std vector
-   */
-  std::vector<double> to_std_vector() const;
-
-  /**
    * @brief Set the value from a std vector
    * @param value the value as a std vector
    */

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -605,6 +605,6 @@ inline void JointState::set_state_variable(const Eigen::VectorXd& new_value,
 
 inline std::vector<double> JointState::to_std_vector() const {
   Eigen::VectorXd data = this->data();
-  return std::vector<double>(data.data(),data.data() + data.size());
+  return std::vector<double>(data.data(), data.data() + data.size());
 }
 }// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/Robot/JointState.hpp
@@ -434,7 +434,7 @@ public:
    * @brief Return the joint state as a std vector of floats
    * @return std::vector<float> the joint vector as a std vector
    */
-  virtual std::vector<double> to_std_vector() const;
+  std::vector<double> to_std_vector() const;
 
   /**
    * @brief Set the value from a std vector
@@ -601,5 +601,10 @@ inline void JointState::set_state_variable(const Eigen::VectorXd& new_value,
       this->set_all_state_variables(new_value);
       break;
   }
+}
+
+inline std::vector<double> JointState::to_std_vector() const {
+  Eigen::VectorXd data = this->data();
+  return std::vector<double>(data.data(),data.data() + data.size());
 }
 }// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianPose.hpp
@@ -201,12 +201,6 @@ public:
   friend CartesianPose operator*(double lambda, const CartesianPose& pose);
 
   /**
-   * @brief Return the pose as a std vector of floats
-   * @return std::vector<float> the pose vector as a 7 elements vector
-   */
-  std::vector<double> to_std_vector() const override;
-
-  /**
    * @brief Set the value from a std vector
    * @param value the value as a std vector
    */

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -769,6 +769,6 @@ inline void CartesianState::set_state_variable(const Eigen::VectorXd& new_value,
 
 inline std::vector<double> CartesianState::to_std_vector() const {
   Eigen::VectorXd data = this->data();
-  return std::vector<double>(data.data(),data.data() + data.size());
+  return std::vector<double>(data.data(), data.data() + data.size());
 }
 }// namespace StateRepresentation

--- a/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/Space/Cartesian/CartesianState.hpp
@@ -468,7 +468,7 @@ public:
    * @brief Return the state as a std vector of floats
    * @return std::vector<float> the state vector as a std vector
    */
-  virtual std::vector<double> to_std_vector() const;
+  std::vector<double> to_std_vector() const;
 
   /**
    * @brief Set the value from a std vector
@@ -765,5 +765,10 @@ inline void CartesianState::set_state_variable(const Eigen::VectorXd& new_value,
       this->set_wrench(new_value.segment(19, 6));
       break;
   }
+}
+
+inline std::vector<double> CartesianState::to_std_vector() const {
+  Eigen::VectorXd data = this->data();
+  return std::vector<double>(data.data(),data.data() + data.size());
 }
 }// namespace StateRepresentation

--- a/source/state_representation/src/Robot/JointPositions.cpp
+++ b/source/state_representation/src/Robot/JointPositions.cpp
@@ -157,11 +157,6 @@ JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& po
   return result;
 }
 
-std::vector<double> JointPositions::to_std_vector() const {
-  std::vector<double> temp(this->get_positions().data(), this->get_positions().data() + this->get_size());
-  return temp;
-}
-
 void JointPositions::from_std_vector(const std::vector<double>& value) {
   this->set_positions(value);
 }

--- a/source/state_representation/src/Robot/JointState.cpp
+++ b/source/state_representation/src/Robot/JointState.cpp
@@ -296,11 +296,6 @@ JointState operator*(const Eigen::ArrayXd& lambda, const JointState& state) {
   return result;
 }
 
-std::vector<double> JointState::to_std_vector() const {
-  throw NotImplementedException("to_std_vector() is not implemented for the base JointState class");
-  return std::vector<double>();
-}
-
 void JointState::from_std_vector(const std::vector<double>&) {
   throw NotImplementedException("from_std_vector() is not implemented for the base JointState class");
 }

--- a/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianPose.cpp
@@ -132,16 +132,6 @@ CartesianPose operator*(double lambda, const CartesianPose& pose) {
   return pose * lambda;
 }
 
-std::vector<double> CartesianPose::to_std_vector() const {
-  std::vector<double> pose = std::vector<double>(this->get_position().data(), this->get_position().data() + 3);
-  pose.resize(7);
-  pose[3] = this->get_orientation().w();
-  pose[4] = this->get_orientation().x();
-  pose[5] = this->get_orientation().y();
-  pose[6] = this->get_orientation().z();
-  return pose;
-}
-
 void CartesianPose::from_std_vector(const std::vector<double>& value) {
   if (value.size() == 3) {
     this->set_position(value);

--- a/source/state_representation/src/Space/Cartesian/CartesianState.cpp
+++ b/source/state_representation/src/Space/Cartesian/CartesianState.cpp
@@ -304,11 +304,6 @@ double dist(const CartesianState& s1, const CartesianState& s2, const CartesianS
   return s1.dist(s2, state_variable_type);
 }
 
-std::vector<double> CartesianState::to_std_vector() const {
-  throw(NotImplementedException("to_std_vector() is not implemented for the base CartesianState class"));
-  return std::vector<double>();
-}
-
 void CartesianState::from_std_vector(const std::vector<double>&) {
   throw(NotImplementedException("from_std_vector() is not implemented for the base CartesianState class"));
 }

--- a/source/state_representation/tests/testCartesianState.cpp
+++ b/source/state_representation/tests/testCartesianState.cpp
@@ -68,6 +68,49 @@ TEST(RandomWrenchInitialization, PositiveNos) {
   EXPECT_TRUE(random.get_wrench().norm() > 0);
 }
 
+TEST(GetData, PositiveNos) {
+  CartesianState cs = CartesianState::Random("test");
+  Eigen::VectorXd concatenated_state(25);
+  concatenated_state << cs.get_pose(), cs.get_twist(), cs.get_accelerations(), cs.get_wrench();
+  EXPECT_NEAR(concatenated_state.norm(), cs.data().norm(), 1e-4);
+}
+
+TEST(CartesianStateToStdVector, PositiveNos) {
+  CartesianState cs = CartesianState::Random("test");
+  std::vector<double> vec_data = cs.to_std_vector();
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(cs.data()(i) == vec_data[i]);
+  }
+}
+
+TEST(CartesianPoseToStdVector, PositiveNos) {
+  CartesianPose cp = CartesianPose::Random("test");
+  std::vector<double> vec_data = cp.to_std_vector();
+  EXPECT_TRUE(vec_data.size() == 7);
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(cp.data()(i) == vec_data[i]);
+  }
+}
+
+TEST(CartesianTwistToStdVector, PositiveNos) {
+  CartesianTwist ct = CartesianTwist::Random("test");
+  std::vector<double> vec_data = ct.to_std_vector();
+  EXPECT_TRUE(vec_data.size() == 6);
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(ct.data()(i) == vec_data[i]);
+  }
+}
+
+TEST(CartesianWrenchToStdVector, PositiveNos) {
+  CartesianWrench cw = CartesianWrench::Random("test");
+  std::vector<double> vec_data = cw.to_std_vector();
+  EXPECT_TRUE(vec_data.size() == 6);
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(cw.data()(i) == vec_data[i]);
+  }
+}
+
+
 TEST(NegateQuaternion, PositiveNos) {
   Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
   Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());

--- a/source/state_representation/tests/testJointState.cpp
+++ b/source/state_representation/tests/testJointState.cpp
@@ -99,6 +99,41 @@ TEST(GetData, PositiveNos) {
   EXPECT_NEAR(concatenated_state.norm(), js.data().norm(), 1e-4);
 }
 
+TEST(JointStateToStdVector, PositiveNos) {
+  StateRepresentation::JointState js = StateRepresentation::JointState::Random("test_robot", 4);
+  std::vector<double> vec_data = js.to_std_vector();
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(js.data()(i) == vec_data[i]);
+  }
+}
+
+TEST(JointPositionsToStdVector, PositiveNos) {
+  StateRepresentation::JointPositions jp = StateRepresentation::JointPositions::Random("test_robot", 4);
+  std::vector<double> vec_data = jp.to_std_vector();
+  EXPECT_TRUE(vec_data.size() == jp.get_size());
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(jp.get_positions()(i) == vec_data[i]);
+  }
+}
+
+TEST(JointVelocitiesToStdVector, PositiveNos) {
+  StateRepresentation::JointVelocities jv = StateRepresentation::JointVelocities::Random("test_robot", 4);
+  std::vector<double> vec_data = jv.to_std_vector();
+  EXPECT_TRUE(vec_data.size() == jv.get_size());
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(jv.get_velocities()(i) == vec_data[i]);
+  }
+}
+
+TEST(JointTorquesToStdVector, PositiveNos) {
+  StateRepresentation::JointTorques jt = StateRepresentation::JointTorques::Random("test_robot", 4);
+  std::vector<double> vec_data = jt.to_std_vector();
+  EXPECT_TRUE(vec_data.size() == jt.get_size());
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_TRUE(jt.get_torques()(i) == vec_data[i]);
+  }
+}
+
 TEST(AddTwoState, PositiveNos) {
   StateRepresentation::JointState j1 = StateRepresentation::JointState::Random("test_robot", 4);
   StateRepresentation::JointState j2 = StateRepresentation::JointState::Random("test_robot", 4);


### PR DESCRIPTION
`to_std_vector` is a conversion function mainly used in `modulo` to convert the states to ros2 parameters. I needed it and realized it was poorly implemented. I refactored it to use the new `data()` functions avoiding code duplication. Tests have been added for those functionalities.