### PR TITLE
Get the name of the joints from the model

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -18,6 +18,7 @@ private:
   // @format:off
   std::shared_ptr<StateRepresentation::Parameter<std::string>> robot_name_;       ///< name of the robot
   std::shared_ptr<StateRepresentation::Parameter<std::string>> urdf_path_;        ///< path to the urdf file
+  std::vector<std::string> frame_names_;                                          ///< name of the frames
   pinocchio::Model robot_model_;                                                  ///< the robot model with pinocchio
   pinocchio::Data robot_data_;                                                    ///< the robot data with pinocchio
   OsqpEigen::Solver solver_;                                                      ///< osqp solver for the quadratic programming based inverse kinematics
@@ -94,13 +95,19 @@ public:
    * @brief Getter of the number of joints
    * @return the number of joints
    */
-  unsigned int get_nb_joints() const;
+  unsigned int get_number_of_joints() const;
 
   /**
-   * Getter of the joint names from the model
-   * @return the joint names
+   * Getter of the joint frames from the model
+   * @return the joint frames
    */
-  std::vector<std::string> get_joint_names() const;
+  std::vector<std::string> get_joint_frames() const;
+
+  /**
+   * Getter of the frames from the model
+   * @return the frame names
+   */
+  std::vector<std::string> get_frames() const;
 
   /**
    * @brief Initialize the pinocchio model from the URDF
@@ -212,21 +219,20 @@ inline void Model::set_urdf_path(const std::string& urdf_path) {
   this->urdf_path_->set_value(urdf_path);
 }
 
-inline unsigned int Model::get_nb_joints() const {
+inline unsigned int Model::get_number_of_joints() const {
   // subtract 1 because of the 'universe' joint
   return this->robot_model_.nq;
 }
 
-inline std::vector<std::string> Model::get_joint_names() const {
+inline std::vector<std::string> Model::get_joint_frames() const {
   // model contains a first joint called universe that needs to be discarded
-  std::vector<std::string> joint_names(this->robot_model_.names.begin() + 1,
+  std::vector<std::string> joint_frames(this->robot_model_.names.begin() + 1,
                                        this->robot_model_.names.end());
-  return joint_names;
+  return joint_frames;
 }
 
-inline void Model::init_model() {
-  pinocchio::urdf::buildModel(this->get_urdf_path(), this->robot_model_);
-  this->robot_data_ = pinocchio::Data(this->robot_model_);
+inline std::vector<std::string> Model::get_frames() const {
+  return this->frame_names_;
 }
 
 inline const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Model::get_parameters() const {

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -38,6 +38,24 @@ private:
    */
   bool init_qp_solver();
 
+  /**
+   * @brief Compute the jacobian from a given joint state at the frame in parameter
+   * @param joint_state containing the joint values of the robot
+   * @param joint_id id of the frame at which to compute the jacobian
+   * @return the jacobian matrix
+   */
+  StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state,
+                                                 unsigned int frame_id);
+
+  /**
+   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
+   * @param joint_state the joint state of the robot
+   * @param frame_ids ids of the frames at which we want to extract the pose
+   * @return the poses of the desired poses
+   */
+  std::vector<StateRepresentation::CartesianPose> forward_geometry(const StateRepresentation::JointState& joint_state,
+                                                                   const std::vector<unsigned int>& frame_ids);
+
 public:
   /**
    * @brief Empty constructor
@@ -56,7 +74,7 @@ public:
   Model(const Model& model);
 
   /**
-   * @brief Desctructor
+   * @brief Destructor
    */
   ~Model();
 
@@ -115,15 +133,6 @@ public:
   void init_model();
 
   /**
-   * @brief Compute the jacobian from a given joint state at the frame in parameter
-   * @param joint_state containing the joint values of the robot
-   * @param joint_id id of the frame at which to compute the jacobian
-   * @return the jacobian matrix
-   */
-  StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state,
-                                                 unsigned int frame_id);
-
-  /**
    * @brief Compute the jacobian from a given joint state at the frame given in parameter
    * @param joint_state containing the joint values of the robot
    * @param frame_name name of the frame at which to compute the jacobian, if empty computed for the last frame
@@ -131,15 +140,6 @@ public:
    */
   StateRepresentation::Jacobian compute_jacobian(const StateRepresentation::JointState& joint_state,
                                                  const std::string& frame_name = "");
-
-  /**
-   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
-   * @param joint_state the joint state of the robot
-   * @param frame_ids ids of the frames at which we want to extract the pose
-   * @return the poses of the desired poses
-   */
-  std::vector<StateRepresentation::CartesianPose> forward_geometry(const StateRepresentation::JointState& joint_state,
-                                                                   const std::vector<unsigned int>& frame_ids);
 
   /**
    * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
@@ -192,7 +192,7 @@ public:
                                                          const StateRepresentation::CartesianState& cartesian_state);
 
   /**
-   * @brief Helper funtion to print the qp_problem (for debugging)
+   * @brief Helper function to print the qp_problem (for debugging)
    */
   void print_qp_problem();
 

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -220,7 +220,6 @@ inline void Model::set_urdf_path(const std::string& urdf_path) {
 }
 
 inline unsigned int Model::get_number_of_joints() const {
-  // subtract 1 because of the 'universe' joint
   return this->robot_model_.nq;
 }
 

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -97,6 +97,12 @@ public:
   unsigned int get_nb_joints() const;
 
   /**
+   * Getter of the joint names from the model
+   * @return the joint names
+   */
+  std::vector<std::string> get_joint_names() const;
+
+  /**
    * @brief Initialize the pinocchio model from the URDF
    */
   void init_model();
