### PR TITLE
Add Jacobian frame and reference frame

### DIFF
--- a/source/controllers/test/tests/test_dissipative_impedance.cpp
+++ b/source/controllers/test/tests/test_dissipative_impedance.cpp
@@ -216,10 +216,9 @@ TEST_F(DissipativeImpedanceControllerTest, TestComputeTaskToJointCommand) {
   CartesianTwist desired_twist("test", Eigen::Vector3d(1, 0, 0));
   CartesianTwist feedback_twist("test", Eigen::Vector3d(1, 1, 0));
   // set a Jacobian matrix
-  Jacobian jacobian("test_robot", 3);
-  jacobian.set_data(Eigen::MatrixXd::Random(6, 3));
+  Jacobian jac = Jacobian::Random("test_robot", 3, "test");
   // check command
-  JointTorques command = task_controller_.compute_command(desired_twist, feedback_twist, jacobian);
+  JointTorques command = task_controller_.compute_command(desired_twist, feedback_twist, jac);
   // expect some non null data
   EXPECT_TRUE(command.data().norm() > 0.);
 }

--- a/source/controllers/test/tests/test_impedance.cpp
+++ b/source/controllers/test/tests/test_impedance.cpp
@@ -83,10 +83,9 @@ TEST(ImpedanceControllerTest, TestCartesianToJointImpedance) {
   feedback_state.set_orientation(Eigen::Quaterniond(0, 0, 1, 1));
   feedback_state.set_linear_velocity(Eigen::Vector3d(0.5, 0, 0));
   // set a Jacobian matrix
-  Jacobian jacobian("test_robot", 3);
-  jacobian.set_data(Eigen::MatrixXd::Random(6, 3));
+  Jacobian jac = Jacobian::Random("test_robot", 3, "test");
   // check command
-  JointTorques command = impedance_controller.compute_command(desired_state, feedback_state, jacobian);
+  JointTorques command = impedance_controller.compute_command(desired_state, feedback_state, jac);
   // expect some non null data
   EXPECT_TRUE(command.data().norm() > 0.);
 }

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -132,7 +132,10 @@ state_representation::Jacobian Model::compute_jacobian(const state_representatio
   // compute the jacobian from the joint state
   pinocchio::Data::Matrix6x J(6, this->get_number_of_joints());
   J.setZero();
-  pinocchio::computeFrameJacobian(this->robot_model_, this->robot_data_, joint_state.get_positions(), frame_id,
+  pinocchio::computeFrameJacobian(this->robot_model_,
+                                  this->robot_data_,
+                                  joint_state.get_positions(),
+                                  frame_id,
                                   pinocchio::LOCAL_WORLD_ALIGNED, J);
   // the model does not have any reference frame
   return state_representation::Jacobian(this->get_robot_name(),

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -132,13 +132,14 @@ state_representation::Jacobian Model::compute_jacobian(const state_representatio
   // compute the jacobian from the joint state
   pinocchio::Data::Matrix6x J(6, this->get_number_of_joints());
   J.setZero();
-  pinocchio::computeFrameJacobian(this->robot_model_,
-                                  this->robot_data_,
-                                  joint_state.get_positions(),
-                                  frame_id,
-                                  pinocchio::LOCAL_WORLD_ALIGNED,
-                                  J);
-  return state_representation::Jacobian(this->get_robot_name(), this->get_joint_frames(), J);
+  pinocchio::computeFrameJacobian(this->robot_model_, this->robot_data_, joint_state.get_positions(), frame_id,
+                                  pinocchio::LOCAL_WORLD_ALIGNED, J);
+  // the model does not have any reference frame
+  return state_representation::Jacobian(this->get_robot_name(),
+                                        this->get_joint_frames(),
+                                        this->robot_model_.frames[frame_id].name,
+                                        J,
+                                        this->frame_names_.front());
 }
 
 state_representation::Jacobian Model::compute_jacobian(const state_representation::JointState& joint_state,
@@ -180,16 +181,16 @@ Eigen::MatrixXd Model::compute_coriolis_matrix(const state_representation::Joint
                                           joint_state.get_velocities());
 }
 
-state_representation::JointTorques Model::compute_coriolis_torques(
-    const state_representation::JointState& joint_state) {
+state_representation::JointTorques
+Model::compute_coriolis_torques(const state_representation::JointState& joint_state) {
   Eigen::MatrixXd coriolis_matrix = this->compute_coriolis_matrix(joint_state);
   return state_representation::JointTorques(joint_state.get_name(),
                                             joint_state.get_names(),
                                             coriolis_matrix * joint_state.get_velocities());
 }
 
-state_representation::JointTorques Model::compute_gravity_torques(
-    const state_representation::JointPositions& joint_positions) {
+state_representation::JointTorques
+Model::compute_gravity_torques(const state_representation::JointPositions& joint_positions) {
   Eigen::VectorXd gravity_torque =
       pinocchio::computeGeneralizedGravity(this->robot_model_, this->robot_data_, joint_positions.data());
   return state_representation::JointTorques(joint_positions.get_name(), joint_positions.get_names(), gravity_torque);
@@ -200,8 +201,8 @@ state_representation::CartesianPose Model::forward_geometry(const state_represen
   return this->forward_geometry(joint_state, std::vector<unsigned int>{frame_id}).front();
 }
 
-std::vector<state_representation::CartesianPose> Model::forward_geometry(
-    const state_representation::JointState& joint_state, const std::vector<unsigned int>& frame_ids) {
+std::vector<state_representation::CartesianPose> Model::forward_geometry(const state_representation::JointState& joint_state,
+                                                                         const std::vector<unsigned int>& frame_ids) {
   if (joint_state.get_size() != this->get_number_of_joints()) {
     throw (exceptions::InvalidJointStateSizeException(joint_state.get_size(), this->get_number_of_joints()));
   }
@@ -231,8 +232,8 @@ state_representation::CartesianPose Model::forward_geometry(const state_represen
   return this->forward_geometry(joint_state, std::vector<std::string>{frame_name}).front();
 }
 
-std::vector<state_representation::CartesianPose> Model::forward_geometry(
-    const state_representation::JointState& joint_state, const std::vector<std::string>& frame_names) {
+std::vector<state_representation::CartesianPose> Model::forward_geometry(const state_representation::JointState& joint_state,
+                                                                         const std::vector<std::string>& frame_names) {
   std::vector<unsigned int> frame_ids(frame_names.size());
   for (unsigned int i = 0; i < frame_names.size(); ++i) {
     std::string name = frame_names[i];

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -136,7 +136,8 @@ state_representation::Jacobian Model::compute_jacobian(const state_representatio
                                   this->robot_data_,
                                   joint_state.get_positions(),
                                   frame_id,
-                                  pinocchio::LOCAL_WORLD_ALIGNED, J);
+                                  pinocchio::LOCAL_WORLD_ALIGNED,
+                                  J);
   // the model does not have any reference frame
   return state_representation::Jacobian(this->get_robot_name(),
                                         this->get_joint_frames(),

--- a/source/robot_model/test/tests/test_model.cpp
+++ b/source/robot_model/test/tests/test_model.cpp
@@ -72,18 +72,28 @@ TEST_F(RobotModelTest, TestJacobianJointNames) {
   }
 }
 
+TEST_F(RobotModelTest, TestJacobianFrameNames) {
+  state_representation::JointState dummy = state_representation::JointState(robot_name, 7);
+  state_representation::Jacobian jac = franka->compute_jacobian(dummy);
+  EXPECT_TRUE(jac.get_reference_frame() == "panda_link0");
+  EXPECT_TRUE(jac.get_frame() == "panda_link8");
+  state_representation::Jacobian jac2 = franka->compute_jacobian(dummy, "panda_link2");
+  EXPECT_TRUE(jac2.get_reference_frame() == "panda_link0");
+  EXPECT_TRUE(jac2.get_frame() == "panda_link2");
+}
+
 TEST_F(RobotModelTest, TestJacobianInvalidFrameName) {
   EXPECT_THROW(franka->compute_jacobian(joint_state, "panda_link99"), exceptions::FrameNotFoundException);
 }
 
 TEST_F(RobotModelTest, TestJacobianNbRows) {
   state_representation::Jacobian jac = franka->compute_jacobian(joint_state, "panda_joint2");
-  EXPECT_EQ(jac.get_nb_rows(), 6);
+  EXPECT_EQ(jac.rows(), 6);
 }
 
 TEST_F(RobotModelTest, TestJacobianNbCols) {
   state_representation::Jacobian jac = franka->compute_jacobian(joint_state, "panda_joint2");
-  EXPECT_EQ(jac.get_nb_cols(), joint_state.get_size());
+  EXPECT_EQ(jac.cols(), joint_state.get_size());
 }
 
 TEST_F(RobotModelTest, TestGravityGetterAndSetters) {

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -399,11 +399,11 @@ match the current `Jacobian` reference frame.
 
 ```cpp
 state_representation::Jacobian jac = state_representation::Jacobian::Random("myrobot", 3, "eef", "base_frame");
-state_representation::CartesianPose pose = state_representation::CartesianPose::Random("base_frame");
+state_representation::CartesianPose pose = state_representation::CartesianPose::Random("base_frame", "world");
 // the result is the Jacobian expressed in world
 state_representation::Jacobian jac_in_world = pose * jac;
 // alternatively, one case use the set_reference_frame function for inplace modifications
 jac.set_reference_frame(pose);
 // in case of non matching operation throw an IncompatibleStatesExceptions
-jac.set_reference_frame(state_representation::CartesianPose::Random("link0"));
+jac.set_reference_frame(state_representation::CartesianPose::Random("link0", "world"));
 ```

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -351,8 +351,8 @@ state_representation::Jacobian jac("myrobot", 3, "eef");
 state_representation::CartesianTwist eef_twist("eef")
 state_representation::JointVelocities jv = jac.pseudoinverse() * eef_twist;
 // in case of non matching frame or reference frame throw an IncompatibleStatesException
-state_representation::CartesianTwist eef_link("link2", "link0")
-state_representation::JointVelocities jv = jac.pseudoinverse() * eef_link;
+state_representation::CartesianTwist link2_twist("link2", "link0")
+state_representation::JointVelocities jv = jac.pseudoinverse() * link2_twist;
 ```
 
 Note that the `inverse` or `pseudoinverse` functions are computationally expensive and the `solve` function that relies

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -19,6 +19,7 @@ This description covers most of the functionalities starting from the spatial tr
   * [Conversion between JointVelocities and CartesianTwist](#conversion-between-jointvelocities-and-cartesiantwist)
   * [Conversion between JointTorques and CartesianWrench](#conversion-between-jointtorques-and-cartesianwrench)
   * [Matrix multiplication](#matrix-multiplication)
+  * [Changing the Jacobian reference frame](#changing-the-jacobian-reference-frame)
 
 ## Cartesian state
 
@@ -294,18 +295,21 @@ state_representation::JointPositions jp = period * jv; // note that jv * period 
 
 The `Jacobian` matrix of a robot ensures the conversion between both `CartesianState` and `JointState`.
 Similarly to the `JointState`, a `Jacobian` is associated to a robot and defined by the robot and the number of joints.
+As it is a mapping between joint and task spaces, as for the `CartesianState`, it is also defined by an associated
+frame name and a reference frame.
 
 ```cpp
-// create a jacobian for myrobot with 3 joints
-state_representation::Jacobian jac("myrobot", std::vector<string>({"joint0", "joint1", "joint2"}));
+// create a jacobian for myrobot with 3 joints, associated to frame A and expressed in B
+state_representation::Jacobian jac("myrobot", std::vector<string>({"joint0", "joint1", "joint2"}), "A", "B");
 ```
 
 The API is the same as the `JointState`, hence the constructor can also accept the number of joints to initialize the
 joint names vector.
 
 ```cpp
-// create a jacobian for myrobot with 3 joints named {"joint0", "joint1", "joint3"}
-state_representation::Jacobian jac("myrobot", 3);
+// create a jacobian for myrobot with 3 joints named {"joint0", "joint1", "joint3"}, associated to frame A and
+// expressed in world (default value of the reference frame when not provided)
+state_representation::Jacobian jac("myrobot", 3, "A");
 ```
 
 The `Jacobian` is simply a `6 x N` matrix where `N` is the number of joints.
@@ -333,16 +337,22 @@ Those operations are very useful to convert `JointState` from `CartesianState` a
 The simplest conversion is to transform a `JointVelocities` into a `CartesiantTwist` by multiplication with the `Jacobian`
 
 ```cpp
+state_representation::Jacobian jac("myrobot", 3, "eef_frame", "base_frame");
 state_representation::JointVelocities jv("myrobot", 3);
-state_representation::CartesianTwist eef_twist = jac * js;
+// compute the twist of eef_frame in base_frame from the joint velocities
+state_representation::CartesianTwist eef_twist = jac * jv;
 ```
 
 The opposite transformation, from `CartesianTwist` to `JointVelocities` requires the multiplication with the `inverse`
 (or `pseudoinverse`).
 
 ```cpp
+state_representation::Jacobian jac("myrobot", 3, "eef");
 state_representation::CartesianTwist eef_twist("eef")
 state_representation::JointVelocities jv = jac.pseudoinverse() * eef_twist;
+// in case of non matching frame or reference frame throw an IncompatibleStatesException
+state_representation::CartesianTwist eef_link("link2", "link0")
+state_representation::JointVelocities jv = jac.pseudoinverse() * eef_link;
 ```
 
 Note that the `inverse` or `pseudoinverse` functions are computationally expensive and the `solve` function that relies
@@ -372,7 +382,28 @@ Direct multiplication of the `Jacobian` object with another `Eigen::MatrixXd` ha
 `Eigen::MatrixXd` product.
 
 ```cpp
-state_representation::Jacobian jac("myrobot", 3, Eigen::MatrixXd::Random(6, 3));
+state_representation::Jacobian jac("myrobot", 3, "eef", Eigen::MatrixXd::Random(6, 3));
+// alternatively can use the Random static constructor
+state_representation::Jacobian jac = state_representation::Jacobian::Random("myrobot", 3, "eef");
 Eigen::MatrixXd mat = jac.data();
 Eigen::MatrixXd res = jac * Eigen::MatrixXd(3, 4); // equivalent to  jac.data() * Eigen::MatrixXd(3, 4);
+```
+
+### Changing the Jacobian reference frame
+
+As stated earlier, the `Jacobian` is expressed in a reference frame and can, therefore, use the operations with
+`CartesianPose` to be modified. It relies on the usage of the overloaded `operator*` or the `set_reference_frame`
+function for inplace modifications. It is equivalent to multiply each columns of the `Jacobian` by the `CartesianPose`
+on both the linear and angular part of the matrix. For this operation to be valid, the `CartesianPose` name has to
+match the current `Jacobian` reference frame.
+
+```cpp
+state_representation::Jacobian jac = state_representation::Jacobian::Random("myrobot", 3, "eef", "base_frame");
+state_representation::CartesianPose pose = state_representation::CartesianPose::Random("base_frame");
+// the result is the Jacobian expressed in world
+state_representation::Jacobian jac_in_world = pose * jac;
+// alternatively, one case use the set_reference_frame function for inplace modifications
+jac.set_reference_frame(pose);
+// in case of non matching operation throw an IncompatibleStatesExceptions
+jac.set_reference_frame(state_representation::CartesianPose::Random("link0"));
 ```

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -75,6 +75,13 @@ public:
   State(const State& state);
 
   /**
+   * @brief Swap the values of the two State
+   * @param state1 State to be swapped with 2
+   * @param state2 State to be swapped with 1
+   */
+  friend void swap(State& state1, State& state2);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
@@ -108,7 +115,7 @@ public:
   const std::chrono::time_point<std::chrono::steady_clock>& get_timestamp() const;
 
   /**
-   * @brief Reset the timestramp attribute to now
+   * @brief Reset the timestamp attribute to now
    */
   void reset_timestamp();
 
@@ -142,19 +149,24 @@ public:
 
   /**
    * @brief Overload the ostream operator for printing
-   * @param os the ostream to happend the string representing the State to
+   * @param os the ostream to append the string representing the State to
    * @param state the State to print
    * @return the appended ostream 
    */
   friend std::ostream& operator<<(std::ostream& os, const State& state);
 };
 
+inline void swap(State& state1, State& state2) {
+  std::swap(state1.type_, state2.type_);
+  std::swap(state1.name_, state2.name_);
+  std::swap(state1.empty_, state2.empty_);
+  std::swap(state1.timestamp_, state2.timestamp_);
+}
+
 inline State& State::operator=(const State& state) {
-  this->type_ = state.type_;
-  this->name_ = state.name_;
-  this->empty_ = state.empty_;
-  this->timestamp_ = std::chrono::steady_clock::now();
-  return (*this);
+  State tmp(state);
+  swap(*this, tmp);
+  return *this;
 }
 
 inline const StateType& State::get_type() const {

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -13,15 +13,10 @@
 #include "state_representation/State.hpp"
 #include <eigen3/Eigen/Core>
 
-using namespace state_representation::exceptions;
-
 namespace state_representation {
 class CartesianTwist;
-
 class CartesianWrench;
-
 class JointVelocities;
-
 class JointTorques;
 
 /**
@@ -31,45 +26,60 @@ class JointTorques;
 class Jacobian : public State {
 private:
   std::vector<std::string> joint_names_;///< names of the joints
-  unsigned int nb_rows_;                ///< number of rows
-  unsigned int nb_cols_;                ///< number of columns
-  Eigen::MatrixXd data_matrix_;         ///< internal storage of the jacobian matrix
+  std::string frame_;                   ///< name of the frame at which the jacobian is computed
+  std::string reference_frame_;         /// name of the reference frame in which the jacobian is expressed
+  unsigned int rows_;                   ///< number of rows
+  unsigned int cols_;                   ///< number of columns
+  Eigen::MatrixXd data_;                ///< internal storage of the jacobian matrix
 
 public:
   /**
-   * @brief Empty constructor for a Jacobian
+   * @brief Constructor with names and number of joints provided
+   * @param robot_name the name of the robot associated to
+   * @param nb_joints the number of joints
+   * @param frame the name of the frame at which the jacobian is computed
+   * @param reference_frame the name of the reference frame in which the jacobian is expressed (default "world")
    */
-  explicit Jacobian();
+  explicit Jacobian(const std::string& robot_name,
+                    unsigned int nb_joints,
+                    const std::string& frame,
+                    const std::string& reference_frame = "world");
 
   /**
-   * @brief Constructor with name and number of joints provided
-   * @brief name the name of the robot associated to
-   * @brief nb_joints the number of joints
+   * @brief Constructor with names and list of joint names provided
+   * @param joint_names the vector of joint names
+   * @param robot_name the name of the robot associated to
+   * @param frame the name of the frame at which the jacobian is computed
+   * @param reference_frame the name of the reference frame in which the jacobian is expressed (default "world")
    */
-  explicit Jacobian(const std::string& robot_name, unsigned int nb_joints = 0);
+  explicit Jacobian(const std::string& robot_name,
+                    const std::vector<std::string>& joint_names,
+                    const std::string& frame,
+                    const std::string& reference_frame = "world");
 
   /**
-   * @brief Constructor with name and list of joint names provided
-   * @brief name the name of the robot associated to
-   * @brief joint_names the list of joint names
+   * @brief Constructor with names and jacobian matrix as eigen matrix
+   * @param frame the name of the frame at which the jacobian is computed
+   * @param data the values of the jacobian matrix
+   * @param reference_frame the name of the reference frame in which the jacobian is expressed (default "world")
    */
-  explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names);
+  explicit Jacobian(const std::string& robot_name,
+                    const std::string& frame,
+                    const Eigen::MatrixXd& data,
+                    const std::string& reference_frame = "world");
 
   /**
-   * @brief Constructor with name and jacobian matrix as eigen matrix
-   * @brief name the name of the robot associated to
-   * @brief data the value of the jacobian matrix
+   * @brief Constructor with names, vector of joint names, and jacobian matrix as eigen matrix
+   * @param joint_names the vector of joint names
+   * @param frame the name of the frame at which the jacobian is computed
+   * @param data the values of the jacobian matrix
+   * @param reference_frame the name of the reference frame in which the jacobian is expressed (default "world")
    */
-  explicit Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data);
-
-  /**
-   * @brief Constructor with name, list of joint names and jacobian matrix as eigen matrix
-   * @brief name the name of the robot associated to
-   * @brief joint_names the list of joint names
-   * @brief data the value of the jacobian matrix
-   */
-  explicit Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names,
-                    const Eigen::MatrixXd& data);
+  explicit Jacobian(const std::string& robot_name,
+                    const std::vector<std::string>& joint_names,
+                    const std::string& frame,
+                    const Eigen::MatrixXd& data,
+                    const std::string& reference_frame = "world");
 
   /**
    * @brief Copy constructor of a Jacobian
@@ -77,46 +87,116 @@ public:
   Jacobian(const Jacobian& jacobian);
 
   /**
+   * @brief Constructor for a random Jacobian
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints for initialization
+   * @param frame the name of the frame at which the jacobian is computed
+   * @param reference_frame the name of the reference frame in which the jacobian is expressed (default "world")
+   * @return Jacobian with random data values
+   */
+  static Jacobian Random(const std::string& robot_name,
+                         unsigned int nb_joints,
+                         const std::string& frame,
+                         const std::string& reference_frame = "world");
+
+  /**
+   * @brief Constructor for a random Jacobian
+   * @param robot_name the name of the associated robot
+   * @param joint_names list of joint names
+   * @param frame the name of the frame at which the jacobian is computed
+   * @param reference_frame the name of the reference frame in which the jacobian is expressed (default "world")
+   * @return Jacobian with random data values
+   */
+  static Jacobian Random(const std::string& robot_name,
+                         const std::vector<std::string>& joint_names,
+                         const std::string& frame,
+                         const std::string& reference_frame = "world");
+
+  /**
+   * @brief Swap the values of the two Jacobian
+   * @param jacobian1 Jacobian to be swapped with 2
+   * @param jacobian2 Jacobian to be swapped with 1
+   */
+  friend void swap(Jacobian& jacobian1, Jacobian& jacobian2);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
-   * @param matrix the matrix with value to assign
-   * @return reference to the current matrix with new values
+   * @param jacobian the Jacobian with value to assign
+   * @return reference to the current Jacobian with new values
    */
-  Jacobian& operator=(const Jacobian& matrix);
+  Jacobian& operator=(const Jacobian& jacobian);
 
   /**
-   * @brief Getter of the nb_rows from the attributes
+   * @brief Getter of the number of rows attribute
+   * @return the number of rows
    */
-  unsigned int get_nb_rows() const;
+  unsigned int rows() const;
 
   /**
-   * @brief Setter of the nb_rows
+   * @brief Setter of the number of rows
+   * @param rows the number of rows
    */
-  void set_nb_rows(unsigned int nb_rows);
+  void set_rows(unsigned int rows);
 
   /**
-   * @brief Setter of the nb_cols
+   * @brief Accessor of the row data at given index
+   * @param index the desired index of the row
+   * @return the row vector at index
    */
-  void set_nb_cols(unsigned int nb_cols);
+  Eigen::VectorXd row(unsigned int index) const;
 
   /**
-   * @brief Getter of the nb_cols from the attributes
+   * @brief Getter of the number of columns attribute
+   * @return the number of cols
    */
-  unsigned int get_nb_cols() const;
+  unsigned int cols() const;
 
   /**
-   * @brief Getter of the names attribute
+   * @brief Setter of the number of columns
+   * @param cols the number of columns
+   */
+  void set_cols(unsigned int cols);
+
+  /**
+   * @brief Accessor of the column data at given index
+   * @param index the desired index of the column
+   * @return the column vector at index
+   */
+  Eigen::VectorXd col(unsigned int index) const;
+
+  /**
+   * @brief Getter of the joint_names attribute
    */
   const std::vector<std::string>& get_joint_names() const;
 
   /**
-   * @brief Setter of the names attribute from the number of joints
+   * @brief Setter of the joint_names attribute from the number of joints
    */
   void set_joint_names(unsigned int nb_joints);
 
   /**
-   * @brief Setter of the names attribute
+   * @brief Setter of the joint_names attribute from a vector of joint names
    */
-  void set_joint_names(const std::vector<std::string>& names);
+  void set_joint_names(const std::vector<std::string>& joint_names);
+
+  /**
+   * @brief Getter of the frame_name attribute
+   */
+  const std::string& get_frame() const;
+
+  /**
+   * @brief Getter of the frame_name attribute
+   */
+  const std::string& get_reference_frame() const;
+
+  /**
+   * @brief Setter of the reference_frame attribute from a CartesianPose
+   * Update the value of the data matrix accordingly by changing the reference frame of each columns.
+   * This means that the computation needs to be compatible, i.e. the previous reference frame should
+   * match the name of the new reference frame as input.
+   * @param reference_frame the reference frame as a CartesianPose
+   */
+  void set_reference_frame(const CartesianPose& reference_frame);
 
   /**
    * @brief Getter of the data attribute
@@ -132,12 +212,12 @@ public:
    * @brief Check if the jacobian matrix is compatible for operations with the state given as argument
    * @param state the state to check compatibility with
    */
-  bool is_compatible(const State& state) const;
+  bool is_compatible(const State& state) const override;
 
   /**
    * @brief Initialize the matrix to a zero value
    */
-  void initialize();
+  void initialize() override;
 
   /**
     * @brief Return the transpose of the jacobian matrix
@@ -228,35 +308,59 @@ public:
   /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to append the string representing the matrix to
-   * @param matrix the matrix to print
+   * @param jacobian the Jacobian to print
    * @return the appended ostream
    */
-  friend std::ostream& operator<<(std::ostream& os, const Jacobian& matrix);
+  friend std::ostream& operator<<(std::ostream& os, const Jacobian& jacobian);
+
+  /**
+   * @brief Overload the * operator with a CartesianPose on left side. This is
+   * equivalent to a changing of reference frame of the Jacobian
+   * @param pose the CartesianPose to multiply with
+   * @param jacobian the Jacobian to be multiplied with the CartesianPose
+   * @return the Jacobian expressed in the new reference frame
+   */
+  friend Jacobian operator*(const CartesianPose& pose, const Jacobian& jacobian);
 };
 
-inline Jacobian& Jacobian::operator=(const Jacobian& matrix) {
-  State::operator=(matrix);
-  this->joint_names_ = matrix.joint_names_;
-  this->nb_cols_ = matrix.nb_cols_;
-  this->nb_rows_ = matrix.nb_rows_;
-  this->data_matrix_ = matrix.data_matrix_;
-  return (*this);
+inline void swap(Jacobian& jacobian1, Jacobian& jacobian2) {
+  swap(static_cast<State&>(jacobian1), static_cast<State&>(jacobian2));
+  std::swap(jacobian1.joint_names_, jacobian2.joint_names_);
+  std::swap(jacobian1.frame_, jacobian2.frame_);
+  std::swap(jacobian1.reference_frame_, jacobian2.reference_frame_);
+  std::swap(jacobian1.cols_, jacobian2.cols_);
+  std::swap(jacobian1.rows_, jacobian2.rows_);
+  std::swap(jacobian1.data_, jacobian2.data_);
 }
 
-inline unsigned int Jacobian::get_nb_rows() const {
-  return this->nb_rows_;
+inline Jacobian& Jacobian::operator=(const Jacobian& jacobian) {
+  Jacobian tmp(jacobian);
+  swap(*this, tmp);
+  return *this;
 }
 
-inline unsigned int Jacobian::get_nb_cols() const {
-  return this->nb_cols_;
+inline unsigned int Jacobian::rows() const {
+  return this->rows_;
 }
 
-inline void Jacobian::set_nb_rows(unsigned int nb_rows) {
-  this->nb_rows_ = nb_rows;
+inline unsigned int Jacobian::cols() const {
+  return this->cols_;
 }
 
-inline void Jacobian::set_nb_cols(unsigned int nb_cols) {
-  this->nb_cols_ = nb_cols;
+inline void Jacobian::set_rows(unsigned int rows) {
+  this->rows_ = rows;
+}
+
+inline void Jacobian::set_cols(unsigned int cols) {
+  this->cols_ = cols;
+}
+
+inline Eigen::VectorXd Jacobian::row(unsigned int index) const {
+  return this->data_.row(index);
+}
+
+inline Eigen::VectorXd Jacobian::col(unsigned int index) const {
+  return this->data_.col(index);
 }
 
 inline const std::vector<std::string>& Jacobian::get_joint_names() const {
@@ -264,67 +368,84 @@ inline const std::vector<std::string>& Jacobian::get_joint_names() const {
 }
 
 inline void Jacobian::set_joint_names(unsigned int nb_joints) {
-  this->joint_names_.resize(nb_joints);
-  this->nb_cols_ = nb_joints;
+  if (this->joint_names_.size() != nb_joints) {
+    throw exceptions::IncompatibleSizeException("Input number of joints is of incorrect size, expected "
+                                                    + std::to_string(this->joint_names_.size())
+                                                    + " got " + std::to_string(nb_joints));
+  }
   for (unsigned int i = 0; i < nb_joints; ++i) {
     this->joint_names_[i] = "joint" + std::to_string(i);
   }
-  this->initialize();
 }
 
 inline void Jacobian::set_joint_names(const std::vector<std::string>& joint_names) {
+  if (this->joint_names_.size() != joint_names.size()) {
+    throw exceptions::IncompatibleSizeException("Input vector of joint names is of incorrect size, expected "
+                                                    + std::to_string(this->joint_names_.size())
+                                                    + " got " + std::to_string(joint_names.size()));
+  }
   this->joint_names_ = joint_names;
-  this->nb_cols_ = joint_names.size();
-  this->initialize();
+}
+
+inline const std::string& Jacobian::get_frame() const {
+  return this->frame_;
+}
+
+inline const std::string& Jacobian::get_reference_frame() const {
+  return this->reference_frame_;
 }
 
 inline const Eigen::MatrixXd& Jacobian::data() const {
-  return this->data_matrix_;
+  return this->data_;
 }
 
 inline void Jacobian::set_data(const Eigen::MatrixXd& data) {
-  if (this->get_nb_rows() != data.rows() || this->get_nb_cols() != data.cols()) {
-    throw IncompatibleSizeException("Input matrix is of incorrect size");
+  if (this->rows() != data.rows() || this->cols() != data.cols()) {
+    throw exceptions::IncompatibleSizeException("Input matrix is of incorrect size, expected "
+                                                    + std::to_string(this->rows_) + "x" + std::to_string(this->cols_)
+                                                    + " got " + std::to_string(data.rows()) + "x"
+                                                    + std::to_string(data.cols()));
   }
   this->set_filled();
-  this->data_matrix_ = data;
+  this->data_ = data;
 }
 
 inline bool Jacobian::is_compatible(const State& state) const {
   bool compatible = false;
   if (state.get_type() == StateType::JOINTSTATE) {
+    // compatibility is assured through the vector of joint names
     compatible = (this->get_name() == state.get_name())
-        && (this->get_nb_cols() == static_cast<const JointState&>(state).get_size());
+        && (this->cols_ == dynamic_cast<const JointState&>(state).get_size());
     if (compatible) {
-      for (unsigned int i = 0; i < this->get_nb_cols(); ++i) {
-        compatible = (compatible && this->joint_names_[i] == static_cast<const JointState&>(state).get_names()[i]);
+      for (unsigned int i = 0; i < this->cols_; ++i) {
+        compatible = (compatible && this->joint_names_[i] == dynamic_cast<const JointState&>(state).get_names()[i]);
       }
     }
-  }
-    // there is no possibilities to check that a correct frame associated to the robot is sent
-  else if (state.get_type() == StateType::CARTESIANSTATE) {
-    compatible = true;
+  } else if (state.get_type() == StateType::CARTESIANSTATE) {
+    // compatibility is assured through the reference frame and the name of the frame
+    compatible = (this->reference_frame_ == dynamic_cast<const CartesianState&>(state).get_reference_frame())
+        && (this->frame_ == dynamic_cast<const CartesianState&>(state).get_name());
   }
   return compatible;
 }
 
 inline double& Jacobian::operator()(unsigned int row, unsigned int col) {
-  if (row > this->get_nb_rows()) {
-    throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
+  if (row > this->rows_) {
+    throw std::out_of_range("Given row is out of range: number of rows = " + std::to_string(this->rows_));
   }
-  if (col > this->get_nb_cols()) {
-    throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  if (col > this->cols_) {
+    throw std::out_of_range("Given column is out of range: number of columns = " + std::to_string(this->cols_));
   }
-  return this->data_matrix_(row, col);
+  return this->data_(row, col);
 }
 
 inline const double& Jacobian::operator()(unsigned int row, unsigned int col) const {
-  if (row > this->get_nb_rows()) {
-    throw std::out_of_range("Given row is out of range: number of rows = " + this->get_nb_rows());
+  if (row > this->rows_) {
+    throw std::out_of_range("Given row is out of range: number of rows = " + std::to_string(this->rows_));
   }
-  if (col > this->get_nb_cols()) {
-    throw std::out_of_range("Given column is out of range: number of columns = " + this->get_nb_cols());
+  if (col > this->cols_) {
+    throw std::out_of_range("Given column is out of range: number of columns = " + std::to_string(this->cols_));
   }
-  return this->data_matrix_(row, col);
+  return this->data_(row, col);
 }
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -95,7 +95,7 @@ public:
    * @brief Constructor for the random JointPositions
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointPositions with zero positions values
+   * @return JointPositions with random positions values
    */
   static JointPositions Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
 

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -63,7 +63,7 @@ public:
    * @brief Constructor for the zero JointTorques
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointTorques with zero velocities values
+   * @return JointTorques with zero torques values
    */
   static JointTorques Zero(const std::string& robot_name, unsigned int nb_joints);
 
@@ -71,7 +71,7 @@ public:
    * @brief Constructor for the zero JointTorques
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointTorques with zero velocities values
+   * @return JointTorques with zero torques values
    */
   static JointTorques Zero(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
@@ -79,7 +79,7 @@ public:
    * @brief Constructor for the random JointTorques
    * @param robot_name the name of the associated robot
    * @param nb_joints the number of joints for initialization
-   * @return JointTorques with random velocities values
+   * @return JointTorques with random torques values
    */
   static JointTorques Random(const std::string& robot_name, unsigned int nb_joints);
 
@@ -87,7 +87,7 @@ public:
    * @brief Constructor for the random JointTorques
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
-   * @return JointTorques with random velocities values
+   * @return JointTorques with random torques values
    */
   static JointTorques Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
 

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -81,7 +81,7 @@ Jacobian Jacobian::Random(const std::string& robot_name,
 }
 
 void Jacobian::set_reference_frame(const CartesianPose& reference_frame) {
-  *this = reference_frame * *this;
+  *this = reference_frame * (*this);
 }
 
 Jacobian Jacobian::transpose() const {

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -3,60 +3,103 @@
 #include "state_representation/exceptions/IncompatibleStatesException.hpp"
 
 namespace state_representation {
-Jacobian::Jacobian() : State(StateType::JACOBIANMATRIX), nb_rows_(6) {}
-
-Jacobian::Jacobian(const std::string& robot_name, unsigned int nb_joints) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(6), nb_cols_(nb_joints) {
+Jacobian::Jacobian(const std::string& robot_name,
+                   unsigned int nb_joints,
+                   const std::string& frame,
+                   const std::string& reference_frame) :
+    State(StateType::JACOBIANMATRIX, robot_name),
+    joint_names_(nb_joints),
+    frame_(frame),
+    reference_frame_(reference_frame),
+    rows_(6),
+    cols_(nb_joints) {
   this->set_joint_names(nb_joints);
+  this->initialize();
 }
 
-Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(6), nb_cols_(joint_names.size()) {
-  this->set_joint_names(joint_names);
+Jacobian::Jacobian(const std::string& robot_name,
+                   const std::vector<std::string>& joint_names,
+                   const std::string& frame,
+                   const std::string& reference_frame) :
+    State(StateType::JACOBIANMATRIX, robot_name),
+    joint_names_(joint_names),
+    frame_(frame),
+    reference_frame_(reference_frame),
+    rows_(6),
+    cols_(joint_names.size()) {
+  this->initialize();
 }
 
-Jacobian::Jacobian(const std::string& robot_name, const Eigen::MatrixXd& data) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(data.rows()), nb_cols_(data.cols()) {
-  this->set_joint_names(this->get_nb_cols());
+Jacobian::Jacobian(const std::string& robot_name,
+                   const std::string& frame,
+                   const Eigen::MatrixXd& data,
+                   const std::string& reference_frame) :
+    Jacobian(robot_name, data.cols(), frame, reference_frame) {
   this->set_data(data);
 }
 
-Jacobian::Jacobian(const std::string& robot_name, const std::vector<std::string>& joint_names,
-                   const Eigen::MatrixXd& data) :
-    State(StateType::JACOBIANMATRIX, robot_name), nb_rows_(data.rows()), nb_cols_(joint_names.size()) {
-  this->set_joint_names(joint_names);
+Jacobian::Jacobian(const std::string& robot_name,
+                   const std::vector<std::string>& joint_names,
+                   const std::string& frame,
+                   const Eigen::MatrixXd& data,
+                   const std::string& reference_frame) :
+    Jacobian(robot_name, joint_names, frame, reference_frame) {
   this->set_data(data);
 }
 
 Jacobian::Jacobian(const Jacobian& jacobian) :
     State(jacobian),
     joint_names_(jacobian.joint_names_),
-    nb_rows_(jacobian.nb_rows_),
-    nb_cols_(jacobian.nb_cols_),
-    data_matrix_(jacobian.data_matrix_) {}
+    frame_(jacobian.frame_),
+    reference_frame_(jacobian.reference_frame_),
+    rows_(jacobian.rows_),
+    cols_(jacobian.cols()),
+    data_(jacobian.data_) {}
 
 void Jacobian::initialize() {
   this->State::initialize();
-  this->data_matrix_.resize(this->nb_rows_, this->nb_cols_);
-  this->data_matrix_.setZero();
+  this->data_.resize(this->rows_, this->cols());
+  this->data_.setZero();
+}
+
+Jacobian Jacobian::Random(const std::string& robot_name,
+                          unsigned int nb_joints,
+                          const std::string& frame,
+                          const std::string& reference_frame) {
+  Jacobian random(robot_name, nb_joints, frame, reference_frame);
+  random.set_data(Eigen::MatrixXd::Random(random.rows_, random.cols_));
+  return random;
+}
+
+Jacobian Jacobian::Random(const std::string& robot_name,
+                          const std::vector<std::string>& joint_names,
+                          const std::string& frame,
+                          const std::string& reference_frame) {
+  Jacobian random(robot_name, joint_names, frame, reference_frame);
+  random.set_data(Eigen::MatrixXd::Random(random.rows_, random.cols_));
+  return random;
+}
+
+void Jacobian::set_reference_frame(const CartesianPose& reference_frame) {
+  *this = reference_frame * *this;
 }
 
 Jacobian Jacobian::transpose() const {
   Jacobian result(*this);
-  result.set_nb_cols(this->get_nb_rows());
-  result.set_nb_rows(this->get_nb_cols());
+  result.cols_ = this->rows_;
+  result.rows_ = this->cols_;
   result.set_data(result.data().transpose());
   return result;
 }
 
 Jacobian Jacobian::inverse() const {
-  if (this->get_nb_rows() != this->get_nb_cols()) {
+  if (this->rows_ != this->cols_) {
     throw exceptions::IncompatibleSizeException(
         "The Jacobian matrix is not invertible, use the pseudoinverse function instead");
   }
   Jacobian result(*this);
-  result.set_nb_cols(this->get_nb_cols());
-  result.set_nb_rows(this->get_nb_rows());
+  result.cols_ = this->cols_;
+  result.rows_ = this->rows_;
   result.set_data(result.data().inverse());
   return result;
 }
@@ -64,50 +107,90 @@ Jacobian Jacobian::inverse() const {
 Jacobian Jacobian::pseudoinverse() const {
   Jacobian result(*this);
   Eigen::MatrixXd pinv = this->data().completeOrthogonalDecomposition().pseudoInverse();
-  result.set_nb_cols(pinv.cols());
-  result.set_nb_rows(pinv.rows());
+  result.cols_ = pinv.cols();
+  result.rows_ = pinv.rows();
   result.set_data(pinv);
   return result;
 }
 
 Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const {
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (matrix.rows() != this->get_nb_cols()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (matrix.rows() != this->cols_) {
+    throw IncompatibleSizeException("Input matrix is of incorrect size, expected "
+                                        + std::to_string(this->cols_) + " rows, got " + std::to_string(matrix.rows()));
+  }
   return this->data() * matrix;
 }
 
 CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
-  if (dq.is_empty()) { throw EmptyStateException(dq.get_name() + " state is empty"); }
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (dq.is_empty()) {
+    throw EmptyStateException(dq.get_name() + " state is empty");
+  }
   if (!this->is_compatible(dq)) {
     throw IncompatibleStatesException("The Jacobian and the input JointVelocities are incompatible");
   }
   Eigen::Matrix<double, 6, 1> twist = (*this) * dq.data();
-  // crate a CartesianTwist with name "robot"_end_effector and reference frame "robot"_base
-  CartesianTwist result(this->get_name() + "_end_effector", twist, this->get_name() + "_base");
+  CartesianTwist result(this->frame_, twist, this->reference_frame_);
   return result;
 }
 
 JointVelocities Jacobian::operator*(const CartesianTwist& twist) const {
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (twist.is_empty()) {
+    throw EmptyStateException(twist.get_name() + " state is empty");
+  }
+  if (!this->is_compatible(twist)) {
+    throw IncompatibleStatesException("The Jacobian and the input CartesianTwist are incompatible");
+  }
   Eigen::VectorXd joint_velocities = (*this) * twist.data();
   JointVelocities result(this->get_name(), this->get_joint_names(), joint_velocities);
   return result;
 }
 
 JointTorques Jacobian::operator*(const CartesianWrench& wrench) const {
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (wrench.is_empty()) {
+    throw EmptyStateException(wrench.get_name() + " state is empty");
+  }
+  if (!this->is_compatible(wrench)) {
+    throw IncompatibleStatesException("The Jacobian and the input CartesianWrench are incompatible");
+  }
   Eigen::VectorXd joint_torques = (*this) * wrench.data();
   JointTorques result(this->get_name(), this->get_joint_names(), joint_torques);
   return result;
 }
 
 Eigen::MatrixXd Jacobian::solve(const Eigen::MatrixXd& matrix) const {
-  if (this->is_empty()) { throw EmptyStateException(this->get_name() + " state is empty"); }
-  if (this->get_nb_rows() != matrix.rows()) { throw IncompatibleSizeException("Input matrix is of incorrect size"); }
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (this->rows_ != matrix.rows()) {
+    throw IncompatibleSizeException("Input matrix is of incorrect size, expected "
+                                        + std::to_string(this->rows_) + " rows, got " + std::to_string(matrix.rows()));
+  }
   return this->data().colPivHouseholderQr().solve(matrix);
 }
 
 JointVelocities Jacobian::solve(const CartesianTwist& twist) const {
-  if (twist.is_empty()) { throw EmptyStateException(twist.get_name() + " state is empty"); }
-  // this use the solve operation instead of using the inverse or pseudo-inverse of the jacobian
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  if (twist.is_empty()) {
+    throw EmptyStateException(twist.get_name() + " state is empty");
+  }
+  if (!this->is_compatible(twist)) {
+    throw IncompatibleStatesException("The Jacobian and the input CartesianTwist are incompatible");
+  }
+  // this uses the solve operation instead of using the inverse or pseudo-inverse of the jacobian
   Eigen::VectorXd joint_velocities = this->solve(twist.data());
   // return a JointVelocities state
   JointVelocities result(this->get_name(), this->get_joint_names(), joint_velocities);
@@ -119,24 +202,55 @@ Jacobian Jacobian::copy() const {
   return result;
 }
 
-std::ostream& operator<<(std::ostream& os, const Jacobian& matrix) {
-  if (matrix.is_empty()) {
+std::ostream& operator<<(std::ostream& os, const Jacobian& jacobian) {
+  if (jacobian.is_empty()) {
     os << "Empty Jacobian";
   } else {
-    os << matrix.get_name() << " Jacobian" << std::endl;
+    os << jacobian.get_name() << " Jacobian associated to " << jacobian.frame_;
+    os << ", expressed in " << jacobian.reference_frame_ << std::endl;
     os << "joint names: [";
-    for (auto& n : matrix.get_joint_names()) { os << n << ", "; }
+    for (auto& n : jacobian.get_joint_names()) { os << n << ", "; }
     os << "]" << std::endl;
-    os << "number of rows: " << matrix.get_nb_rows() << std::endl;
-    os << "number of columns: " << matrix.get_nb_cols() << std::endl;
-    for (unsigned int i = 0; i < matrix.get_nb_rows(); ++i) {
-      os << "| " << matrix(i, 0);
-      for (unsigned int j = 1; j < matrix.get_nb_cols(); ++j) {
-        os << ", " << matrix(i, j);
+    os << "number of rows: " << jacobian.rows_ << std::endl;
+    os << "number of columns: " << jacobian.cols_ << std::endl;
+    for (unsigned int i = 0; i < jacobian.rows_; ++i) {
+      os << "| " << jacobian(i, 0);
+      for (unsigned int j = 1; j < jacobian.cols_; ++j) {
+        os << ", " << jacobian(i, j);
       }
       os << " |" << std::endl;
     }
   }
   return os;
+}
+
+Jacobian operator*(const CartesianPose& pose, const Jacobian& jacobian) {
+  // check compatibility
+  if (jacobian.is_empty()) {
+    throw EmptyStateException(jacobian.get_name() + " state is empty");
+  }
+  if (pose.is_empty()) {
+    throw EmptyStateException(pose.get_name() + " state is empty");
+  }
+  if (pose.get_name() != jacobian.get_reference_frame()) {
+    throw IncompatibleStatesException("The Jacobian and the input CartesianPose are incompatible, expected pose of "
+                                          + jacobian.get_reference_frame() + " got " + pose.get_name());
+  }
+  // number of rows of the jacobian should be 6 (incorrect if it has been transposed before)
+  if (jacobian.rows_ != 6) {
+    throw IncompatibleStatesException(
+        "The Jacobian and the input CartesianPose are incompatible, the Jacobian has probably been transposed before");
+  }
+  Jacobian result(jacobian);
+  // change the reference frame of all the columns
+  for (unsigned int i = 0; i < jacobian.cols_; ++i) {
+    // update position part
+    result.data_.col(i).head(3) = pose * jacobian.data_.col(i).head(3);
+    // update orientation part
+    result.data_.col(i).tail(3) = pose * jacobian.data_.col(i).tail(3);
+  }
+  // change the reference frame
+  result.reference_frame_ = pose.get_reference_frame();
+  return result;
 }
 }// namespace state_representation

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -245,9 +245,9 @@ Jacobian operator*(const CartesianPose& pose, const Jacobian& jacobian) {
   // change the reference frame of all the columns
   for (unsigned int i = 0; i < jacobian.cols_; ++i) {
     // update position part
-    result.data_.col(i).head(3) = pose * jacobian.data_.col(i).head(3);
+    result.data_.col(i).head(3) = pose.get_orientation() * jacobian.data_.col(i).head(3);
     // update orientation part
-    result.data_.col(i).tail(3) = pose * jacobian.data_.col(i).tail(3);
+    result.data_.col(i).tail(3) = pose.get_orientation() * jacobian.data_.col(i).tail(3);
   }
   // change the reference frame
   result.reference_frame_ = pose.get_reference_frame();

--- a/source/state_representation/test/tests/test_jacobian.cpp
+++ b/source/state_representation/test/tests/test_jacobian.cpp
@@ -99,7 +99,7 @@ TEST(JacobianTest, TestSolve) {
 
 TEST(JacobianTest, TestJointToCartesian) {
   Jacobian jac = Jacobian::Random("robot", 7, "test", "test_ref");
-  JointVelocities jvel = JointVelocities::Random("robot",7);
+  JointVelocities jvel = JointVelocities::Random("robot", 7);
   CartesianTwist cvel = jac * jvel;
 
   EXPECT_TRUE(cvel.get_name() == jac.get_frame());

--- a/source/state_representation/test/tests/test_jacobian.cpp
+++ b/source/state_representation/test/tests/test_jacobian.cpp
@@ -118,9 +118,6 @@ TEST(JacobianTest, TestCartesianToJoint) {
     except_thrown1 = true;
   }
   EXPECT_TRUE(except_thrown1);
-
-  // this changing of reference frame should actually not be possible I think. As it should include a transformation
-  // from previous reference frame to the new desired one. This is how it is now implemented in the Jacobian
   cvel.set_reference_frame("test_ref");
 
   state_representation::JointVelocities jvel2;

--- a/source/state_representation/test/tests/test_jacobian.cpp
+++ b/source/state_representation/test/tests/test_jacobian.cpp
@@ -7,22 +7,22 @@ using namespace state_representation::exceptions;
 
 TEST(JacobianTest, TestCreate) {
   Jacobian jac("robot", 7, "test");
-  EXPECT_TRUE(jac.rows() == 6);
-  EXPECT_TRUE(jac.cols() == 7);
+  EXPECT_EQ(jac.rows(), 6);
+  EXPECT_EQ(jac.cols(), 7);
   EXPECT_TRUE(jac.is_empty());
-  EXPECT_TRUE(jac.get_frame() == "test");
-  EXPECT_TRUE(jac.get_reference_frame() == "world");
+  EXPECT_EQ(jac.get_frame(), "test");
+  EXPECT_EQ(jac.get_reference_frame(), "world");
   for (std::size_t i = 0; i < jac.cols(); ++i) {
-    EXPECT_TRUE(jac.get_joint_names().at(i) == ("joint" + std::to_string(i)));
-    EXPECT_TRUE(jac.col(i).norm() == 0);
+    EXPECT_EQ(jac.get_joint_names().at(i), ("joint" + std::to_string(i)));
+    EXPECT_EQ(jac.col(i).norm(), 0);
   }
 }
 
 TEST(JacobianTest, TestCreateWithVectorOfJoints) {
   Jacobian jac("robot", std::vector<std::string>{"j1", "j2"}, "test", "test_ref");
-  EXPECT_TRUE(jac.get_joint_names().at(0) == "j1");
-  EXPECT_TRUE(jac.get_joint_names().at(1) == "j2");
-  EXPECT_TRUE(jac.get_reference_frame() == "test_ref");
+  EXPECT_EQ(jac.get_joint_names().at(0), "j1");
+  EXPECT_EQ(jac.get_joint_names().at(1), "j2");
+  EXPECT_EQ(jac.get_reference_frame(), "test_ref");
 }
 
 TEST(JacobianTest, TestSetData) {
@@ -30,7 +30,7 @@ TEST(JacobianTest, TestSetData) {
   jac.set_data(Eigen::MatrixXd::Random(6, 3));
   EXPECT_FALSE(jac.is_empty());
   for (std::size_t i = 0; i < jac.cols(); ++i) {
-    EXPECT_TRUE(jac.col(i).norm() > 0);
+    EXPECT_GT(jac.col(i).norm(), 0);
   }
   bool except_thrown = false;
   try {
@@ -45,7 +45,7 @@ TEST(JacobianTest, TestRandomCreate) {
   Jacobian jac = Jacobian::Random("robot", 7, "test");
   EXPECT_FALSE(jac.is_empty());
   for (std::size_t i = 0; i < jac.cols(); ++i) {
-    EXPECT_TRUE(jac.col(i).norm() > 0);
+    EXPECT_GT(jac.col(i).norm(), 0);
   }
 }
 
@@ -53,8 +53,8 @@ TEST(JacobianTest, TestTranspose) {
   Jacobian jac = Jacobian::Random("robot", 7, "test");
   Jacobian jact = jac.transpose();
 
-  EXPECT_TRUE(jact.rows() == 7);
-  EXPECT_TRUE(jact.cols() == 6);
+  EXPECT_EQ(jact.rows(), 7);
+  EXPECT_EQ(jact.cols(), 6);
 
   for (std::size_t i = 0; i < jac.cols(); ++i) {
     EXPECT_TRUE(jac.col(i).isApprox(jact.row(i)));
@@ -93,8 +93,8 @@ TEST(JacobianTest, TestSolve) {
   Eigen::MatrixXd mat2 = Eigen::VectorXd::Random(6, 1);
   Eigen::MatrixXd res2 = jac.solve(mat2);
 
-  EXPECT_TRUE(res2.rows() == 7);
-  EXPECT_TRUE(res2.cols() == 1);
+  EXPECT_EQ(res2.rows(), 7);
+  EXPECT_EQ(res2.cols(), 1);
 }
 
 TEST(JacobianTest, TestJointToCartesian) {
@@ -102,8 +102,8 @@ TEST(JacobianTest, TestJointToCartesian) {
   JointVelocities jvel = JointVelocities::Random("robot", 7);
   CartesianTwist cvel = jac * jvel;
 
-  EXPECT_TRUE(cvel.get_name() == jac.get_frame());
-  EXPECT_TRUE(cvel.get_reference_frame() == jac.get_reference_frame());
+  EXPECT_EQ(cvel.get_name(), jac.get_frame());
+  EXPECT_EQ(cvel.get_reference_frame(), jac.get_reference_frame());
   EXPECT_TRUE(cvel.data().isApprox(jac.data() * jvel.data()));
 }
 
@@ -128,14 +128,14 @@ TEST(JacobianTest, TestCartesianToJoint) {
     except_thrown2 = true;
   }
   EXPECT_FALSE(except_thrown2);
-  EXPECT_TRUE(jvel2.data().norm() > 0);
+  EXPECT_GT(jvel2.data().norm(), 0);
 }
 
 TEST(JacobianTest, TestChangeReferenceFrame) {
   Jacobian jac_in_test_ref = Jacobian::Random("robot", 7, "test", "test_ref");
   CartesianPose wTtest_ref = CartesianPose::Random("test_ref", "world");
   Jacobian jac_in_world = wTtest_ref * jac_in_test_ref;
-  EXPECT_TRUE(jac_in_world.get_reference_frame() == wTtest_ref.get_reference_frame());
+  EXPECT_EQ(jac_in_world.get_reference_frame(), wTtest_ref.get_reference_frame());
   // use a proxy operation with a twist to check correctness
   CartesianTwist vel_in_world = CartesianTwist::Random("test", "world");
   CartesianTwist vel_in_test_ref = wTtest_ref.inverse() * vel_in_world;


### PR DESCRIPTION
I thought this would be a small PR to close issue #29 and part of #22. Turns out is is not that small but introduces some interesting features. It gave me the opportunity to refactor a bit the class that was actually quite messy and brings it closer to Eigen conventions. e.g. by renaming `get_nb_rows` and `get_nb_cols` to `rows` and `cols`.

I have added a functionality to change the reference frame by multiplying with a `CartesianPose`.