### PR TITLE
CI job to build and test in Release configuration

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -1,5 +1,12 @@
 name: 'Build and Test'
 description: 'Build the project sources and run all unit tests'
+inputs:
+  configuration:
+    description: 'CMake build configuration'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.configuration }}

--- a/.github/actions/build-test/entrypoint.sh
+++ b/.github/actions/build-test/entrypoint.sh
@@ -1,9 +1,16 @@
 #!/bin/sh -l
 
+CONFIGURATION=""
+if [ -n "$1" ]; then
+  echo ">>> Configuration: $1"
+  CONFIGURATION="-DCMAKE_BUILD_TYPE=$1"
+fi
+
 cd /github/workspace/source && mkdir build && cd build || exit 1
 
 echo ">>> Configuring cmake..."
-cmake -DBUILD_CONTROLLERS=ON -DBUILD_DYNAMICAL_SYSTEMS=ON -DBUILD_ROBOT_MODEL=ON -DBUILD_TESTING=ON .. || \
+cmake "${CONFIGURATION}" -DBUILD_TESTING=ON \
+  -DBUILD_CONTROLLERS=ON -DBUILD_DYNAMICAL_SYSTEMS=ON -DBUILD_ROBOT_MODEL=ON .. || \
   (echo ">>> [ERROR] Configuration stage failed!" && exit 2) || exit $?
 
 echo ">>> Building project..."

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-test-debug:
     runs-on: ubuntu-latest
-    name: Build the source code and run all unit tests in Debug configuration
+    name: Debug configuration test
     steps:
       # First check out the repository
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
 
   build-test-release:
     runs-on: ubuntu-latest
-    name: Build the source code and run all unit tests in Release configuration
+    name: Release configuration test
     steps:
       # First check out the repository
       - name: Checkout

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,11 +9,11 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Define the build test job
+# Define the build test jobs for each configuration
 jobs:
-  build-test:
+  build-test-debug:
     runs-on: ubuntu-latest
-    name: Build the source code and run all unit tests
+    name: Build the source code and run all unit tests in Debug configuration
     steps:
       # First check out the repository
       - name: Checkout
@@ -21,3 +21,18 @@ jobs:
       # Load the repository build-test action
       - name: Build and Test
         uses: ./.github/actions/build-test
+        with:
+          configuration: Debug
+
+  build-test-release:
+    runs-on: ubuntu-latest
+    name: Build the source code and run all unit tests in Release configuration
+    steps:
+      # First check out the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Load the repository build-test action
+      - name: Build and Test
+        uses: ./.github/actions/build-test
+        with:
+          configuration: Release


### PR DESCRIPTION
* Edit build-test action.yml to support a configuration input
argument

* Edit build-test entrypoint.sh to set cmake build type flag
from configuration input, or use default configuration if
no input is supplied

* Add second job (runs in parallel) to build-test workflow
so that one uses Debug and the other uses Release configuration

See also Discussion #84