### PR TITLE
Fix bug in DS twist conversion

### DIFF
--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -65,10 +65,10 @@ It is currently implemented for the `CartesianState` and `JointState` types.
 The Linear DS is constructed with a state as an argument; this becomes the attractor.
 ```c++
 state_representation::CartesianState cartesianAttractor("A");
-dynamical_system::Linear<state_representation::CartesianState> linear(cartesianAttractor);
+dynamical_systems::Linear<state_representation::CartesianState> linear(cartesianAttractor);
 
 state_representation::JointState jointAttractor("B");
-dynamical_system::Linear<state_representation::JointState> linear(jointAttractor);
+dynamical_systems::Linear<state_representation::JointState> linear(jointAttractor);
 ```
 
 ### Configuring the Linear DS
@@ -90,7 +90,7 @@ length, or as a scalar (which sets the value along the diagonal elements of the 
 // set a gain (scalar, vector or matrix during construction)
 double gain = 10;
 state_representation::CartesianState csA("A");
-dynamical_system::Linear<state_representation::CartesianState> linear(csA, gain);
+dynamical_systems::Linear<state_representation::CartesianState> linear(csA, gain);
 
 // or set / update the gain for the created object
 std::vector<double> gains = {1, 2, 3, 4, 5, 6};
@@ -107,7 +107,7 @@ To get the velocity from a state, simply call the `evaluate()` function.
 
 ```c++
 state_representation::CartesianState csA("A"), csB("B");
-dynamical_system::Linear<state_representation::CartesianState> linear(csA);
+dynamical_systems::Linear<state_representation::CartesianState> linear(csA);
 
 // note: the return type of evaluate() is a CartesianState, but
 // it can be directly assigned to a CartesianTwist because the =operator

--- a/source/dynamical_systems/src/Circular.cpp
+++ b/source/dynamical_systems/src/Circular.cpp
@@ -46,7 +46,7 @@ CartesianState Circular::compute_dynamics(const CartesianState& state) const {
 
   //compute back the linear velocity in the desired frame
   auto frame = this->get_center() * this->get_limit_cycle().get_rotation();
-  return CartesianTwist(frame) * velocity;
+  return CartesianState(frame) * velocity;
 }
 
 std::list<std::shared_ptr<ParameterInterface>> Circular::get_parameters() const {

--- a/source/dynamical_systems/src/Ring.cpp
+++ b/source/dynamical_systems/src/Ring.cpp
@@ -40,7 +40,7 @@ CartesianState Ring::compute_dynamics(const CartesianState& state) const {
   twist.set_angular_velocity(this->calculate_local_angular_velocity(pose, twist.get_linear_velocity(), local_field_strength));
 
   // transform the twist back to the base reference frame
-  return CartesianTwist(this->get_center()) * twist;
+  return CartesianState(this->get_center()) * twist;
 }
 
 Eigen::Vector3d Ring::calculate_local_linear_velocity(const CartesianPose& pose,

--- a/source/dynamical_systems/tests/test_circular.cpp
+++ b/source/dynamical_systems/tests/test_circular.cpp
@@ -34,6 +34,21 @@ TEST_F(CircularDSTest, TestPositionOnRadius) {
   EXPECT_NEAR((current_pose.get_position() - center.get_position()).norm(), radius, linear_tol);
 }
 
+TEST_F(CircularDSTest, TestPositionOnRadiusRandomCenter) {
+  center.set_position(Eigen::Vector3d::Random());
+  center.set_orientation(Eigen::Quaterniond::UnitRandom());
+  dynamical_systems::Circular circularDS(center);
+  circularDS.set_radius(radius);
+
+  for (unsigned int i = 0; i < nb_steps; ++i) {
+    state_representation::CartesianTwist twist = circularDS.evaluate(current_pose);
+    twist.clamp(10, 10, 0.001, 0.001);
+    current_pose += dt * twist;
+  }
+
+  EXPECT_NEAR((current_pose.get_position() - center.get_position()).norm(), radius, linear_tol);
+}
+
 TEST_F(CircularDSTest, SetCenterAndBase) {
   auto BinA = state_representation::CartesianState::Identity("B", "A");
   auto CinA = state_representation::CartesianState::Identity("C", "A");

--- a/source/dynamical_systems/tests/test_ring.cpp
+++ b/source/dynamical_systems/tests/test_ring.cpp
@@ -102,6 +102,20 @@ TEST_F(RingDSTest, ConvergenceOnRadius) {
   EXPECT_NEAR((current_pose.get_position() - center.get_position()).norm(), radius, tol);
 }
 
+TEST_F(RingDSTest, ConvergenceOnRadiusRandomCenter) {
+  center.set_position(Eigen::Vector3d::Random());
+  center.set_orientation(Eigen::Quaterniond::UnitRandom());
+  dynamical_systems::Ring ring(center, radius);
+
+  for (unsigned int i = 0; i < nb_steps; ++i) {
+    state_representation::CartesianTwist twist = ring.evaluate(current_pose);
+    twist.clamp(vlim[0], vlim[1], vlim[2], vlim[3]);
+    current_pose += dt * twist;
+  }
+
+  EXPECT_NEAR((current_pose.get_position() - center.get_position()).norm(), radius, tol);
+}
+
 TEST_F(RingDSTest, ZeroNormalGain) {
   dynamical_systems::Ring ring(center);
   ring.set_normal_gain(0);


### PR DESCRIPTION
This is an interesting subtle bug that has disastrous consequences!

The return of the compute_command function in Ring and Circular had a final operation `CartesianTwist(center) * twist` intended to return the local twist back to the base frame.

But, this makes no sense! The construction of a twist from pose actually does unit differentiation, so it ends up returning a constant bias twist that increases the further the center is from Identity.

I guess I was intending to cast the pose to a twist so that the transform could happen without the return type being a Pose.
Really I intended to convert it to a State, so that the center pose transforms the local twist and the twist is kept.

The unit tests didn't catch it because the center is set to Identity. This makes checking the expected outputs at certain points easier at least, but at the cost of insufficient coverage.

I have added a test to check convergence on radius for a random center pose for Ring and Circular.