### PR TITLE
Refactor/robot model namespace

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -199,7 +199,8 @@ public:
    * @param joint_positions containing the joint positions of the robot
    * @return the gravity torque as a JointTorques
    */
-  state_representation::JointTorques compute_gravity_torques(const state_representation::JointPositions& joint_positions);
+  state_representation::JointTorques compute_gravity_torques(
+      const state_representation::JointPositions& joint_positions);
 
   /**
    * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
@@ -224,7 +225,8 @@ public:
    * @param cartesian_state containing the pose of the end-effector
    * @return the joint state of the robot
    */
-  state_representation::JointPositions inverse_geometry(const state_representation::CartesianState& cartesian_state) const;
+  state_representation::JointPositions inverse_geometry(
+      const state_representation::CartesianState& cartesian_state) const;
 
   /**
    * @brief Compute the forward kinematic, i.e. the twist of the end-effector from the joint velocities
@@ -285,8 +287,7 @@ inline unsigned int Model::get_number_of_joints() const {
 
 inline std::vector<std::string> Model::get_joint_frames() const {
   // model contains a first joint called universe that needs to be discarded
-  std::vector<std::string> joint_frames(this->robot_model_.names.begin() + 1,
-                                       this->robot_model_.names.end());
+  std::vector<std::string> joint_frames(this->robot_model_.names.begin() + 1, this->robot_model_.names.end());
   return joint_frames;
 }
 
@@ -303,12 +304,12 @@ inline void Model::set_gravity_vector(const Eigen::Vector3d& gravity) {
 }
 
 inline state_representation::CartesianPose Model::forward_geometry(const state_representation::JointState& joint_state,
-                                                                  unsigned int frame_id) {
+                                                                   unsigned int frame_id) {
   return this->forward_geometry(joint_state, std::vector<unsigned int>{frame_id}).front();
 }
 
 inline state_representation::CartesianPose Model::forward_geometry(const state_representation::JointState& joint_state,
-                                                                  std::string frame_name) {
+                                                                   std::string frame_name) {
   if (frame_name.empty()) {
     // get last frame if none specified
     frame_name = this->robot_model_.frames.back().name;

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -14,7 +14,7 @@
 #include <state_representation/robot/JointState.hpp>
 #include <state_representation/space/cartesian/CartesianState.hpp>
 
-namespace RobotModel {
+namespace robot_model {
 class Model {
 private:
   // @format:off
@@ -325,4 +325,4 @@ inline std::list<std::shared_ptr<state_representation::ParameterInterface>> Mode
   param_list.push_back(this->proportional_gain_);
   return param_list;
 }
-}// namespace RobotModel
+}// namespace robot_model

--- a/source/robot_model/include/robot_model/exceptions/FrameNotFoundException.hpp
+++ b/source/robot_model/include/robot_model/exceptions/FrameNotFoundException.hpp
@@ -2,10 +2,10 @@
 
 #include <exception>
 
-namespace RobotModel::Exceptions {
+namespace robot_model::exceptions {
 class FrameNotFoundException : public std::invalid_argument {
 public:
   explicit FrameNotFoundException(const std::string& frame_name) :
       invalid_argument("Frame with name or ID " + frame_name + " is not in the robot model") {};
 };
-}// namespace RobotModel::exceptions
+}// namespace robot_model::exceptions

--- a/source/robot_model/include/robot_model/exceptions/InvalidJointStateSizeException.hpp
+++ b/source/robot_model/include/robot_model/exceptions/InvalidJointStateSizeException.hpp
@@ -2,11 +2,11 @@
 
 #include <exception>
 
-namespace RobotModel::Exceptions {
+namespace robot_model::exceptions {
 class InvalidJointStateSizeException : public std::invalid_argument {
 public:
   explicit InvalidJointStateSizeException(unsigned int state_nb_joints, unsigned int robot_nb_joints) :
       invalid_argument("The robot has " + std::to_string(robot_nb_joints) + " joints, but the current joint state size "
                            + std::to_string(state_nb_joints) + ".") {};
 };
-}// namespace RobotModel::exceptions
+}// namespace robot_model::exceptions

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -141,8 +141,12 @@ state_representation::Jacobian Model::compute_jacobian(const state_representatio
   // compute the jacobian from the joint state
   pinocchio::Data::Matrix6x J(6, this->get_number_of_joints());
   J.setZero();
-  pinocchio::computeFrameJacobian(this->robot_model_, this->robot_data_, joint_state.get_positions(), frame_id,
-                                  pinocchio::LOCAL_WORLD_ALIGNED, J);
+  pinocchio::computeFrameJacobian(this->robot_model_,
+                                  this->robot_data_,
+                                  joint_state.get_positions(),
+                                  frame_id,
+                                  pinocchio::LOCAL_WORLD_ALIGNED,
+                                  J);
   return state_representation::Jacobian(this->get_robot_name(), this->get_joint_frames(), J);
 }
 
@@ -174,8 +178,8 @@ Eigen::MatrixXd Model::compute_inertia_matrix(const state_representation::JointP
 state_representation::JointTorques Model::compute_inertia_torques(const state_representation::JointState& joint_state) {
   Eigen::MatrixXd inertia = this->compute_inertia_matrix(joint_state);
   return state_representation::JointTorques(joint_state.get_name(),
-                                           joint_state.get_names(),
-                                           inertia * joint_state.get_accelerations());
+                                            joint_state.get_names(),
+                                            inertia * joint_state.get_accelerations());
 }
 
 Eigen::MatrixXd Model::compute_coriolis_matrix(const state_representation::JointState& joint_state) {
@@ -185,21 +189,23 @@ Eigen::MatrixXd Model::compute_coriolis_matrix(const state_representation::Joint
                                           joint_state.get_velocities());
 }
 
-state_representation::JointTorques Model::compute_coriolis_torques(const state_representation::JointState& joint_state) {
+state_representation::JointTorques Model::compute_coriolis_torques(
+    const state_representation::JointState& joint_state) {
   Eigen::MatrixXd coriolis_matrix = this->compute_coriolis_matrix(joint_state);
-  return state_representation::JointTorques(joint_state.get_name(), joint_state.get_names(),
-                                           coriolis_matrix * joint_state.get_velocities());
+  return state_representation::JointTorques(joint_state.get_name(),
+                                            joint_state.get_names(),
+                                            coriolis_matrix * joint_state.get_velocities());
 }
 
-state_representation::JointTorques Model::compute_gravity_torques(const state_representation::JointPositions& joint_positions) {
-  Eigen::VectorXd gravity_torque = pinocchio::computeGeneralizedGravity(this->robot_model_,
-                                                                        this->robot_data_,
-                                                                        joint_positions.data());
+state_representation::JointTorques Model::compute_gravity_torques(
+    const state_representation::JointPositions& joint_positions) {
+  Eigen::VectorXd gravity_torque =
+      pinocchio::computeGeneralizedGravity(this->robot_model_, this->robot_data_, joint_positions.data());
   return state_representation::JointTorques(joint_positions.get_name(), joint_positions.get_names(), gravity_torque);
 }
 
-std::vector<state_representation::CartesianPose> Model::forward_geometry(const state_representation::JointState& joint_state,
-                                                                         const std::vector<unsigned int>& frame_ids) {
+std::vector<state_representation::CartesianPose> Model::forward_geometry(
+    const state_representation::JointState& joint_state, const std::vector<unsigned int>& frame_ids) {
   if (joint_state.get_size() != this->get_number_of_joints()) {
     throw (exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_number_of_joints()));
   }
@@ -220,8 +226,8 @@ std::vector<state_representation::CartesianPose> Model::forward_geometry(const s
   return pose_vector;
 }
 
-std::vector<state_representation::CartesianPose> Model::forward_geometry(const state_representation::JointState& joint_state,
-                                                                        const std::vector<std::string>& frame_names) {
+std::vector<state_representation::CartesianPose> Model::forward_geometry(
+    const state_representation::JointState& joint_state, const std::vector<std::string>& frame_names) {
   std::vector<unsigned int> frame_ids(frame_names.size());
   for (unsigned int i = 0; i < frame_names.size(); ++i) {
     std::string name = frame_names[i];

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -154,7 +154,9 @@ state_representation::Jacobian Model::compute_jacobian(const state_representatio
     frame_id = this->robot_model_.getFrameId(this->robot_model_.frames.back().name);
   } else {
     // throw error if specified frame does not exist
-    if (!this->robot_model_.existFrame(frame_name)) { throw (exceptions::FrameNotFoundException(frame_name)); }
+    if (!this->robot_model_.existFrame(frame_name)) {
+      throw (exceptions::FrameNotFoundException(frame_name));
+    }
     frame_id = this->robot_model_.getFrameId(frame_name);
   }
   return this->compute_jacobian(joint_state, frame_id);
@@ -164,8 +166,8 @@ Eigen::MatrixXd Model::compute_inertia_matrix(const state_representation::JointP
   // compute only the upper part of the triangular inertia matrix stored in robot_data_.M
   pinocchio::crba(this->robot_model_, this->robot_data_, joint_positions.data());
   // copy the symmetric lower part
-  this->robot_data_.M.triangularView<Eigen::StrictlyLower>()
-      = this->robot_data_.M.transpose().triangularView<Eigen::StrictlyLower>();
+  this->robot_data_.M.triangularView<Eigen::StrictlyLower>() =
+      this->robot_data_.M.transpose().triangularView<Eigen::StrictlyLower>();
   return this->robot_data_.M;
 }
 

--- a/source/robot_model/tests/test_robot_model.cpp
+++ b/source/robot_model/tests/test_robot_model.cpp
@@ -3,10 +3,10 @@
 #include <stdexcept>
 #include <gtest/gtest.h>
 
-#include "robot_model/Exceptions/InvalidJointStateSizeException.hpp"
-#include "robot_model/Exceptions/FrameNotFoundException.hpp"
+#include "robot_model/exceptions/InvalidJointStateSizeException.hpp"
+#include "robot_model/exceptions/FrameNotFoundException.hpp"
 
-using namespace RobotModel;
+using namespace robot_model;
 
 class RobotModelTest : public testing::Test {
 protected:
@@ -103,7 +103,7 @@ TEST_F(RobotModelTest, TestNumberOfJoints) {
 
 TEST_F(RobotModelTest, TestForwardGeometryJointStateSize) {
   state_representation::JointState dummy = state_representation::JointState(robot_name, 6);
-  EXPECT_THROW(franka.forward_geometry(dummy), Exceptions::InvalidJointStateSizeException);
+  EXPECT_THROW(franka.forward_geometry(dummy), exceptions::InvalidJointStateSizeException);
 }
 
 TEST_F(RobotModelTest, TestForwardGeometry) {
@@ -112,7 +112,7 @@ TEST_F(RobotModelTest, TestForwardGeometry) {
 }
 
 TEST_F(RobotModelTest, TestForwardGeometryInvalidFrameName) {
-  EXPECT_THROW(franka.forward_geometry(joint_state, "panda_link99"), Exceptions::FrameNotFoundException);
+  EXPECT_THROW(franka.forward_geometry(joint_state, "panda_link99"), exceptions::FrameNotFoundException);
 }
 
 TEST_F(RobotModelTest, TestJacobianJointNames) {
@@ -125,7 +125,7 @@ TEST_F(RobotModelTest, TestJacobianJointNames) {
 }
 
 TEST_F(RobotModelTest, TestJacobianInvalidFrameName) {
-  EXPECT_THROW(franka.compute_jacobian(joint_state, "panda_link99"), Exceptions::FrameNotFoundException);
+  EXPECT_THROW(franka.compute_jacobian(joint_state, "panda_link99"), exceptions::FrameNotFoundException);
 }
 
 TEST_F(RobotModelTest, TestJacobianNbRows) {

--- a/source/state_representation/include/state_representation/exceptions/UnrecognizedParameterTypeException.hpp
+++ b/source/state_representation/include/state_representation/exceptions/UnrecognizedParameterTypeException.hpp
@@ -3,7 +3,7 @@
 #include <exception>
 #include <iostream>
 
-namespace state_representation::Exceptions {
+namespace state_representation::exceptions {
 class UnrecognizedParameterTypeException : public std::logic_error {
 public:
   explicit UnrecognizedParameterTypeException(const std::string& msg) : logic_error(msg) {};


### PR DESCRIPTION
Changed the namespace of robot_model lib from`RobotModel` to `robot_model` and `Exceptions` to `exceptions` (including the directory including the exceptions). Caught one last `Exceptions` in state_representation that we missed until now.

The first of a few small PRs to close some issues concerning the robot_model. Could maybe someone write a README?