### PR TITLE
Fix indentations issues and minor code duplication

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -73,19 +73,24 @@ private:
                                                        unsigned int frame_id);
   
   /**
-   * @brief It checks if the vector's elements are inside at their limits
+   * @brief Checks if the vector's elements are inside the limits in parameter
    * @param vector the vector to check
+   * @param lower_limits the lower bounds of the limits
+   * @param upper_limits the upper bounds of the limits
    * @return true if all the elements are inside at their limits, false otherwise.
    */
   bool in_range(const Eigen::VectorXd& vector, const Eigen::VectorXd& lower_limits, const Eigen::VectorXd& upper_limits);
 
   /**
-   * @brief It clamps the vector's elements according to their limits
+   * @brief Clamps the vector's elements according to the limits in parameter
    * @param vector the vector to clamp
+   * @param lower_limits the lower bounds of the limits
+   * @param upper_limits the upper bounds of the limits
    * @return the clamped vector
    */
-  Eigen::VectorXd clamp_in_range(const Eigen::VectorXd& vector, const Eigen::VectorXd& lower_limits,
-                                                                const Eigen::VectorXd& upper_limits);
+  Eigen::VectorXd clamp_in_range(const Eigen::VectorXd& vector,
+                                 const Eigen::VectorXd& lower_limits,
+                                 const Eigen::VectorXd& upper_limits);
 
 public:
   /**
@@ -212,8 +217,7 @@ public:
    * @param joint_positions containing the joint positions of the robot
    * @return the gravity torque as a JointTorques
    */
-  state_representation::JointTorques compute_gravity_torques(
-      const state_representation::JointPositions& joint_positions);
+  state_representation::JointTorques compute_gravity_torques(const state_representation::JointPositions& joint_positions);
 
   /**
    * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
@@ -238,8 +242,7 @@ public:
    * @param cartesian_state containing the pose of the end-effector
    * @return the joint state of the robot
    */
-  state_representation::JointPositions inverse_geometry(
-      const state_representation::CartesianState& cartesian_state) const;
+  state_representation::JointPositions inverse_geometry(const state_representation::CartesianState& cartesian_state) const;
 
   /**
    * @brief Compute the forward kinematic, i.e. the twist of the end-effector from the joint velocities
@@ -300,18 +303,17 @@ public:
 
   /**
    * @brief It checks if the joint state is inside at its limits
-   * @param joint_states the joint state to check
+   * @param joint_state the joint state to check
    * @return true if the state is inside its limits, false otherwise.
    */
-  bool in_range(const state_representation::JointState& joint_states);
+  bool in_range(const state_representation::JointState& joint_state);
 
   /**
    * @brief It clamps the joint positions, velocities and torques according to their limits
-   * @param joint_states the joint state to be clamped
+   * @param joint_state the joint state to be clamped
    * @return the clamped joint states
    */
-  state_representation::JointState clamp_in_range(const state_representation::JointState& joint_states);
-
+  state_representation::JointState clamp_in_range(const state_representation::JointState& joint_state);
 };
 
 inline const std::string& Model::get_robot_name() const {

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -73,7 +73,7 @@ private:
                                                        unsigned int frame_id);
   
   /**
-   * @brief Checks if the vector's elements are inside the limits in parameter
+   * @brief Check if the vector's elements are inside the parameter limits
    * @param vector the vector to check
    * @param lower_limits the lower bounds of the limits
    * @param upper_limits the upper bounds of the limits
@@ -82,7 +82,7 @@ private:
   bool in_range(const Eigen::VectorXd& vector, const Eigen::VectorXd& lower_limits, const Eigen::VectorXd& upper_limits);
 
   /**
-   * @brief Clamps the vector's elements according to the limits in parameter
+   * @brief Clamp the vector's elements according to the parameter limits
    * @param vector the vector to clamp
    * @param lower_limits the lower bounds of the limits
    * @param upper_limits the upper bounds of the limits
@@ -281,35 +281,37 @@ public:
   std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
 
   /**
-   * @brief It checks if the joint positions are inside at their limits
+   * @brief Check if the joint positions are inside the limits provided by the model
    * @param joint_positions the joint positions to check
    * @return true if the positions are inside their limits, false otherwise.
    */
   bool in_range(const state_representation::JointPositions& joint_positions);
 
   /**
-   * @brief It checks if the joint velocities are inside at their limits
+   * @brief Check if the joint velocities are inside the limits provided by the model
    * @param joint_velocities the joint velocities to check
    * @return true if the velocities are inside their limits, false otherwise.
    */
   bool in_range(const state_representation::JointVelocities& joint_velocities);
 
   /**
-   * @brief It checks if the joint torques are inside at their limits
+   * @brief Check if the joint torques are inside the limits provided by the model
    * @param joint_torques the joint torques to check
    * @return true if the torques are inside their limits, false otherwise.
    */
   bool in_range(const state_representation::JointTorques& joint_torques);
 
   /**
-   * @brief It checks if the joint state is inside at its limits
+   * @brief Check if the joint state variables (positions, velocities & torques) are inside the limits provided by
+   * the model
    * @param joint_state the joint state to check
-   * @return true if the state is inside its limits, false otherwise.
+   * @return true if the state variables are inside the limits, false otherwise.
    */
   bool in_range(const state_representation::JointState& joint_state);
 
   /**
-   * @brief It clamps the joint positions, velocities and torques according to their limits
+   * @brief Clamp the joint state variables (positions, velocities & torques) according to the limits provided by
+   * the model
    * @param joint_state the joint state to be clamped
    * @return the clamped joint states
    */

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -347,19 +347,29 @@ void Model::print_qp_problem() {
   }
 }
 
