### PR TITLE
Add Jacobian operations with other matrices and Jacobian

### DIFF
--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -241,8 +241,8 @@ public:
 
   /**
    * @brief Overload the * operator with an arbitrary matrix
-   * @param matrix the vector to multiply with
-   * @return the matrix multiply by the jacobian matrix
+   * @param matrix the matrix to multiply with
+   * @return the jacobian matrix multiplied by the matrix in parameter
    */
   Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix) const;
 

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -410,25 +410,6 @@ inline void Jacobian::set_data(const Eigen::MatrixXd& data) {
   this->data_ = data;
 }
 
-inline bool Jacobian::is_compatible(const State& state) const {
-  bool compatible = false;
-  if (state.get_type() == StateType::JOINTSTATE) {
-    // compatibility is assured through the vector of joint names
-    compatible = (this->get_name() == state.get_name())
-        && (this->cols_ == dynamic_cast<const JointState&>(state).get_size());
-    if (compatible) {
-      for (unsigned int i = 0; i < this->cols_; ++i) {
-        compatible = (compatible && this->joint_names_[i] == dynamic_cast<const JointState&>(state).get_names()[i]);
-      }
-    }
-  } else if (state.get_type() == StateType::CARTESIANSTATE) {
-    // compatibility is assured through the reference frame and the name of the frame
-    compatible = (this->reference_frame_ == dynamic_cast<const CartesianState&>(state).get_reference_frame())
-        && (this->frame_ == dynamic_cast<const CartesianState&>(state).get_name());
-  }
-  return compatible;
-}
-
 inline double& Jacobian::operator()(unsigned int row, unsigned int col) {
   if (row > this->rows_) {
     throw std::out_of_range("Given row is out of range: number of rows = " + std::to_string(this->rows_));

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -240,11 +240,18 @@ public:
   Jacobian pseudoinverse() const;
 
   /**
-   * @brief Overload the * operator with an non specific matrix
+   * @brief Overload the * operator with an arbitrary matrix
    * @param matrix the vector to multiply with
    * @return the matrix multiply by the jacobian matrix
    */
   Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix) const;
+
+  /**
+   * @brief Overload the * operator with another Jacobian
+   * @param jacobian the Jacobian to multiply with
+   * @return the current Jacobian multiplied by the one in parameter
+   */
+  Eigen::MatrixXd operator*(const Jacobian& jacobian) const;
 
   /**
    * @brief Overload the * operator with a JointVelocities

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -328,6 +328,14 @@ public:
    * @return the Jacobian expressed in the new reference frame
    */
   friend Jacobian operator*(const CartesianPose& pose, const Jacobian& jacobian);
+
+  /**
+   * @brief Overload the * operator with an arbitrary matrix on the left side
+   * @param matrix the matrix to multiply with
+   * @param jacobian the jacobian matrix
+   * @return the matrix multiplied by the jacobian matrix
+   */
+  friend Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix, const Jacobian& jacobian);
 };
 
 inline void swap(Jacobian& jacobian1, Jacobian& jacobian2) {

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -76,14 +76,14 @@ public:
   static CartesianPose Random(const std::string& name, const std::string& reference = "world");
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param pose the pose with value to assign
    * @return reference to the current pose with new values
    */
   CartesianPose& operator=(const CartesianPose& pose);
 
   /**
-   * @brief Copy assignement operator from a state
+   * @brief Copy assignment operator from a state
    * @param state the state with value to assign
    * @return reference to the current pose with new values
    */
@@ -147,28 +147,28 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param pose CartesianPose to substract
+   * @param pose CartesianPose to subtract
    * @return the current CartesianPose minus the CartesianPose given in argument
    */
   CartesianPose& operator-=(const CartesianPose& pose);
 
   /**
    * @brief Overload the - operator with a pose
-   * @param pose CartesianPose to substract
+   * @param pose CartesianPose to subtract
    * @return the current CartesianPose minus the CartesianPose given in argument
    */
   CartesianPose operator-(const CartesianPose& pose) const;
 
   /**
    * @brief Overload the - operator with a state
-   * @param state CartesianState to substract
+   * @param state CartesianState to subtract
    * @return the current CartesianPose minus the CartesianState given in argument
    */
   CartesianState operator-(const CartesianState& state) const;
 
   /**
    * @brief Overload the / operator with a time period
-   * @param dt the time period to divise by
+   * @param dt the time period to divide by
    * @return the corresponding CartesianTwist
    */
   CartesianTwist operator/(const std::chrono::nanoseconds& dt) const;
@@ -201,7 +201,7 @@ public:
 
   /**
    * @brief Overload the ostream operator for printing
-   * @param os the ostream to happend the string representing the CartesianPose to
+   * @param os the ostream to append the string representing the CartesianPose to
    * @param CartesianPose the CartesianPose to print
    * @return the appended ostream
    */

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -80,6 +80,43 @@ Jacobian Jacobian::Random(const std::string& robot_name,
   return random;
 }
 
+bool Jacobian::is_compatible(const State& state) const {
+  bool compatible = false;
+  switch (state.get_type()) {
+    case StateType::JACOBIANMATRIX:
+      // compatibility is assured through the vector of joint names
+      compatible = (this->get_name() == state.get_name())
+          && (this->cols_ == dynamic_cast<const Jacobian&>(state).get_joint_names().size());
+      if (compatible) {
+        for (unsigned int i = 0; i < this->cols_; ++i) {
+          compatible = (compatible && this->joint_names_[i] == dynamic_cast<const Jacobian&>(state).get_joint_names()[i]);
+        }
+        // compatibility is assured through the reference frame and the name of the frame
+        compatible = (compatible && ((this->reference_frame_ == dynamic_cast<const Jacobian&>(state).get_reference_frame())
+            && (this->frame_ == dynamic_cast<const Jacobian&>(state).get_frame())));
+      }
+      break;
+    case StateType::JOINTSTATE:
+      // compatibility is assured through the vector of joint names
+      compatible = (this->get_name() == state.get_name())
+          && (this->cols_ == dynamic_cast<const JointState&>(state).get_size());
+      if (compatible) {
+        for (unsigned int i = 0; i < this->cols_; ++i) {
+          compatible = (compatible && this->joint_names_[i] == dynamic_cast<const JointState&>(state).get_names()[i]);
+        }
+      }
+      break;
+    case StateType::CARTESIANSTATE:
+      // compatibility is assured through the reference frame and the name of the frame
+      compatible = (this->reference_frame_ == dynamic_cast<const CartesianState&>(state).get_reference_frame())
+          && (this->frame_ == dynamic_cast<const CartesianState&>(state).get_name());
+      break;
+    default:
+      break;
+  }
+  return compatible;
+}
+
 void Jacobian::set_reference_frame(const CartesianPose& reference_frame) {
   *this = reference_frame * (*this);
 }

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -166,8 +166,7 @@ Eigen::MatrixXd Jacobian::operator*(const Jacobian& jacobian) const {
     throw IncompatibleStatesException("The two Jacobian matrices are not compatible");
   }
   // multiply with the data of the second jacobian
-  Eigen::MatrixXd data = (*this) * jacobian.data();
-  return data;
+  return (*this) * jacobian.data();
 }
 
 CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -161,6 +161,15 @@ Eigen::MatrixXd Jacobian::operator*(const Eigen::MatrixXd& matrix) const {
   return this->data() * matrix;
 }
 
