### PR TITLE
Add force feedback in the impedance control law

### DIFF
--- a/source/controllers/include/controllers/Controller.hpp
+++ b/source/controllers/include/controllers/Controller.hpp
@@ -22,7 +22,7 @@ public:
   explicit Controller();
 
   /**
-   * @brief Compute the command based on the input state in a non const fashion
+   * @brief Compute the command based on the input state
    * To be redefined based on the actual controller implementation
    * @param state the input state of the system. This function accept any number of extra arguments.
    * @return the output command at the input state
@@ -30,7 +30,7 @@ public:
   virtual S compute_command(const S& state, ...);
 
   /**
-   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * @brief Compute the command based on the desired state and a feedback state
    * To be redefined based on the actual controller implementation.
    * @param desired_state the desired state of the system.
    * @param feedback_state the real state of the system as read from feedback loop
@@ -39,7 +39,7 @@ public:
   virtual S compute_command(const S& desired_state, const S& feedback_state);
 
   /**
-   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * @brief Compute the command based on the desired state and a feedback state
    * To be redefined based on the actual controller implementation.
    * @param desired_state the desired state of the system.
    * @param feedback_state the real state of the system as read from feedback loop

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -135,7 +135,7 @@ public:
   S compute_command(const S& desired_state, const S& feedback_state) override;
 
   /**
-   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * @brief Compute the command based on the desired state and a feedback state
    * To be redefined based on the actual controller implementation.
    * @param desired_state the desired state of the system.
    * @param feedback_state the real state of the system as read from feedback loop
@@ -157,7 +157,7 @@ template<class S>
 Dissipative<S>::Dissipative(const ComputationalSpaceType& computational_space, unsigned int nb_dimensions) :
     Impedance<S>(Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions),
                  Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions),
-                 Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions)),
+                 Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions)),
     computational_space_(computational_space),
     nb_dimensions_(nb_dimensions),
     basis_(Eigen::MatrixXd::Random(nb_dimensions, nb_dimensions)),

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -157,7 +157,7 @@ template<class S>
 Dissipative<S>::Dissipative(const ComputationalSpaceType& computational_space, unsigned int nb_dimensions) :
     Impedance<S>(Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions),
                  Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions),
-                 Eigen::MatrixXd::Identity(nb_dimensions, nb_dimensions)),
+                 Eigen::MatrixXd::Zero(nb_dimensions, nb_dimensions)),
     computational_space_(computational_space),
     nb_dimensions_(nb_dimensions),
     basis_(Eigen::MatrixXd::Random(nb_dimensions, nb_dimensions)),

--- a/source/controllers/include/controllers/impedance/Impedance.hpp
+++ b/source/controllers/include/controllers/impedance/Impedance.hpp
@@ -62,7 +62,7 @@ public:
   virtual S compute_command(const S& desired_state, const S& feedback_state);
 
   /**
-   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * @brief Compute the command based on the desired state and a feedback state
    * To be redefined based on the actual controller implementation.
    * @param desired_state the desired state of the system.
    * @param feedback_state the real state of the system as read from feedback loop

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -32,19 +32,19 @@ template<>
 CartesianState Impedance<CartesianState>::compute_command(const CartesianState& desired_state,
                                                           const CartesianState& feedback_state) {
   CartesianState state_error = desired_state - feedback_state;
-  // compute the wrench using the formula W = I * acc_desired + K * e_pose + D * e_twist - e_wrench
+  // compute the wrench using the formula W = I * acc_desired + K * e_pose + D * e_twist + e_wrench
   CartesianWrench command(feedback_state.get_name(), feedback_state.get_reference_frame());
   // compute force
   Eigen::Vector3d position_control = this->get_stiffness().topLeftCorner<3,3>() * state_error.get_position()
       + this->get_damping().topLeftCorner<3,3>() * state_error.get_linear_velocity()
       + this->get_inertia().topLeftCorner<3,3>() * desired_state.get_linear_acceleration();
-  Eigen::Vector3d commanded_force = position_control - state_error.get_force();
+  Eigen::Vector3d commanded_force = position_control + state_error.get_force();
   command.set_force(commanded_force);
   // compute torque (orientation requires special care)
   Eigen::Vector3d orientation_control = this->get_stiffness().bottomRightCorner<3,3>() * state_error.get_orientation().vec()
       + this->get_damping().bottomRightCorner<3,3>() * state_error.get_angular_velocity()
       + this->get_inertia().bottomRightCorner<3,3>() * desired_state.get_angular_acceleration();
-  Eigen::Vector3d commanded_torque = orientation_control - state_error.get_torque();
+  Eigen::Vector3d commanded_torque = orientation_control + state_error.get_torque();
   command.set_torque(commanded_torque);
   return command;
 }
@@ -53,13 +53,13 @@ template<>
 JointState Impedance<JointState>::compute_command(const JointState& desired_state,
                                                   const JointState& feedback_state) {
   JointState state_error = desired_state - feedback_state;
-  // compute the wrench using the formula T = I * acc_desired + K * e_pos + D * e_vel - e_tor
+  // compute the wrench using the formula T = I * acc_desired + K * e_pos + D * e_vel + e_tor
   JointTorques command(feedback_state.get_name(), feedback_state.get_names());
   // compute torques
   Eigen::VectorXd state_control = this->get_stiffness() * state_error.get_positions()
       + this->get_damping() * state_error.get_velocities()
       + this->get_inertia() * desired_state.get_accelerations();
-  Eigen::VectorXd commanded_torques = state_control - state_error.get_torques();
+  Eigen::VectorXd commanded_torques = state_control + state_error.get_torques();
   command.set_torques(commanded_torques);
   return command;
 }

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -32,19 +32,19 @@ template<>
 CartesianState Impedance<CartesianState>::compute_command(const CartesianState& desired_state,
                                                           const CartesianState& feedback_state) {
   CartesianState state_error = desired_state - feedback_state;
-  // compute the wrench using the formula W = acc_desired + I^-1 [K * e_pose + D * e_twist - e_wrench]
+  // compute the wrench using the formula W = I * acc_desired + K * e_pose + D * e_twist - e_wrench
   CartesianWrench command(feedback_state.get_name(), feedback_state.get_reference_frame());
   // compute force
   Eigen::Vector3d force_control = this->get_stiffness().block<3, 3>(0, 0) * state_error.get_position()
       + this->get_damping().block<3, 3>(0, 0) * state_error.get_linear_velocity();
-  Eigen::Vector3d commanded_force = desired_state.get_linear_acceleration()
-      + this->get_inertia().block<3, 3>(0, 0).ldlt().solve(force_control - state_error.get_force());
+  Eigen::Vector3d commanded_force = this->get_inertia().block<3, 3>(0, 0) * desired_state.get_linear_acceleration()
+      + force_control - state_error.get_force();
   command.set_force(commanded_force);
   // compute torque (orientation requires special care)
   Eigen::Vector3d torque_control = this->get_stiffness().block<3, 3>(3, 3) * state_error.get_orientation().vec()
       + this->get_damping().block<3, 3>(3, 3) * state_error.get_angular_velocity();
-  Eigen::Vector3d commanded_torque = desired_state.get_linear_acceleration()
-      + this->get_inertia().block<3, 3>(3, 3).ldlt().solve(torque_control - state_error.get_torque());
+  Eigen::Vector3d commanded_torque = this->get_inertia().block<3, 3>(3, 3) * desired_state.get_angular_acceleration()
+      + torque_control - state_error.get_torque();
   command.set_torque(commanded_torque);
   return command;
 }
@@ -53,13 +53,13 @@ template<>
 JointState Impedance<JointState>::compute_command(const JointState& desired_state,
                                                   const JointState& feedback_state) {
   JointState state_error = desired_state - feedback_state;
-  // compute the wrench using the formula T = acc_desired + I^-1 [K * e_pos + D * e_vel - e_tor]
+  // compute the wrench using the formula T = I * acc_desired + K * e_pos + D * e_vel - e_tor
   JointTorques command(feedback_state.get_name(), feedback_state.get_names());
   // compute torques
   Eigen::VectorXd torque_control = this->get_stiffness() * state_error.get_positions()
       + this->get_damping() * state_error.get_velocities();
-  Eigen::VectorXd commanded_torque = desired_state.get_accelerations()
-      + this->get_inertia().ldlt().solve(torque_control - state_error.get_torques());
+  Eigen::VectorXd commanded_torque = this->get_inertia() * desired_state.get_accelerations()
+      + torque_control - state_error.get_torques();
   command.set_torques(commanded_torque);
   return command;
 }

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -32,16 +32,20 @@ template<>
 CartesianState Impedance<CartesianState>::compute_command(const CartesianState& desired_state,
                                                           const CartesianState& feedback_state) {
   CartesianState state_error = desired_state - feedback_state;
-  // compute the wrench using the formula W = K * e_pos + D * e_vel + I * acc_desired
+  // compute the wrench using the formula W = acc_desired + I^-1 [K * e_pose + D * e_twist - e_wrench]
   CartesianWrench command(feedback_state.get_name(), feedback_state.get_reference_frame());
   // compute force
-  command.set_force(this->get_stiffness().block<3, 3>(0, 0) * state_error.get_position()
-                        + this->get_damping().block<3, 3>(0, 0) * state_error.get_linear_velocity()
-                        + this->get_inertia().block<3, 3>(0, 0) * desired_state.get_linear_acceleration());
+  Eigen::Vector3d force_control = this->get_stiffness().block<3, 3>(0, 0) * state_error.get_position()
+      + this->get_damping().block<3, 3>(0, 0) * state_error.get_linear_velocity();
+  Eigen::Vector3d commanded_force = desired_state.get_linear_acceleration()
+      + this->get_inertia().block<3, 3>(0, 0).ldlt().solve(force_control - state_error.get_force());
+  command.set_force(commanded_force);
   // compute torque (orientation requires special care)
-  command.set_torque(this->get_stiffness().block<3, 3>(3, 3) * state_error.get_orientation().vec()
-                         + this->get_damping().block<3, 3>(3, 3) * state_error.get_angular_velocity()
-                         + this->get_inertia().block<3, 3>(3, 3) * desired_state.get_angular_acceleration());
+  Eigen::Vector3d torque_control = this->get_stiffness().block<3, 3>(3, 3) * state_error.get_orientation().vec()
+      + this->get_damping().block<3, 3>(3, 3) * state_error.get_angular_velocity();
+  Eigen::Vector3d commanded_torque = desired_state.get_linear_acceleration()
+      + this->get_inertia().block<3, 3>(3, 3).ldlt().solve(torque_control - state_error.get_torque());
+  command.set_torque(commanded_torque);
   return command;
 }
 
@@ -49,12 +53,14 @@ template<>
 JointState Impedance<JointState>::compute_command(const JointState& desired_state,
                                                   const JointState& feedback_state) {
   JointState state_error = desired_state - feedback_state;
-  // compute the wrench using the formula W = K * e_pos + D * e_vel + I * acc_desired
+  // compute the wrench using the formula T = acc_desired + I^-1 [K * e_pos + D * e_vel - e_tor]
   JointTorques command(feedback_state.get_name(), feedback_state.get_names());
   // compute torques
-  command.set_torques(this->get_stiffness() * state_error.get_positions()
-                          + this->get_damping() * state_error.get_velocities()
-                          + this->get_inertia() * desired_state.get_accelerations());
+  Eigen::VectorXd torque_control = this->get_stiffness() * state_error.get_positions()
+      + this->get_damping() * state_error.get_velocities();
+  Eigen::VectorXd commanded_torque = desired_state.get_accelerations()
+      + this->get_inertia().ldlt().solve(torque_control - state_error.get_torques());
+  command.set_torques(commanded_torque);
   return command;
 }
 

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -35,16 +35,16 @@ CartesianState Impedance<CartesianState>::compute_command(const CartesianState& 
   // compute the wrench using the formula W = I * acc_desired + K * e_pose + D * e_twist - e_wrench
   CartesianWrench command(feedback_state.get_name(), feedback_state.get_reference_frame());
   // compute force
-  Eigen::Vector3d force_control = this->get_stiffness().block<3, 3>(0, 0) * state_error.get_position()
-      + this->get_damping().block<3, 3>(0, 0) * state_error.get_linear_velocity();
-  Eigen::Vector3d commanded_force = this->get_inertia().block<3, 3>(0, 0) * desired_state.get_linear_acceleration()
-      + force_control - state_error.get_force();
+  Eigen::Vector3d position_control = this->get_stiffness().topLeftCorner<3,3>() * state_error.get_position()
+      + this->get_damping().topLeftCorner<3,3>() * state_error.get_linear_velocity()
+      + this->get_inertia().topLeftCorner<3,3>() * desired_state.get_linear_acceleration();
+  Eigen::Vector3d commanded_force = position_control - state_error.get_force();
   command.set_force(commanded_force);
   // compute torque (orientation requires special care)
-  Eigen::Vector3d torque_control = this->get_stiffness().block<3, 3>(3, 3) * state_error.get_orientation().vec()
-      + this->get_damping().block<3, 3>(3, 3) * state_error.get_angular_velocity();
-  Eigen::Vector3d commanded_torque = this->get_inertia().block<3, 3>(3, 3) * desired_state.get_angular_acceleration()
-      + torque_control - state_error.get_torque();
+  Eigen::Vector3d orientation_control = this->get_stiffness().bottomRightCorner<3,3>() * state_error.get_orientation().vec()
+      + this->get_damping().bottomRightCorner<3,3>() * state_error.get_angular_velocity()
+      + this->get_inertia().bottomRightCorner<3,3>() * desired_state.get_angular_acceleration();
+  Eigen::Vector3d commanded_torque = orientation_control - state_error.get_torque();
   command.set_torque(commanded_torque);
   return command;
 }
@@ -56,11 +56,11 @@ JointState Impedance<JointState>::compute_command(const JointState& desired_stat
   // compute the wrench using the formula T = I * acc_desired + K * e_pos + D * e_vel - e_tor
   JointTorques command(feedback_state.get_name(), feedback_state.get_names());
   // compute torques
-  Eigen::VectorXd torque_control = this->get_stiffness() * state_error.get_positions()
-      + this->get_damping() * state_error.get_velocities();
-  Eigen::VectorXd commanded_torque = this->get_inertia() * desired_state.get_accelerations()
-      + torque_control - state_error.get_torques();
-  command.set_torques(commanded_torque);
+  Eigen::VectorXd state_control = this->get_stiffness() * state_error.get_positions()
+      + this->get_damping() * state_error.get_velocities()
+      + this->get_inertia() * desired_state.get_accelerations();
+  Eigen::VectorXd commanded_torques = state_control - state_error.get_torques();
+  command.set_torques(commanded_torques);
   return command;
 }
 


### PR DESCRIPTION
I have seen different version of the impedance control law that includes force feedback as well (e.g. https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1291418) and think it makes sense. If no desired or feedback force is provided then the computation is equivalent to what it was before. Also. the multiplication with the inertia matrix is slightly different. In that case, we need to have an `Identity` value for the `Dissipative` controller. I have seen that formulation in other paper as well so I think it is the one that makes the most sense. Let me know what you think.