### PR TITLE
Fix Dissipative damping velocity in case of CartesianState input

### DIFF
--- a/source/controllers/include/controllers/Controller.hpp
+++ b/source/controllers/include/controllers/Controller.hpp
@@ -69,14 +69,12 @@ std::list<std::shared_ptr<state_representation::ParameterInterface>> Controller<
 template<class S>
 S Controller<S>::compute_command(const S&, ...) {
   throw exceptions::NotImplementedException("compute_command(state, ...) not implemented for the base controller class");
-  return S();
 }
 
 template<class S>
 S Controller<S>::compute_command(const S&, const S&) {
   throw exceptions::NotImplementedException(
       "compute_command(desired_state, feedback_state) not implemented for the base controller class");
-  return S();
 }
 
 template<class S>
@@ -85,6 +83,5 @@ state_representation::JointState Controller<S>::compute_command(const S&,
                                                                 const state_representation::Jacobian&) {
   throw exceptions::NotImplementedException(
       "compute_command(desired_state, feedback_state) not implemented for the base controller class");
-  return state_representation::JointState();
 }
 }// namespace controllers

--- a/source/controllers/include/controllers/impedance/Dissipative.hpp
+++ b/source/controllers/include/controllers/impedance/Dissipative.hpp
@@ -304,17 +304,9 @@ void Dissipative<S>::compute_damping(const Eigen::VectorXd& desired_velocity) {
 }
 
 template<class S>
-S Dissipative<S>::compute_command(const S& desired_state, const S& feedback_state) {
-  // compute the damping matrix out of the desired_state twist
-  this->compute_damping(desired_state.data());
-  // apply the impedance control law
-  return this->Impedance<S>::compute_command(desired_state, feedback_state);
-}
-
-template<class S>
 state_representation::JointState Dissipative<S>::compute_command(const S& desired_state,
-                                                                 const S& feedback_state,
-                                                                 const state_representation::Jacobian& jacobian) {
+                                                                const S& feedback_state,
+                                                                const state_representation::Jacobian& jacobian) {
   return this->Impedance<S>::compute_command(desired_state, feedback_state, jacobian);
 }
 }// namespace controllers

--- a/source/controllers/src/impedance/Dissipative.cpp
+++ b/source/controllers/src/impedance/Dissipative.cpp
@@ -19,7 +19,6 @@ template<class S>
 Eigen::MatrixXd Dissipative<S>::compute_orthonormal_basis(const S&) {
   throw exceptions::NotImplementedException(
       "compute_orthonormal_basis(desired_velocity) not implemented for this input class");
-  return Eigen::MatrixXd::Zero(this->nb_dimensions_, this->nb_dimensions_);
 }
 
 template<>

--- a/source/controllers/src/impedance/Dissipative.cpp
+++ b/source/controllers/src/impedance/Dissipative.cpp
@@ -14,4 +14,27 @@ Dissipative<S>::Dissipative(unsigned int nb_dimensions):
     Dissipative<S>(ComputationalSpaceType::FULL, nb_dimensions) {}
 
 template Dissipative<JointState>::Dissipative(unsigned int);
+
+template<class S>
+S Dissipative<S>::compute_command(const S&, const S&) {
+  throw exceptions::NotImplementedException(
+      "compute_command(desired_state, feedback_state) not implemented for this input class");
+  return S();
+}
+
+template<>
+CartesianState Dissipative<CartesianState>::compute_command(const CartesianState& desired_state, const CartesianState& feedback_state) {
+  // compute the damping matrix out of the desired_state twist
+  this->compute_damping(desired_state.get_twist());
+  // apply the impedance control law
+  return this->Impedance<CartesianState>::compute_command(desired_state, feedback_state);
+}
+
+template<>
+JointState Dissipative<JointState>::compute_command(const JointState& desired_state, const JointState& feedback_state) {
+  // compute the damping matrix out of the desired_state twist
+  this->compute_damping(desired_state.get_velocities());
+  // apply the impedance control law
+  return this->Impedance<JointState>::compute_command(desired_state, feedback_state);
+}
 }// namespace controllers

--- a/source/controllers/src/impedance/Dissipative.cpp
+++ b/source/controllers/src/impedance/Dissipative.cpp
@@ -16,25 +16,88 @@ Dissipative<S>::Dissipative(unsigned int nb_dimensions):
 template Dissipative<JointState>::Dissipative(unsigned int);
 
 template<class S>
-S Dissipative<S>::compute_command(const S&, const S&) {
+Eigen::MatrixXd Dissipative<S>::compute_orthonormal_basis(const S&) {
   throw exceptions::NotImplementedException(
-      "compute_command(desired_state, feedback_state) not implemented for this input class");
-  return S();
+      "compute_orthonormal_basis(desired_velocity) not implemented for this input class");
+  return Eigen::MatrixXd::Zero(this->nb_dimensions_, this->nb_dimensions_);
 }
 
 template<>
