### PR TITLE
Add Cartesian norms computation

### DIFF
--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -170,7 +170,7 @@ CartesianState cs1 = CartesianState::Random("test");
 CartesianState cs2 = CartesianState::Random("test");
 
 double d = cs1.dist(cs2);
-// alternatively one cas used the friend type notation
+// alternatively one can use the friend type notation
 d = dist(cs1, cs2)
 ```
 

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -159,6 +159,53 @@ state_representation::CartesianTwist wVa("a", Eigen::Vector3d(1, 0, 0));
 state_representation::CartesianPose wPa = period * wVa; // note that wVa * period is also implemented
 ```
 
+### Cartesian state distance and norms
+
+As a `CartesianState` represents a spatial transformation, distance between states and norms computations have been
+implemented. The distance functions is represented as the sum of the distance over all the state variables:
+
+```cpp
+using namespace StateRepresentation;
+CartesianState cs1 = CartesianState::Random("test");
+CartesianState cs2 = CartesianState::Random("test");
+
+double d = cs1.dist(cs2);
+// alternatively one cas used the friend type notation
+d = dist(cs1, cs2)
+```
+
+By default, the distance is computed over all the state variables.
+One can specify the state variable to consider using the `CartesianStateVariable` enumeration:
+
+```cpp
+// only the distance in position
+double d_pos = cs1.dist(cs2, CartesianStateVariable::POSITION);
+// distance over the wrench
+double d_wrench = cs1.dist(cs2, CartesianStateVariable::WRENCH);
+```
+
+The norm of a state is using a similar API and returns the norms of each state variable:
+
+```cpp
+using namespace StateRepresentation;
+CartesianState cs = CartesianState::Random("test");
+// default is norm over all the state variables, hence vector is of size 8
+std::vector<double> norms = cs.norms();
+// for only norm over the pose you need to specify it
+std::vector<double> pose_norms = cs.norms(CartesianStateVariable::POSE);
+```
+
+`normalize`, inplace normalization, and the copy normalization, `normalized`, are also implemented:
+
+```cpp
+using namespace StateRepresentation;
+CartesianState cs = CartesianState::Random("test");
+// inplace, default is normalization over all the state variables
+cs.normalize()
+// copied normalized state, with only linear velocity normalized
+CartesianState csn = cs.normalized(CartesianStateVariable::LINEAR_VELOCITY)
+```
+
 ## Joint state
 
 `JointState` follows the same logic as `CartesianState` but for representing robot states.

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -175,6 +175,7 @@ d = dist(cs1, cs2)
 ```
 
 By default, the distance is computed over all the state variables.
+It is worth noting that it has no physical units, but is still relevant to check how far two states are in all their features.
 One can specify the state variable to consider using the `CartesianStateVariable` enumeration:
 
 ```cpp
@@ -184,6 +185,7 @@ double d_pos = cs1.dist(cs2, CartesianStateVariable::POSITION);
 double d_wrench = cs1.dist(cs2, CartesianStateVariable::WRENCH);
 ```
 
+When doing so, the unit of the distance is the one of the corresponding state variable.
 The norm of a state is using a similar API and returns the norms of each state variable:
 
 ```cpp

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -165,7 +165,7 @@ As a `CartesianState` represents a spatial transformation, distance between stat
 implemented. The distance functions is represented as the sum of the distance over all the state variables:
 
 ```cpp
-using namespace StateRepresentation;
+using namespace state_representation;
 CartesianState cs1 = CartesianState::Random("test");
 CartesianState cs2 = CartesianState::Random("test");
 
@@ -189,7 +189,7 @@ When doing so, the unit of the distance is the one of the corresponding state va
 The norm of a state is using a similar API and returns the norms of each state variable:
 
 ```cpp
-using namespace StateRepresentation;
+using namespace state_representation;
 CartesianState cs = CartesianState::Random("test");
 // default is norm over all the state variables, hence vector is of size 8
 std::vector<double> norms = cs.norms();
