### PR TITLE
Fix Build and Test action exit codes

### DIFF
--- a/.github/actions/build-test/entrypoint.sh
+++ b/.github/actions/build-test/entrypoint.sh
@@ -2,14 +2,15 @@
 
 cd /github/workspace/source && mkdir build && cd build || exit 1
 
-echo "Configuring cmake"
+echo ">>> Configuring cmake"
 cmake -DBUILD_CONTROLLERS=ON -DBUILD_DYNAMICAL_SYSTEMS=ON -DBUILD_ROBOT_MODEL=ON -DBUILD_TESTING=ON ..
 
-echo "Building project"
-make -j all
+echo ">>> Building project..."
+make -j all || (echo ">>> Build stage failed!" && exit 2) || exit $?
+echo ">>> Build stage completed successfully!"
 
-echo "Running all test stages"
-CTEST_OUTPUT_ON_FAILURE=1 make test
+echo ">>> Running all test stages..."
+CTEST_OUTPUT_ON_FAILURE=1 make test || (echo ">>> Test stage failed!" && exit 3) || exit $?
+echo ">>> Test stages completed successfully!"
 
-echo "Test stages completed successfully!"
 exit 0

--- a/.github/actions/build-test/entrypoint.sh
+++ b/.github/actions/build-test/entrypoint.sh
@@ -2,15 +2,16 @@
 
 cd /github/workspace/source && mkdir build && cd build || exit 1
 
-echo ">>> Configuring cmake"
-cmake -DBUILD_CONTROLLERS=ON -DBUILD_DYNAMICAL_SYSTEMS=ON -DBUILD_ROBOT_MODEL=ON -DBUILD_TESTING=ON ..
+echo ">>> Configuring cmake..."
+cmake -DBUILD_CONTROLLERS=ON -DBUILD_DYNAMICAL_SYSTEMS=ON -DBUILD_ROBOT_MODEL=ON -DBUILD_TESTING=ON .. || \
+  (echo ">>> [ERROR] Configuration stage failed!" && exit 2) || exit $?
 
 echo ">>> Building project..."
-make -j all || (echo ">>> Build stage failed!" && exit 2) || exit $?
+make -j all || (echo ">>> [ERROR] Build stage failed!" && exit 3) || exit $?
 echo ">>> Build stage completed successfully!"
 
 echo ">>> Running all test stages..."
-CTEST_OUTPUT_ON_FAILURE=1 make test || (echo ">>> Test stage failed!" && exit 3) || exit $?
+CTEST_OUTPUT_ON_FAILURE=1 make test || (echo ">>> [ERROR] Test stage failed!" && exit 4) || exit $?
 echo ">>> Test stages completed successfully!"
 
 exit 0


### PR DESCRIPTION
* Pipe output of make commands with || in case of failure
to echo a relevant message and exit the script properly

* Make printout lines clearer by using ">>> " message prefix

Context: the CI was "passing" even when build or test stages
failed, because the non-zero exit of the make commands
was not handled properly.

---

This will close Issue #69 

I tested this syntax locally by slightly modifying the COPY steps of the file `.github/actions/build-test/Dockerfile`
```shell
COPY ./.github/actions/build-test/entrypoint.sh /entrypoint.sh
COPY ./source /github/workspace/source
```

Then I ran this command from the project root:
`docker build -f .github/actions/build-test/Dockerfile --tag build-test-container --no-cache . && docker run docker.io/library/build-test-container`

I tried with an intentional build failure and test failure, and it successfully caught both.