@@ -208,7 +214,14 @@ inline void Model::set_urdf_path(const std::string& urdf_path) {
 
 inline unsigned int Model::get_nb_joints() const {
   // subtract 1 because of the 'universe' joint
-  return this->robot_model_.njoints - 1;
+  return this->robot_model_.nq;
+}
+
+inline std::vector<std::string> Model::get_joint_names() const {
+  // model contains a first joint called universe that needs to be discarded
+  std::vector<std::string> joint_names(this->robot_model_.names.begin() + 1,
+                                       this->robot_model_.names.end());
+  return joint_names;
 }
 
 inline void Model::init_model() {

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -129,11 +129,11 @@ StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation:
     throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_nb_joints()));
   }
   // compute the jacobian from the joint state
-  pinocchio::Data::Matrix6x J(6, this->robot_model_.nq);
+  pinocchio::Data::Matrix6x J(6, this->get_nb_joints());
   J.setZero();
   pinocchio::computeFrameJacobian(this->robot_model_, this->robot_data_, joint_state.get_positions(), frame_id,
                                   pinocchio::LOCAL_WORLD_ALIGNED, J);
-  return StateRepresentation::Jacobian(this->get_robot_name(), J);
+  return StateRepresentation::Jacobian(this->get_robot_name(), this->get_joint_names(), J);
 }
 
 StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -41,6 +41,17 @@ Model::Model(const Model& model) :
 
 Model::~Model() {}
 
+void Model::init_model() {
+  pinocchio::urdf::buildModel(this->get_urdf_path(), this->robot_model_);
+  this->robot_data_ = pinocchio::Data(this->robot_model_);
+  // get the frame names
+  std::vector<std::string> frames;
+  for (auto& f : this->robot_model_.frames) {
+    frames.push_back(f.name);
+  }
+  this->frame_names_ = std::vector<std::string>(frames.begin() + 2, frames.end());
+}
+
 Model& Model::operator=(const Model& model) {
   this->robot_name_ = model.robot_name_;
   this->urdf_path_ = model.urdf_path_;
@@ -58,7 +69,7 @@ bool Model::init_qp_solver() {
   this->solver_.data()->clearLinearConstraintsMatrix();
   this->solver_.clearSolver();
 
-  unsigned int nb_joints = this->get_nb_joints();
+  unsigned int nb_joints = this->get_number_of_joints();
   // initialize the matrices
   this->hessian_ = Eigen::SparseMatrix<double>(nb_joints + 1, nb_joints + 1);
   this->gradient_ = Eigen::VectorXd::Zero(nb_joints + 1);
@@ -125,15 +136,15 @@ bool Model::init_qp_solver() {
 
 StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
                                                       unsigned int frame_id) {
-  if (joint_state.get_size() != this->get_nb_joints()) {
-    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_nb_joints()));
+  if (joint_state.get_size() != this->get_number_of_joints()) {
+    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_number_of_joints()));
   }
   // compute the jacobian from the joint state
-  pinocchio::Data::Matrix6x J(6, this->get_nb_joints());
+  pinocchio::Data::Matrix6x J(6, this->get_number_of_joints());
   J.setZero();
   pinocchio::computeFrameJacobian(this->robot_model_, this->robot_data_, joint_state.get_positions(), frame_id,
                                   pinocchio::LOCAL_WORLD_ALIGNED, J);
-  return StateRepresentation::Jacobian(this->get_robot_name(), this->get_joint_names(), J);
+  return StateRepresentation::Jacobian(this->get_robot_name(), this->get_joint_frames(), J);
 }
 
 StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation::JointState& joint_state,
@@ -152,8 +163,8 @@ StateRepresentation::Jacobian Model::compute_jacobian(const StateRepresentation:
 
 std::vector<StateRepresentation::CartesianPose> Model::forward_geometry(
     const StateRepresentation::JointState& joint_state, const std::vector<unsigned int>& frame_ids) {
-  if (joint_state.get_size() != this->get_nb_joints()) {
-    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_nb_joints()));
+  if (joint_state.get_size() != this->get_number_of_joints()) {
+    throw (Exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_number_of_joints()));
   }
   std::vector<StateRepresentation::CartesianPose> pose_vector;
   pinocchio::forwardKinematics(this->robot_model_, this->robot_data_, joint_state.get_positions());