-CartesianState Dissipative<CartesianState>::compute_command(const CartesianState& desired_state, const CartesianState& feedback_state) {
-  // compute the damping matrix out of the desired_state twist
-  this->compute_damping(desired_state.get_twist());
-  // apply the impedance control law
-  return this->Impedance<CartesianState>::compute_command(desired_state, feedback_state);
+Eigen::MatrixXd Dissipative<CartesianState>::compute_orthonormal_basis(const CartesianState& desired_velocity) {
+  double tolerance = 1e-4;
+  Eigen::MatrixXd updated_basis = Eigen::MatrixXd::Zero(this->nb_dimensions_, this->nb_dimensions_);
+  switch (this->computational_space_) {
+    case ComputationalSpaceType::LINEAR: {
+      const Eigen::Vector3d& linear_velocity = desired_velocity.get_linear_velocity();
+      // only update the damping if the commanded linear velocity is non null
+      if (linear_velocity.norm() < tolerance) {
+        updated_basis.topLeftCorner<3, 3>() = Eigen::Matrix3d::Identity();
+        return updated_basis;
+      }
+      //return only the linear block
+      updated_basis.topLeftCorner<3, 3>() =
+          Dissipative<CartesianState>::orthonormalize_basis(this->basis_.topLeftCorner<3, 3>(), linear_velocity);
+      break;
+    }
+    case ComputationalSpaceType::ANGULAR: {
+      const Eigen::Vector3d& angular_velocity = desired_velocity.get_angular_velocity();
+      // only update the damping if the commanded angular velocity is non null
+      if (angular_velocity.norm() < tolerance) {
+        updated_basis.bottomRightCorner<3, 3>() = Eigen::Matrix3d::Identity();
+        return updated_basis;
+      }
+      // return only the angular block
+      updated_basis.bottomRightCorner<3, 3>() =
+          Dissipative<CartesianState>::orthonormalize_basis(this->basis_.bottomRightCorner<3, 3>(), angular_velocity);
+      break;
+    }
+    case ComputationalSpaceType::DECOUPLED_TWIST: {
+      // compute per block
+      bool updated = false;
+      const Eigen::Vector3d& linear_velocity = desired_velocity.get_linear_velocity();
+      const Eigen::Vector3d& angular_velocity = desired_velocity.get_angular_velocity();
+      if (linear_velocity.norm() > tolerance) {
+        updated_basis.block<3, 3>(0, 0) =
+            Dissipative<CartesianState>::orthonormalize_basis(this->basis_.topLeftCorner<3, 3>(), linear_velocity);
+        updated = true;
+      }
+      if (angular_velocity.norm() > tolerance) {
+        updated_basis.block<3, 3>(3, 3) =
+            Dissipative<CartesianState>::orthonormalize_basis(this->basis_.bottomRightCorner<3, 3>(), angular_velocity);
+        updated = true;
+      }
+      // at least the linear or angular parts have been updated
+      if (!updated) {
+        return Eigen::MatrixXd::Identity(this->nb_dimensions_, this->nb_dimensions_);
+      }
+      break;
+    }
+    case ComputationalSpaceType::FULL: {
+      // only update the damping if the commanded velocity is non null
+      if (desired_velocity.get_twist().norm() < tolerance) {
+        return Eigen::MatrixXd::Identity(this->nb_dimensions_, this->nb_dimensions_);
+      }
+      // return the full damping matrix
+      updated_basis = Dissipative<CartesianState>::orthonormalize_basis(this->basis_, desired_velocity.get_twist());
+      break;
+    }
+  }
+  return updated_basis;
 }
 
 template<>
-JointState Dissipative<JointState>::compute_command(const JointState& desired_state, const JointState& feedback_state) {
-  // compute the damping matrix out of the desired_state twist
-  this->compute_damping(desired_state.get_velocities());
-  // apply the impedance control law
-  return this->Impedance<JointState>::compute_command(desired_state, feedback_state);
+Eigen::MatrixXd Dissipative<JointState>::compute_orthonormal_basis(const JointState& desired_velocity) {
+  if (desired_velocity.get_size() != this->nb_dimensions_) {
+    throw state_representation::exceptions::IncompatibleSizeException(
+        "The input state is of incorrect dimensions, expected "
+            + std::to_string(this->nb_dimensions_) + " got " + std::to_string(desired_velocity.get_size()));
+  }
+  double tolerance = 1e-4;
+  // only update the damping if the commanded velocity is non null
+  if (desired_velocity.get_velocities().norm() < tolerance) {
+    return Eigen::MatrixXd::Identity(this->nb_dimensions_, this->nb_dimensions_);
+  }
+  // return the full damping matrix
+  return Dissipative<JointState>::orthonormalize_basis(this->basis_, desired_velocity.get_velocities());
 }
 }// namespace controllers

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -26,7 +26,6 @@ template<class S>
 S Impedance<S>::compute_command(const S&, const S&) {
   throw exceptions::NotImplementedException(
       "compute_command(desired_state, feedback_state) not implemented for this input class");
-  return S();
 }
 
 template<>
@@ -71,7 +70,6 @@ JointState Impedance<S>::compute_command(const S&,
                                          const state_representation::Jacobian&) {
   throw exceptions::NotImplementedException(
       "compute_command(desired_state, feedback_state) not implemented for this input class");
-  return JointState();
 }
 
 template<>

--- a/source/controllers/src/impedance/Impedance.cpp
+++ b/source/controllers/src/impedance/Impedance.cpp
@@ -26,6 +26,7 @@ template<class S>
 S Impedance<S>::compute_command(const S&, const S&) {
   throw exceptions::NotImplementedException(
       "compute_command(desired_state, feedback_state) not implemented for this input class");
+  return S();
 }
 
 template<>


### PR DESCRIPTION
Nasty bug in `Dissipative`. I tried to be smart but ended up a fool instead. The `compute_damping` function was taking  `data()` as input which was fine if the desired state was a `CartesianTwist` or a `JointVelocities`. But if you actually put a `CartesianState` or `JointState` there...

So, unfortunately, this means we need to have a different function for each input type. But at least now it is behaving correctly.