### PR TITLE
Mark functions as static or const

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -71,7 +71,7 @@ private:
    */
   state_representation::CartesianPose forward_geometry(const state_representation::JointState& joint_state,
                                                        unsigned int frame_id);
-  
+
   /**
    * @brief Check if the vector's elements are inside the parameter limits
    * @param vector the vector to check
@@ -79,7 +79,9 @@ private:
    * @param upper_limits the upper bounds of the limits
    * @return true if all the elements are inside at their limits, false otherwise.
    */
-  bool in_range(const Eigen::VectorXd& vector, const Eigen::VectorXd& lower_limits, const Eigen::VectorXd& upper_limits);
+  static bool in_range(const Eigen::VectorXd& vector,
+                       const Eigen::VectorXd& lower_limits,
+                       const Eigen::VectorXd& upper_limits);
 
   /**
    * @brief Clamp the vector's elements according to the parameter limits
@@ -88,9 +90,9 @@ private:
    * @param upper_limits the upper bounds of the limits
    * @return the clamped vector
    */
-  Eigen::VectorXd clamp_in_range(const Eigen::VectorXd& vector,
-                                 const Eigen::VectorXd& lower_limits,
-                                 const Eigen::VectorXd& upper_limits);
+  static Eigen::VectorXd clamp_in_range(const Eigen::VectorXd& vector,
+                                        const Eigen::VectorXd& lower_limits,
+                                        const Eigen::VectorXd& upper_limits);
 
 public:
   /**
@@ -285,21 +287,21 @@ public:
    * @param joint_positions the joint positions to check
    * @return true if the positions are inside their limits, false otherwise.
    */
-  bool in_range(const state_representation::JointPositions& joint_positions);
+  bool in_range(const state_representation::JointPositions& joint_positions) const;
 
   /**
    * @brief Check if the joint velocities are inside the limits provided by the model
    * @param joint_velocities the joint velocities to check
    * @return true if the velocities are inside their limits, false otherwise.
    */
-  bool in_range(const state_representation::JointVelocities& joint_velocities);
+  bool in_range(const state_representation::JointVelocities& joint_velocities) const;
 
   /**
    * @brief Check if the joint torques are inside the limits provided by the model
    * @param joint_torques the joint torques to check
    * @return true if the torques are inside their limits, false otherwise.
    */
-  bool in_range(const state_representation::JointTorques& joint_torques);
+  bool in_range(const state_representation::JointTorques& joint_torques) const;
 
   /**
    * @brief Check if the joint state variables (positions, velocities & torques) are inside the limits provided by
@@ -307,7 +309,7 @@ public:
    * @param joint_state the joint state to check
    * @return true if the state variables are inside the limits, false otherwise.
    */
-  bool in_range(const state_representation::JointState& joint_state);
+  bool in_range(const state_representation::JointState& joint_state) const;
 
   /**
    * @brief Clamp the joint state variables (positions, velocities & torques) according to the limits provided by
@@ -315,7 +317,7 @@ public:
    * @param joint_state the joint state to be clamped
    * @return the clamped joint states
    */
-  state_representation::JointState clamp_in_range(const state_representation::JointState& joint_state);
+  state_representation::JointState clamp_in_range(const state_representation::JointState& joint_state) const;
 };
 
 inline const std::string& Model::get_robot_name() const {

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -353,25 +353,23 @@ bool Model::in_range(const Eigen::VectorXd& vector,
   return ((vector.array() >= lower_limits.array()).all() && (vector.array() <= upper_limits.array()).all());
 }
 
-bool Model::in_range(const state_representation::JointPositions& joint_positions) {
+bool Model::in_range(const state_representation::JointPositions& joint_positions) const {
   return this->in_range(joint_positions.get_positions(),
                         this->robot_model_.lowerPositionLimit,
                         this->robot_model_.upperPositionLimit);
 }
 
-bool Model::in_range(const state_representation::JointVelocities& joint_velocities) {
+bool Model::in_range(const state_representation::JointVelocities& joint_velocities) const {
   return this->in_range(joint_velocities.get_velocities(),
                         -this->robot_model_.velocityLimit,
                         this->robot_model_.velocityLimit);
 }
 
-bool Model::in_range(const state_representation::JointTorques& joint_torques) {
-  return this->in_range(joint_torques.get_torques(),
-                        -this->robot_model_.effortLimit,
-                        this->robot_model_.effortLimit);
+bool Model::in_range(const state_representation::JointTorques& joint_torques) const {
+  return this->in_range(joint_torques.get_torques(), -this->robot_model_.effortLimit, this->robot_model_.effortLimit);
 }
 
-bool Model::in_range(const state_representation::JointState& joint_state) {
+bool Model::in_range(const state_representation::JointState& joint_state) const {
   return (this->in_range(static_cast<state_representation::JointPositions>(joint_state))
       && this->in_range(static_cast<state_representation::JointVelocities>(joint_state))
       && this->in_range(static_cast<state_representation::JointTorques>(joint_state)));
@@ -383,7 +381,7 @@ Eigen::VectorXd Model::clamp_in_range(const Eigen::VectorXd& vector,
   return lower_limits.cwiseMax(upper_limits.cwiseMin(vector));
 }
 
-state_representation::JointState Model::clamp_in_range(const state_representation::JointState& joint_state) {
+state_representation::JointState Model::clamp_in_range(const state_representation::JointState& joint_state) const {
   state_representation::JointState joint_state_clamped(joint_state);
   joint_state_clamped.set_positions(this->clamp_in_range(joint_state.get_positions(),
                                                          this->robot_model_.lowerPositionLimit,


### PR DESCRIPTION
I marked new functions as `static` or `const` wherever possible.