### PR TITLE
Create urdf from string

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -252,6 +252,8 @@ public:
    * @return the list of parameters
    */
   std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
+
+  static bool create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path);
 };
 
 inline const std::string& Model::get_robot_name() const {

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -97,6 +97,15 @@ public:
   Model& operator=(const Model& Model);
 
   /**
+   * @brief Creates a URDF file with desired path and name from a string (possibly the robot description
+   * string from the ROS parameter server)
+   * @param urdf_string string containing the URDF description of the robot
+   * @param desired_path desired path and name of the created URDF file as string
+   * @return bool if operation was successful
+   */
+  static bool create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path);
+
+  /**
    * @brief Getter of the robot name
    * @return the robot name
    */
@@ -252,8 +261,6 @@ public:
    * @return the list of parameters
    */
   std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
-
-  static bool create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path);
 };
 
 inline const std::string& Model::get_robot_name() const {

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -339,12 +339,10 @@ void Model::print_qp_problem() {
 
 bool Model::create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path) {
   std::ofstream file(desired_path);
-  if (!file.good() || !file.is_open()) {
-    return false;
-  } else {
+  if (file.good() && file.is_open()) {
     file << urdf_string;
     file.close();
-    return true;
   }
+  return file.good();
 }
 }// namespace robot_model

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -42,6 +42,16 @@ Model& Model::operator=(const Model& model) {
   return (*this);
 }
 
+bool Model::create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path) {
+  std::ofstream file(desired_path);
+  if (file.good() && file.is_open()) {
+    file << urdf_string;
+    file.close();
+    return true;
+  }
+  return false;
+}
+
 void Model::init_model() {
   pinocchio::urdf::buildModel(this->get_urdf_path(), this->robot_model_);
   this->robot_data_ = pinocchio::Data(this->robot_model_);
@@ -335,15 +345,5 @@ void Model::print_qp_problem() {
     std::cout << " < ";
     std::cout << this->upper_bound_constraints_(i) << std::endl;
   }
-}
-
-bool Model::create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path) {
-  std::ofstream file(desired_path);
-  if (file.good() && file.is_open()) {
-    file << urdf_string;
-    file.close();
-    return true;
-  }
-  return false;
 }
 }// namespace robot_model

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -1,4 +1,5 @@
 #include "robot_model/Model.hpp"
+#include <fstream>
 #include <pinocchio/algorithm/frames.hpp>
 #include "robot_model/exceptions/FrameNotFoundException.hpp"
 #include "robot_model/exceptions/InvalidJointStateSizeException.hpp"
@@ -333,6 +334,17 @@ void Model::print_qp_problem() {
     }
     std::cout << " < ";
     std::cout << this->upper_bound_constraints_(i) << std::endl;
+  }
+}
+
+bool Model::create_urdf_from_string(const std::string& urdf_string, const std::string& desired_path) {
+  std::ofstream file(desired_path);
+  if (!file.good() || !file.is_open()) {
+    return false;
+  } else {
+    file << urdf_string;
+    file.close();
+    return true;
   }
 }
 }// namespace robot_model

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -342,7 +342,8 @@ bool Model::create_urdf_from_string(const std::string& urdf_string, const std::s
   if (file.good() && file.is_open()) {
     file << urdf_string;
     file.close();
+    return true;
   }
-  return file.good();
+  return false;
 }
 }// namespace robot_model

--- a/source/robot_model/test/tests/test_model.cpp
+++ b/source/robot_model/test/tests/test_model.cpp
@@ -126,7 +126,7 @@ TEST_F(RobotModelTest, TestCreateURDFFromStringSuccess) {
 }
 
 TEST_F(RobotModelTest, TestCreateURDFFromStringFail) {
-  EXPECT_FALSE(Model::create_urdf_from_string("dummy string", "/dummy"));
+  EXPECT_FALSE(Model::create_urdf_from_string("dummy string", "/invalid path"));
   EXPECT_TRUE(Model::create_urdf_from_string("dummy string", create_urdf_test_path));
   EXPECT_ANY_THROW(Model("dummy", create_urdf_test_path));
 }

--- a/source/robot_model/test/tests/test_model.cpp
+++ b/source/robot_model/test/tests/test_model.cpp
@@ -126,7 +126,7 @@ TEST_F(RobotModelTest, TestCreateURDFFromStringSuccess) {
 }
 
 TEST_F(RobotModelTest, TestCreateURDFFromStringFail) {
-  EXPECT_FALSE(Model::create_urdf_from_string("dummy string", "/invalid path"));
+  EXPECT_FALSE(Model::create_urdf_from_string("dummy string", "/dev/null/invalid.urdf"));
   EXPECT_TRUE(Model::create_urdf_from_string("dummy string", create_urdf_test_path));
   EXPECT_ANY_THROW(Model("dummy", create_urdf_test_path));
 }


### PR DESCRIPTION
This is an attempt to close #54 to create a urdf file from a string that can be loaded upon initialization of a robot model. I developed this the following way:
1. I took a working ROS executable, saved the robot description from the ROS param server as string and checked the output (see screenshot):
```
std::string urdf;
nodeHandle.getParam("/robot_description", urdf);
std::cout << urdf;
```
2. Seeing that the output doesn't contain escape characters, I just put the string into a file and saved it as urdf and I got a perfectly fine urdf file. 

I assume that this might not be enough, I can see that this method is a bit error prone. There are already two checks with `file.good()` and `file.is_open()` but we might have to do more here. Maybe also throw an exception instead of returning `false`. What do you think?