+bool Model::in_range(const Eigen::VectorXd& vector,
+                     const Eigen::VectorXd& lower_limits,
+                     const Eigen::VectorXd& upper_limits) {
+
+  return ((vector.array() >= lower_limits.array()).all() && (vector.array() <= upper_limits.array()).all());
+}
+
 bool Model::in_range(const state_representation::JointPositions& joint_positions) {
-  return this->in_range(joint_positions.get_positions(), this->robot_model_.lowerPositionLimit,
-                                                         this->robot_model_.upperPositionLimit);
+  return this->in_range(joint_positions.get_positions(),
+                        this->robot_model_.lowerPositionLimit,
+                        this->robot_model_.upperPositionLimit);
 }
 
 bool Model::in_range(const state_representation::JointVelocities& joint_velocities) {
-  return this->in_range(joint_velocities.get_velocities(), -this->robot_model_.velocityLimit,
-                                                            this->robot_model_.velocityLimit);
+  return this->in_range(joint_velocities.get_velocities(),
+                        -this->robot_model_.velocityLimit,
+                        this->robot_model_.velocityLimit);
 }
 
 bool Model::in_range(const state_representation::JointTorques& joint_torques) {
-  return this->in_range(joint_torques.get_torques(), -this->robot_model_.effortLimit,
-                                                      this->robot_model_.effortLimit);
+  return this->in_range(joint_torques.get_torques(),
+                        -this->robot_model_.effortLimit,
+                        this->robot_model_.effortLimit);
 }
 
 bool Model::in_range(const state_representation::JointState& joint_state) {
@@ -371,10 +381,11 @@ bool Model::in_range(const state_representation::JointState& joint_state) {
                                                        this->robot_model_.effortLimit));
 }
 
-bool Model::in_range(const Eigen::VectorXd& vector, const Eigen::VectorXd& lower_limits,
-                                                    const Eigen::VectorXd& upper_limits) {
+Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector,
+                                      const Eigen::VectorXd& lower_limits,
+                                      const Eigen::VectorXd& upper_limits) {
 
-  return ((vector.array() >= lower_limits.array()).all() && (vector.array() <= upper_limits.array()).all());
+  return lower_limits.cwiseMin(upper_limits.cwiseMax(vector));
 }
 
 state_representation::JointState Model::clamp_in_range(const state_representation::JointState& joint_state) {
@@ -382,21 +393,17 @@ state_representation::JointState Model::clamp_in_range(const state_representatio
   state_representation::JointState joint_state_clamped(joint_state);
 
   joint_state_clamped.set_positions(this->clamp_in_range(joint_state.get_positions(),
-                                    this->robot_model_.lowerPositionLimit, this->robot_model_.upperPositionLimit));
+                                                         this->robot_model_.lowerPositionLimit,
+                                                         this->robot_model_.upperPositionLimit));
 
   joint_state_clamped.set_velocities(this->clamp_in_range(joint_state.get_velocities(),
-                                    -this->robot_model_.velocityLimit, this->robot_model_.velocityLimit));
+                                                          -this->robot_model_.velocityLimit,
+                                                          this->robot_model_.velocityLimit));
 
   joint_state_clamped.set_torques(this->clamp_in_range(joint_state.get_torques(),
-                                 -this->robot_model_.effortLimit, this->robot_model_.effortLimit));  
+                                                       -this->robot_model_.effortLimit,
+                                                       this->robot_model_.effortLimit));
 
   return joint_state_clamped;
 }
