### PR TITLE
Fix rotation offset transformation order in Ring DS

### DIFF
--- a/source/dynamical_systems/src/Ring.cpp
+++ b/source/dynamical_systems/src/Ring.cpp
@@ -118,6 +118,11 @@ Eigen::Vector3d Ring::calculate_local_angular_velocity(const CartesianPose& pose
     return local_angular_velocity;
   }
 
+  // clamp linear velocity magnitude to half the position, so that the angular displacement
+  // around the local Z axis caused by the linear velocity stays within one quadrant
+  if (linear_velocity2d.norm() > (0.5 * position2d.norm())) {
+    linear_velocity2d = linear_velocity2d.normalized() * (0.5 * position2d).norm();
+  }
   double projection = position2d.normalized().dot((position2d + linear_velocity2d).normalized());
   double dthetaZ = 0;
   if (1 - abs(projection) > 1e-7) {

--- a/source/dynamical_systems/src/Ring.cpp
+++ b/source/dynamical_systems/src/Ring.cpp
@@ -32,7 +32,7 @@ CartesianState Ring::compute_dynamics(const CartesianState& state) const {
   CartesianPose pose(state);
   pose = this->get_center().inverse() * pose;
   // apply the rotation offset
-  pose.set_orientation(this->get_rotation_offset().conjugate() * pose.get_orientation());
+  pose.set_orientation(pose.get_orientation() * this->get_rotation_offset().conjugate());
 
   CartesianTwist twist(pose.get_name(), pose.get_reference_frame());
   double local_field_strength;
@@ -134,8 +134,6 @@ void Ring::set_base_frame(const state_representation::CartesianState& base_frame
   auto center = this->get_center();
   center.set_reference_frame(base_frame.get_name());
   this->set_center(center);
-  // update reference frame of rotation offset
-  this->set_rotation_offset(this->get_rotation_offset());
 }
 
 void Ring::set_center(const CartesianPose& center) {
@@ -155,7 +153,7 @@ void Ring::set_center(const CartesianPose& center) {
 }
 
 void Ring::set_rotation_offset(const Eigen::Quaterniond& rotation) {
-  auto pose = CartesianPose::Identity("rotation", this->get_base_frame().get_name());
+  auto pose = CartesianPose::Identity("rotation", this->get_center().get_name());
   pose.set_orientation(rotation);
   this->rotation_offset_->set_value(pose);
 }

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -90,6 +90,25 @@ TEST_F(RingDSTest, PointsNearRadius) {
   EXPECT_NEAR(twist.get_linear_velocity().y(), 0, tol);
 }
 
+TEST_F(RingDSTest, BehaviourNearBoundaryAtHighSpeeds) {
+  radius = 1;
+  width = 0.1;
+  speed = 10;
+  field_strength = 2;
+  dynamical_systems::Ring ring(center, radius, width, speed, field_strength);
+  state_representation::CartesianTwist twist;
+
+  current_pose.set_position(0, radius + 1.001 * width, 0);
+  twist = ring.evaluate(current_pose);
+  double angular_speed = twist.get_angular_velocity().norm();
+  current_pose.set_position(0, radius + 1.000 * width, 0);
+  twist = ring.evaluate(current_pose);
+  EXPECT_NEAR(twist.get_angular_velocity().norm(), angular_speed, 0.1);
+  current_pose.set_position(0, radius + 0.999 * width, 0);
+  twist = ring.evaluate(current_pose);
+  EXPECT_NEAR(twist.get_angular_velocity().norm(), angular_speed, 0.1);
+}
+
 TEST_F(RingDSTest, ConvergenceOnRadius) {
   dynamical_systems::Ring ring(center, radius);
 


### PR DESCRIPTION
* Get local pose in rotation offset frame, instead of inverse

The rotation offset in the Ring DS is a bit weird to understand,
but it's definitely necessary for configuring rotating frames around
the ring center.

For a given Pose in Base frame, you can get the Local Pose in Base
frame through this series of transformations:
Center in Base frame
Rotation offset in Center frame
Local Pose in Rotation offset frame

I added more test cases to cover this behaviour.

---

It's a subtle issue but I think this will fix the problems I was having with the robot; I will test this out on the robot / optitrack later today.

This also makes me want to make a 3D dynamic visualiser for the DS. Not just a plotting GUI, since that required re-implementing the DS code locally in MATLAB, but to use python bindings to be able to dynamically evaluate the control library DS and see the result of implementation changes on the behaviour directly. That's a separate project though!