@@ -203,7 +214,7 @@ StateRepresentation::CartesianTwist Model::forward_kinematic(const StateRepresen
 
 StateRepresentation::JointVelocities Model::inverse_kinematic(const StateRepresentation::JointState& joint_state,
                                                               const std::vector<StateRepresentation::CartesianState>& cartesian_states) {
-  const unsigned int nb_joints = this->get_nb_joints();
+  const unsigned int nb_joints = this->get_number_of_joints();
   using namespace StateRepresentation;
   // the velocity vector contains position of the intermediate frame and full pose of the end-effector
   Eigen::VectorXd delta_r(3 * cartesian_states.size() + 3);

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -49,6 +49,7 @@ void Model::init_model() {
   for (auto& f : this->robot_model_.frames) {
     frames.push_back(f.name);
   }
+  // remove universe and root_joint frame added by Pinocchio
   this->frame_names_ = std::vector<std::string>(frames.begin() + 2, frames.end());
 }
 

--- a/source/robot_model/tests/testRobotModel.cpp
+++ b/source/robot_model/tests/testRobotModel.cpp
@@ -68,17 +68,6 @@ TEST_F(RobotModelTest, TestForwardGeometryInvalidFrameName) {
   EXPECT_THROW(franka.forward_geometry(joint_state, "panda_link99"), Exceptions::FrameNotFoundException);
 }
 
-TEST_F(RobotModelTest, TestForwardGeometryInvalidFrameID) {
-  std::vector<unsigned int> frame_ids;
-  frame_ids.push_back(99);
-  EXPECT_THROW(franka.forward_geometry(joint_state, frame_ids), RobotModel::Exceptions::FrameNotFoundException);
-}
-
-TEST_F(RobotModelTest, TestJacobianJointStateSize) {
-  StateRepresentation::JointState dummy = StateRepresentation::JointState(robot_name, 6);
-  EXPECT_THROW(franka.compute_jacobian(dummy, 99), Exceptions::InvalidJointStateSizeException);
-}
-
 TEST_F(RobotModelTest, TestJacobianJointNames) {
   StateRepresentation::JointState dummy = StateRepresentation::JointState(robot_name, 7);
   StateRepresentation::Jacobian jac = franka.compute_jacobian(dummy);
@@ -93,12 +82,12 @@ TEST_F(RobotModelTest, TestJacobianInvalidFrameName) {
 }
 
 TEST_F(RobotModelTest, TestJacobianNbRows) {
-  StateRepresentation::Jacobian jac = franka.compute_jacobian(joint_state, 2);
+  StateRepresentation::Jacobian jac = franka.compute_jacobian(joint_state, "panda_joint2");
   EXPECT_EQ(jac.get_nb_rows(), 6);
 }
 
 TEST_F(RobotModelTest, TestJacobianNbCols) {
-  StateRepresentation::Jacobian jac = franka.compute_jacobian(joint_state, 2);
+  StateRepresentation::Jacobian jac = franka.compute_jacobian(joint_state, "panda_joint2");
   EXPECT_EQ(jac.get_nb_cols(), joint_state.get_size());
 }
 

--- a/source/robot_model/tests/testRobotModel.cpp
+++ b/source/robot_model/tests/testRobotModel.cpp
@@ -79,6 +79,15 @@ TEST_F(RobotModelTest, TestJacobianJointStateSize) {
   EXPECT_THROW(franka.compute_jacobian(dummy, 99), Exceptions::InvalidJointStateSizeException);
 }
 
+TEST_F(RobotModelTest, TestJacobianJointNames) {
+  StateRepresentation::JointState dummy = StateRepresentation::JointState(robot_name, 7);
+  StateRepresentation::Jacobian jac = franka.compute_jacobian(dummy);
+  for (int i = 0; i < 7; ++i) {
+    std::string jname = "panda_joint" + std::to_string(i + 1);
+    EXPECT_TRUE(jname.compare(jac.get_joint_names()[i]) == 0);
+  }
+}
+
 TEST_F(RobotModelTest, TestJacobianInvalidFrameName) {
   EXPECT_THROW(franka.compute_jacobian(joint_state, "panda_link99"), Exceptions::FrameNotFoundException);
 }
@@ -94,7 +103,7 @@ TEST_F(RobotModelTest, TestJacobianNbCols) {
 }
 
 TEST_F(RobotModelTest, TestType) {
-  
+
 }
 
 int main(int argc, char** argv) {

--- a/source/robot_model/tests/testRobotModel.cpp
+++ b/source/robot_model/tests/testRobotModel.cpp
@@ -50,8 +50,8 @@ TEST_F(RobotModelTest, TestConstructor) {
   EXPECT_NO_THROW(franka = tmp);
 }
 
-TEST_F(RobotModelTest, TestNbJoint) {
-  EXPECT_EQ(franka.get_nb_joints(), 7);
+TEST_F(RobotModelTest, TestNumberOfJoints) {
+  EXPECT_EQ(franka.get_number_of_joints(), 7);
 }
 
 TEST_F(RobotModelTest, TestForwardGeometryJointStateSize) {


### PR DESCRIPTION
The name of the joints in the `Jacobian` were set to their default value `{"joint0", "joint1", ..., "jointN"}`. We can access them from the model and this PR is setting the correct joint names to the `Jacobian` at compute time. 