+Eigen::MatrixXd Jacobian::operator*(const Jacobian& jacobian) const {
+  if (!this->is_compatible(jacobian)) {
+    throw IncompatibleStatesException("The two Jacobian matrices are not compatible");
+  }
+  // multiply with the data of the second jacobian
+  Eigen::MatrixXd data = (*this) * jacobian.data();
+  return data;
+}
+
 CartesianTwist Jacobian::operator*(const JointVelocities& dq) const {
   if (this->is_empty()) {
     throw EmptyStateException(this->get_name() + " state is empty");

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -299,4 +299,8 @@ Jacobian operator*(const CartesianPose& pose, const Jacobian& jacobian) {
   result.reference_frame_ = pose.get_reference_frame();
   return result;
 }
+
+Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix, const Jacobian& jacobian) {
+  return matrix * jacobian.data();
+}
 }// namespace state_representation

--- a/source/state_representation/test/tests/test_jacobian.cpp
+++ b/source/state_representation/test/tests/test_jacobian.cpp
@@ -86,9 +86,6 @@ TEST(JacobianTest, TestMutltiplyJacobian) {
   EXPECT_TRUE(res.isApprox(jac.data() * jac2.data().transpose()));
 
   // check with incorrect dimensions
-  std::cout << "here!!!" << std::endl;
-  std::cout << jac.is_compatible(jac2) << std::endl;
-
   bool except_thrown = false;
   try {
     Eigen::MatrixXd res2 = jac * jac2;

--- a/source/state_representation/test/tests/test_jacobian.cpp
+++ b/source/state_representation/test/tests/test_jacobian.cpp
@@ -79,6 +79,45 @@ TEST(JacobianTest, TestMutltiplyWithEigen) {
   EXPECT_TRUE(except_thrown);
 }
 
+TEST(JacobianTest, TestMutltiplyJacobian) {
+  Jacobian jac = Jacobian::Random("robot", 7, "test");
+  Jacobian jac2 = Jacobian::Random("robot", 7, "test");
+  Eigen::MatrixXd res = jac * jac2.transpose();
+  EXPECT_TRUE(res.isApprox(jac.data() * jac2.data().transpose()));
+
+  // check with incorrect dimensions
+  std::cout << "here!!!" << std::endl;
+  std::cout << jac.is_compatible(jac2) << std::endl;
+
+  bool except_thrown = false;
+  try {
+    Eigen::MatrixXd res2 = jac * jac2;
+  } catch (const IncompatibleSizeException& e) {
+    except_thrown = true;
+  }
+  EXPECT_TRUE(except_thrown);
+
+  // check with incorrect number of joints
+  Jacobian jac3 = Jacobian::Random("robot", 6, "test");
+  except_thrown = false;
+  try {
+    Eigen::MatrixXd res2 = jac * jac3.transpose();
+  } catch (const IncompatibleStatesException& e) {
+    except_thrown = true;
+  }
+  EXPECT_TRUE(except_thrown);
+
+  // check with incorrect reference frames
+  Jacobian jac4 = Jacobian::Random("robot", 7, "test", "frameA");
+  except_thrown = false;
+  try {
+    Eigen::MatrixXd res2 = jac * jac4.transpose();
+  } catch (const IncompatibleStatesException& e) {
+    except_thrown = true;
+  }
+  EXPECT_TRUE(except_thrown);
+}
+
 TEST(JacobianTest, TestSolve) {
   Jacobian jac = Jacobian::Random("robot", 7, "test");
   Eigen::MatrixXd mat1 = Eigen::VectorXd::Random(7, 1);


### PR DESCRIPTION
Quite often it is needed that the `Jacobian` can be multiplied with other matrices or even the `Jacobian` but transposed (see for example #46). This adds operators that simplify this process.

Initially I was thinking that the results of those operations would actually be a `Jacobian` but I realized it can lead to inconsistencies. For example,

```cpp
Jacobian jac = Jacobian::Random("robot", 7, ...)

Eigen::MatrixXd gain = Eigen::MatrixXd::Random(6,6)
gain * jac // no problem here this should actually be a Jacobian

Eigen::MatrixXd gain = Eigen::MatrixXd::Random(3,6)
gain * jac // the resulting matrix has inconsistent dimensions with a Jacobian

jac * jac.transpose() // the resulting matrix has inconsistent dimensions with a Jacobian

jac.transpose () * jac // the resulting matrix has inconsistent dimensions with a Jacobian
```

Therefore, all the operations returns `Eigen::MatrixXd`. One could argue then about the need to actually have those operations as essentially it just avoid the usage of the `data()` function. If you think they are not needed then we should remove the one there is currently with a matrix on the right side for consistency.