@@ -200,7 +200,7 @@ std::vector<double> pose_norms = cs.norms(CartesianStateVariable::POSE);
 `normalize`, inplace normalization, and the copy normalization, `normalized`, are also implemented:
 
 ```cpp
-using namespace StateRepresentation;
+using namespace state_representation;
 CartesianState cs = CartesianState::Random("test");
 // inplace, default is normalization over all the state variables
 cs.normalize()

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -186,6 +186,20 @@ public:
   Eigen::VectorXd data() const;
 
   /**
+   * @brief Compute the norms of the state variable specified by the input type (default is full pose)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the norms of the state variables as a vector
+   */
+  std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::POSE) const override;
+
+  /**
+   * @brief Compute the normalized pose at the state variable given in argument (default is full pose)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the normalized pose
+   */
+  CartesianPose normalized(const CartesianStateVariable& state_variable_type = CartesianStateVariable::POSE) const;
+
+  /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to happend the string representing the CartesianPose to
    * @param CartesianPose the CartesianPose to print
@@ -210,5 +224,13 @@ public:
 inline CartesianPose& CartesianPose::operator=(const CartesianPose& pose) {
   CartesianState::operator=(pose);
   return (*this);
+}
+
+inline std::vector<double> CartesianPose::norms(const CartesianStateVariable& state_variable_type) const{
+  return CartesianState::norms(state_variable_type);
+}
+
+inline CartesianPose CartesianPose::normalized(const CartesianStateVariable& state_variable_type) const {
+  return CartesianState::normalized(state_variable_type);
 }
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -440,6 +440,26 @@ public:
               const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
 
   /**
+   * @brief Compute the norms of the state variable specified by the input type (default is full state)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the norms of the state variables as a vector
+   */
+  virtual std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
+
+  /**
+   * @brief Normalize inplace the state at the state variable given in argument (default is full state)
+   * @param state_variable_type the type of state variable to compute the norms on
+   */
+  void normalize(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL);
+
+  /**
+   * @brief Compute the normalized state at the state variable given in argument (default is full state)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the normalized state
+   */
+  CartesianState normalized(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
+
+  /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to happend the string representing the state to
    * @param state the state to print

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -460,9 +460,11 @@ public:
    * @param s2 the second CartesianState
    * @param type of the distance between position, orientation, linear_velocity, etc...
    * default all for full distance across all dimensions
-   * @return the distance beteen the two states
+   * @return the distance between the two states
    */
-  friend double dist(const CartesianState& s1, const CartesianState& s2, const std::string& distance_type);
+  friend double dist(const CartesianState& s1,
+                     const CartesianState& s2,
+                     const CartesianStateVariable& state_variable_type);
 
   /**
    * @brief Return the state as a std vector of floats

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -192,6 +192,20 @@ public:
   Eigen::VectorXd data() const;
 
   /**
+   * @brief Compute the norms of the state variable specified by the input type (default is full twist)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the norms of the state variables as a vector
+   */
+  std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::TWIST) const override;
+
+  /**
+   * @brief Compute the normalized twist at the state variable given in argument (default is full twist)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the normalized twist
+   */
+  CartesianTwist normalized(const CartesianStateVariable& state_variable_type = CartesianStateVariable::TWIST) const;
+
+  /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to happend the string representing the CartesianTwist to
    * @param CartesianTwist the CartesianTwist to print
@@ -224,5 +238,13 @@ public:
 inline CartesianTwist& CartesianTwist::operator=(const CartesianTwist& twist) {
   CartesianState::operator=(twist);
   return (*this);
+}
+
+inline std::vector<double> CartesianTwist::norms(const CartesianStateVariable& state_variable_type) const{
+  return CartesianState::norms(state_variable_type);
+}
+
+inline CartesianTwist CartesianTwist::normalized(const CartesianStateVariable& state_variable_type) const {
+  return CartesianState::normalized(state_variable_type);
 }
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -170,10 +170,18 @@ public:
   Eigen::VectorXd data() const;
 
   /**
-   * @brief Return the value of the 6D wrench as Eigen array
-   * @retrun the Eigen array representing the wrench
+   * @brief Compute the norms of the state variable specified by the input type (default is full wrench)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the norms of the state variables as a vector
    */
-  Eigen::Array<double, 6, 1> array() const;
+  std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::WRENCH) const override;
+
+  /**
+   * @brief Compute the normalized wrench at the state variable given in argument (default is full wrench)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the normalized wrench
+   */
+  CartesianWrench normalized(const CartesianStateVariable& state_variable_type = CartesianStateVariable::WRENCH) const;
 
   /**
    * @brief Overload the ostream operator for printing
@@ -194,5 +202,13 @@ public:
 inline CartesianWrench& CartesianWrench::operator=(const CartesianWrench& wrench) {
   CartesianState::operator=(wrench);
   return (*this);
+}
+
+inline std::vector<double> CartesianWrench::norms(const CartesianStateVariable& state_variable_type) const{
+  return CartesianState::norms(state_variable_type);
+}
+
+inline CartesianWrench CartesianWrench::normalized(const CartesianStateVariable& state_variable_type) const {
+  return CartesianState::normalized(state_variable_type);
 }
 }// namespace state_representation

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -128,8 +128,9 @@ CartesianState& CartesianState::operator*=(const CartesianState& state) {
   this->set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
   // acceleration
   this->set_linear_acceleration(f_a_b + f_R_b * b_a_c
-                                    + f_alpha_b.cross(f_R_b * b_P_c) + 2 * f_omega_b.cross(f_R_b * b_v_c)
-                                    + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
+                                + f_alpha_b.cross(f_R_b * b_P_c) 
+                                + 2 * f_omega_b.cross(f_R_b * b_v_c)
+                                + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
   this->set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
   // wrench
   //TODO
@@ -290,6 +291,90 @@ double CartesianState::dist(const CartesianState& state, const CartesianStateVar
       || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_torque() - state.get_torque()).norm();
   }
+  return result;
+}
+
+std::vector<double> CartesianState::norms(const CartesianStateVariable& state_variable_type) const {
+  // compute the norms for each independent state variable
+  std::vector<double> norms;
+  if (state_variable_type == CartesianStateVariable::POSITION || state_variable_type == CartesianStateVariable::POSE
+      || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_position().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::ORIENTATION || state_variable_type == CartesianStateVariable::POSE
+      || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_orientation().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::LINEAR_VELOCITY
+      || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_linear_velocity().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::ANGULAR_VELOCITY
+      || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_angular_velocity().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION
+      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_linear_acceleration().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION
+      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_angular_acceleration().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::FORCE || state_variable_type == CartesianStateVariable::WRENCH
+      || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_force().norm());
+  }
+  if (state_variable_type == CartesianStateVariable::TORQUE || state_variable_type == CartesianStateVariable::WRENCH
+      || state_variable_type == CartesianStateVariable::ALL) {
+    norms.push_back(this->get_torque().norm());
+  }
+  return norms;
+}
+
+void CartesianState::normalize(const CartesianStateVariable& state_variable_type) {
+  if (state_variable_type == CartesianStateVariable::POSITION || state_variable_type == CartesianStateVariable::POSE
+      || state_variable_type == CartesianStateVariable::ALL) {
+    this->position.normalize();
+  }
+  // there shouldn't be a need to renormalize orientation as it is already normalized
+  if (state_variable_type == CartesianStateVariable::ORIENTATION || state_variable_type == CartesianStateVariable::POSE
+      || state_variable_type == CartesianStateVariable::ALL) {
+    this->orientation.normalize();
+  }
+  if (state_variable_type == CartesianStateVariable::LINEAR_VELOCITY
+      || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
+    this->linear_velocity.normalize();
+  }
+  if (state_variable_type == CartesianStateVariable::ANGULAR_VELOCITY
+      || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
+    this->angular_velocity.normalize();
+  }
+  if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION
+      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ALL) {
+    this->linear_acceleration.normalize();
+  }
+  if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION
+      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ALL) {
+    this->angular_acceleration.normalize();
+  }
+  if (state_variable_type == CartesianStateVariable::FORCE || state_variable_type == CartesianStateVariable::WRENCH
+      || state_variable_type == CartesianStateVariable::ALL) {
+    this->force.normalize();
+  }
+  if (state_variable_type == CartesianStateVariable::TORQUE || state_variable_type == CartesianStateVariable::WRENCH
+      || state_variable_type == CartesianStateVariable::ALL) {
+    this->torque.normalize();
+  }
+}
+
+CartesianState CartesianState::normalized(const CartesianStateVariable& state_variable_type) const {
+  CartesianState result(*this);
+  result.normalize(state_variable_type);
   return result;
 }
 

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -145,8 +145,12 @@ CartesianState CartesianState::operator*(const CartesianState& state) const {
 
 CartesianState& CartesianState::operator+=(const CartesianState& state) {
   // sanity check
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (state.is_empty()) { throw EmptyStateException(state.get_name() + " state is empty"); }
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (state.is_empty()) {
+    throw EmptyStateException(state.get_name() + " state is empty");
+  }
   if (!(this->get_reference_frame() == state.get_reference_frame())) {
     throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
   }
@@ -173,8 +177,12 @@ CartesianState CartesianState::operator+(const CartesianState& state) const {
 
 CartesianState& CartesianState::operator-=(const CartesianState& state) {
   // sanity check
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (state.is_empty()) { throw EmptyStateException(state.get_name() + " state is empty"); }
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (state.is_empty()) {
+    throw EmptyStateException(state.get_name() + " state is empty");
+  }
   if (!(this->get_reference_frame() == state.get_reference_frame())) {
     throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
   }
@@ -248,8 +256,12 @@ void CartesianState::clamp_state_variable(double max_value,
 
 double CartesianState::dist(const CartesianState& state, const CartesianStateVariable& state_variable_type) const {
   // sanity check
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (state.is_empty()) { throw EmptyStateException(state.get_name() + " state is empty"); }
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (state.is_empty()) {
+    throw EmptyStateException(state.get_name() + " state is empty");
+  }
   if (!(this->get_reference_frame() == state.get_reference_frame())) {
     throw IncompatibleReferenceFramesException("The two states do not have the same reference frame");
   }

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -108,10 +108,6 @@ Eigen::VectorXd CartesianWrench::data() const {
   return this->get_wrench();
 }
 
-Eigen::Array<double, 6, 1> CartesianWrench::array() const {
-  return this->get_wrench().array();
-}
-
 std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {
   if (wrench.is_empty()) {
     os << "Empty CartesianWrench";

--- a/source/state_representation/tests/testCartesianState.cpp
+++ b/source/state_representation/tests/testCartesianState.cpp
@@ -110,7 +110,6 @@ TEST(CartesianWrenchToStdVector, PositiveNos) {
   }
 }
 
-
 TEST(NegateQuaternion, PositiveNos) {
   Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
   Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());
@@ -132,7 +131,10 @@ TEST(MultiplyTransformsBothOperators, PositiveNos) {
   tf1 *= tf2;
 
   EXPECT_EQ(tf3.get_name(), "t2");
-  for (int i = 0; i < tf1.get_position().size(); ++i) EXPECT_NEAR(tf1.get_position()(i), tf3.get_position()(i), 0.00001);
+  for (int i = 0; i < tf1.get_position().size(); ++i)
+    EXPECT_NEAR(tf1.get_position()(i),
+                tf3.get_position()(i),
+                0.00001);
 }
 
 TEST(MultiplyTransformsSameOrientation, PositiveNos) {
@@ -239,7 +241,10 @@ TEST(MultiplyPoseAndState, PositiveNos) {
   CartesianState res = p * s;
   CartesianPose res2 = p * static_cast<CartesianPose>(s);
 
-  for (int i = 0; i < res.get_position().size(); ++i) EXPECT_NEAR(res.get_position()(i), res2.get_position()(i), 0.00001);
+  for (int i = 0; i < res.get_position().size(); ++i)
+    EXPECT_NEAR(res.get_position()(i),
+                res2.get_position()(i),
+                0.00001);
   EXPECT_TRUE(abs(res.get_orientation().dot(res2.get_orientation())) > 1 - 10E-4);
 }
 
@@ -370,6 +375,133 @@ TEST(TestToSTDVector, PositiveNos) {
   EXPECT_NEAR(p.get_orientation().x(), v[4], 0.00001);
   EXPECT_NEAR(p.get_orientation().y(), v[5], 0.00001);
   EXPECT_NEAR(p.get_orientation().z(), v[6], 0.00001);
+}
+
+TEST(TestAllNorms, PositiveNos) {
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  // first test all norms
+  std::vector<double> norms = cs.norms();
+  EXPECT_TRUE(norms.size() == 8);
+  EXPECT_NEAR(norms[0], cs.get_position().norm(), tolerance);
+  EXPECT_NEAR(norms[1], cs.get_orientation().norm(), tolerance);
+  EXPECT_NEAR(norms[2], cs.get_linear_velocity().norm(), tolerance);
+  EXPECT_NEAR(norms[3], cs.get_angular_velocity().norm(), tolerance);
+  EXPECT_NEAR(norms[4], cs.get_linear_acceleration().norm(), tolerance);
+  EXPECT_NEAR(norms[5], cs.get_angular_acceleration().norm(), tolerance);
+  EXPECT_NEAR(norms[6], cs.get_force().norm(), tolerance);
+  EXPECT_NEAR(norms[7], cs.get_torque().norm(), tolerance);
+
+}
+
+TEST(TestPoseNorms, PositiveNos) {
+  std::vector<double> norms;
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  // independent variables first
+  norms = cs.norms(CartesianStateVariable::POSITION);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_position().norm(), tolerance);
+  norms = cs.norms(CartesianStateVariable::ORIENTATION);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_orientation().norm(), tolerance);
+  // then grouped by two
+  norms = cs.norms(CartesianStateVariable::POSE);
+  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_NEAR(norms[0], cs.get_position().norm(), tolerance);
+  EXPECT_NEAR(norms[1], cs.get_orientation().norm(), tolerance);
+  // test with CartesianPose default variable
+  CartesianPose cp = CartesianPose::Random("cp");
+  std::vector<double> pose_norms = cp.norms();
+  EXPECT_TRUE(pose_norms.size() == 2);
+  EXPECT_NEAR(pose_norms[0], cp.get_position().norm(), tolerance);
+  EXPECT_NEAR(pose_norms[1], cp.get_orientation().norm(), tolerance);
+}
+
+TEST(TestTwistNorms, PositiveNos) {
+  std::vector<double> norms;
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  // independent variables first
+  norms = cs.norms(CartesianStateVariable::LINEAR_VELOCITY);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_linear_velocity().norm(), tolerance);
+  norms = cs.norms(CartesianStateVariable::ANGULAR_VELOCITY);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_angular_velocity().norm(), tolerance);
+  // then grouped by two
+  norms = cs.norms(CartesianStateVariable::TWIST);
+  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_NEAR(norms[0], cs.get_linear_velocity().norm(), tolerance);
+  EXPECT_NEAR(norms[1], cs.get_angular_velocity().norm(), tolerance);
+  // test with CartesianTwist default variable
+  CartesianTwist ct = CartesianTwist::Random("ct");
+  std::vector<double> twist_norms = ct.norms();
+  EXPECT_TRUE(twist_norms.size() == 2);
+  EXPECT_NEAR(twist_norms[0], ct.get_linear_velocity().norm(), tolerance);
+  EXPECT_NEAR(twist_norms[1], ct.get_angular_velocity().norm(), tolerance);
+}
+
+TEST(TestAccelerationNorms, PositiveNos) {
+  std::vector<double> norms;
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  // independent variables first
+  norms = cs.norms(CartesianStateVariable::LINEAR_ACCELERATION);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_linear_acceleration().norm(), tolerance);
+  norms = cs.norms(CartesianStateVariable::ANGULAR_ACCELERATION);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_angular_acceleration().norm(), tolerance);
+  // then grouped by two
+  norms = cs.norms(CartesianStateVariable::ACCELERATIONS);
+  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_NEAR(norms[0], cs.get_linear_acceleration().norm(), tolerance);
+  EXPECT_NEAR(norms[1], cs.get_angular_acceleration().norm(), tolerance);
+}
+
+TEST(TestWrenchNorms, PositiveNos) {
+  std::vector<double> norms;
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  // independent variables first
+  norms = cs.norms(CartesianStateVariable::FORCE);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_force().norm(), tolerance);
+  norms = cs.norms(CartesianStateVariable::TORQUE);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_torque().norm(), tolerance);
+  // then grouped by two
+  norms = cs.norms(CartesianStateVariable::WRENCH);
+  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_NEAR(norms[0], cs.get_force().norm(), tolerance);
+  EXPECT_NEAR(norms[1], cs.get_torque().norm(), tolerance);
+  // test with CartesianTwist default variable
+  CartesianWrench cw = CartesianWrench::Random("cw");
+  std::vector<double> wrench_norms = cw.norms();
+  EXPECT_TRUE(wrench_norms.size() == 2);
+  EXPECT_NEAR(wrench_norms[0], cw.get_force().norm(), tolerance);
+  EXPECT_NEAR(wrench_norms[1], cw.get_torque().norm(), tolerance);
+}
+
+TEST(TestNormalize, PositiveNos) {
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  cs.normalize();
+  std::vector<double> norms = cs.norms();
+  for (double n : norms) {
+    EXPECT_NEAR(n, 1.0, tolerance);
+  }
+}
+
+TEST(TestNormalized, PositiveNos) {
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  CartesianState csn = cs.normalized();
+  std::vector<double> norms = csn.norms();
+  for (double n : norms) {
+    EXPECT_NEAR(n, 1.0, tolerance);
+  }
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
As I needed it for demonstration purposes, I have added the norm computations in `CartesianState`. It includes the `norms` (result as a `std::vector<double>` for each state variables), `normalize` for inplace normalization and `normalized` for copy normalization. I am using the `CartesianStateVariable` enum to specify the desired state variables for all the computations. See the README for more details.