-
-Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector, const Eigen::VectorXd& lower_limits,
-                                                                     const Eigen::VectorXd& upper_limits) {
-  
-  return lower_limits.cwiseMin(upper_limits.cwiseMax(vector));
-}
-
 }// namespace robot_model

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -372,10 +372,9 @@ bool Model::in_range(const state_representation::JointTorques& joint_torques) {
 }
 
 bool Model::in_range(const state_representation::JointState& joint_state) {
-  using namespace state_representation;
-  return (this->in_range(static_cast<JointPositions>(joint_state))
-      && this->in_range(static_cast<JointVelocities>(joint_state))
-      && this->in_range(static_cast<JointTorques>(joint_state)));
+  return (this->in_range(static_cast<state_representation::JointPositions>(joint_state))
+      && this->in_range(static_cast<state_representation::JointVelocities>(joint_state))
+      && this->in_range(static_cast<state_representation::JointTorques>(joint_state)));
 }
 
 Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector,

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -380,7 +380,7 @@ bool Model::in_range(const state_representation::JointState& joint_state) {
 Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector,
                                       const Eigen::VectorXd& lower_limits,
                                       const Eigen::VectorXd& upper_limits) {
-  return lower_limits.cwiseMin(upper_limits.cwiseMax(vector));
+  return lower_limits.cwiseMax(upper_limits.cwiseMin(vector));
 }
 
 state_representation::JointState Model::clamp_in_range(const state_representation::JointState& joint_state) {

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -350,7 +350,6 @@ void Model::print_qp_problem() {
 bool Model::in_range(const Eigen::VectorXd& vector,
                      const Eigen::VectorXd& lower_limits,
                      const Eigen::VectorXd& upper_limits) {
-
   return ((vector.array() >= lower_limits.array()).all() && (vector.array() <= upper_limits.array()).all());
 }
 
@@ -382,26 +381,20 @@ bool Model::in_range(const state_representation::JointState& joint_state) {
 Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector,
                                       const Eigen::VectorXd& lower_limits,
                                       const Eigen::VectorXd& upper_limits) {
-
   return lower_limits.cwiseMin(upper_limits.cwiseMax(vector));
 }
 
 state_representation::JointState Model::clamp_in_range(const state_representation::JointState& joint_state) {
-
   state_representation::JointState joint_state_clamped(joint_state);
-
   joint_state_clamped.set_positions(this->clamp_in_range(joint_state.get_positions(),
                                                          this->robot_model_.lowerPositionLimit,
                                                          this->robot_model_.upperPositionLimit));
-
   joint_state_clamped.set_velocities(this->clamp_in_range(joint_state.get_velocities(),
                                                           -this->robot_model_.velocityLimit,
                                                           this->robot_model_.velocityLimit));
-
   joint_state_clamped.set_torques(this->clamp_in_range(joint_state.get_torques(),
                                                        -this->robot_model_.effortLimit,
                                                        this->robot_model_.effortLimit));
-
   return joint_state_clamped;
 }
 }// namespace robot_model

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -373,12 +373,10 @@ bool Model::in_range(const state_representation::JointTorques& joint_torques) {
 }
 
 bool Model::in_range(const state_representation::JointState& joint_state) {
-  return (this->in_range(joint_state.get_positions(), this->robot_model_.lowerPositionLimit,
-                                                       this->robot_model_.upperPositionLimit)
-       && this->in_range(joint_state.get_velocities(), -this->robot_model_.velocityLimit,
-                                                         this->robot_model_.velocityLimit)
-       && this->in_range(joint_state.get_torques(), -this->robot_model_.effortLimit,
-                                                       this->robot_model_.effortLimit));
+  using namespace state_representation;
+  return (this->in_range(static_cast<JointPositions>(joint_state))
+      && this->in_range(static_cast<JointVelocities>(joint_state))
+      && this->in_range(static_cast<JointTorques>(joint_state)));
 }
 
 Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector,


### PR DESCRIPTION
@patr3 I just took the liberty to correct the minor issues that were still left open in PR #91. Mainly this concerns indentations, some docstring with parameters, and I am sneaking in the solution I proposed to avoid code duplication based on `static_cast`. The rest was all good thanks for the improvement.