### PR TITLE
Correct copy constructor from derived Cartesian classes

### DIFF
--- a/source/state_representation/include/state_representation/space/SpatialState.hpp
+++ b/source/state_representation/include/state_representation/space/SpatialState.hpp
@@ -5,7 +5,7 @@
 namespace state_representation {
 class SpatialState : public State {
 private:
-  std::string reference_frame; ///< name of the reference frame
+  std::string reference_frame_; ///< name of the reference frame
 
 public:
   /**
@@ -31,6 +31,13 @@ public:
   SpatialState(const SpatialState& state);
 
   /**
+   * @brief Swap the values of the two SpatialState
+   * @param state1 State to be swapped with 2
+   * @param state2 State to be swapped with 1
+   */
+  friend void swap(SpatialState& state1, SpatialState& state2);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
@@ -40,12 +47,12 @@ public:
   /**
     * @brief Getter of the reference frame as const reference
      */
-  const std::string get_reference_frame() const;
+  const std::string& get_reference_frame() const;
 
   /**
-    * @brief Setter of the reference frame
-     */
-  virtual void set_reference_frame(const std::string& reference);
+   * @brief Setter of the reference frame
+   */
+  virtual void set_reference_frame(const std::string& reference_frame);
 
   /**
     * @brief Check if the state is compatible for operations with the state given as argument
@@ -54,23 +61,28 @@ public:
   virtual bool is_compatible(const State& state) const;
 };
 
+inline void swap(SpatialState& state1, SpatialState& state2) {
+  swap(static_cast<State&>(state1), static_cast<State&>(state2));
+  std::swap(state1.reference_frame_, state2.reference_frame_);
+}
+
 inline SpatialState& SpatialState::operator=(const SpatialState& state) {
-  State::operator=(state);
-  this->set_reference_frame(state.get_reference_frame());
-  return (*this);
+  SpatialState tmp(state);
+  swap(*this, tmp);
+  return *this;
 }
 
-inline const std::string SpatialState::get_reference_frame() const {
-  return this->reference_frame;
+inline const std::string& SpatialState::get_reference_frame() const {
+  return this->reference_frame_;
 }
 
-inline void SpatialState::set_reference_frame(const std::string& reference) {
-  this->reference_frame = reference;
+inline void SpatialState::set_reference_frame(const std::string& reference_frame) {
+  this->reference_frame_ = reference_frame;
 }
 
 inline bool SpatialState::is_compatible(const State& state) const {
   bool compatible = (this->get_name() == state.get_name())
-      && (this->reference_frame == static_cast<const SpatialState&>(state).reference_frame);
+      && (this->reference_frame_ == dynamic_cast<const SpatialState&>(state).reference_frame_);
   return compatible;
 }
 }

--- a/source/state_representation/include/state_representation/space/SpatialState.hpp
+++ b/source/state_representation/include/state_representation/space/SpatialState.hpp
@@ -32,8 +32,8 @@ public:
 
   /**
    * @brief Swap the values of the two SpatialState
-   * @param state1 State to be swapped with 2
-   * @param state2 State to be swapped with 1
+   * @param state1 SpatialState to be swapped with 2
+   * @param state2 SpatialState to be swapped with 1
    */
   friend void swap(SpatialState& state1, SpatialState& state2);
 

--- a/source/state_representation/include/state_representation/space/SpatialState.hpp
+++ b/source/state_representation/include/state_representation/space/SpatialState.hpp
@@ -9,26 +9,26 @@ private:
 
 public:
   /**
-    * @brief Empty constructor only specifying the type
-     */
+   * @brief Empty constructor only specifying the type
+   */
   explicit SpatialState(const StateType& type);
 
   /**
-    * @brief Constructor with name and reference frame specification
-    * @param type the type of SpatialState (Cartesian or DualQuaternion)
-    * @param name the name of the State
-    * @param reference_frame the reference frame in which the state is expressed, by default world
-    * @param empty specify if the state is initialized as empty, default true
-     */
+   * @brief Constructor with name and reference frame specification
+   * @param type the type of SpatialState (Cartesian or DualQuaternion)
+   * @param name the name of the State
+   * @param reference_frame the reference frame in which the state is expressed, by default world
+   * @param empty specify if the state is initialized as empty, default true
+   */
   explicit SpatialState(const StateType& type,
                         const std::string& name,
                         const std::string& reference_frame = "world",
                         const bool& empty = true);
 
   /**
-    * @brief Copy constructor from another SpatialState
-     */
-  SpatialState(const SpatialState& state);
+   * @brief Copy constructor from another SpatialState
+   */
+  SpatialState(const SpatialState& state) = default;
 
   /**
    * @brief Swap the values of the two SpatialState
@@ -45,8 +45,8 @@ public:
   SpatialState& operator=(const SpatialState& state);
 
   /**
-    * @brief Getter of the reference frame as const reference
-     */
+   * @brief Getter of the reference frame as const reference
+   */
   const std::string& get_reference_frame() const;
 
   /**
@@ -55,9 +55,9 @@ public:
   virtual void set_reference_frame(const std::string& reference_frame);
 
   /**
-    * @brief Check if the state is compatible for operations with the state given as argument
-    * @param state the state to check compatibility with
-     */
+   * @brief Check if the state is compatible for operations with the state given as argument
+   * @param state the state to check compatibility with
+   */
   virtual bool is_compatible(const State& state) const;
 };
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -20,7 +20,7 @@ public:
   /**
    * Empty constructor
    */
-  explicit CartesianPose();
+  explicit CartesianPose() = default;
 
   /**
    * @brief Constructor with name and reference frame provided

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -128,7 +128,7 @@ public:
   /**
    * @brief Copy constructor of a CartesianState
    */
-  CartesianState(const CartesianState& state);
+  CartesianState(const CartesianState& state) = default;
 
   /**
    * @brief Constructor for the identity CartesianState (identity pose and 0 for the rest)

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -42,7 +42,7 @@ enum class CartesianStateVariable {
  * @param s2 the second CartesianState
  * @param state_variable_type name of the state variable from the CartesianStateVariable structure to apply
  * the distance on. Default ALL for full distance across all dimensions
- * @return the distance beteen the two states
+ * @return the distance between the two states
  */
 double dist(const CartesianState& s1,
             const CartesianState& s2,
@@ -54,14 +54,14 @@ double dist(const CartesianState& s1,
  */
 class CartesianState : public SpatialState {
 private:
-  Eigen::Vector3d position;            ///< position of the point
-  Eigen::Quaterniond orientation;      ///< orientation of the point
-  Eigen::Vector3d linear_velocity;     ///< linear_velocity of the point
-  Eigen::Vector3d angular_velocity;    ///< angular_velocity of the point
-  Eigen::Vector3d linear_acceleration; ///< linear_acceleration of the point
-  Eigen::Vector3d angular_acceleration;///< angular_acceleration of the point
-  Eigen::Vector3d force;               ///< force applied at the point
-  Eigen::Vector3d torque;              ///< torque applied at the point
+  Eigen::Vector3d position_;            ///< position of the point
+  Eigen::Quaterniond orientation_;      ///< orientation of the point
+  Eigen::Vector3d linear_velocity_;     ///< linear velocity of the point
+  Eigen::Vector3d angular_velocity_;    ///< angular velocity of the point
+  Eigen::Vector3d linear_acceleration_; ///< linear acceleration of the point
+  Eigen::Vector3d angular_acceleration_;///< angular acceleration of the point
+  Eigen::Vector3d force_;               ///< force applied at the point
+  Eigen::Vector3d torque_;              ///< torque applied at the point
 
   /**
    * @brief Set new_value in the provided state_variable (positions, velocities, accelerations or torques)
@@ -277,7 +277,7 @@ public:
 
   /**
    * @brief Setter of the pose from both position and orientation as std vector
-   * @param pose the pose as a 7d vectorz. Beware, quaternion coefficients 
+   * @param pose the pose as a 7d vector. Beware, quaternion coefficients
    * uses the (w, x, y, z) convention
    */
   void set_pose(const std::vector<double>& pose);
@@ -298,7 +298,7 @@ public:
   void set_twist(const Eigen::Matrix<double, 6, 1>& twist);
 
   /**
-   * @brief Setter of the linear accelration attribute
+   * @brief Setter of the linear acceleration attribute
    */
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration);
 
@@ -330,7 +330,7 @@ public:
   /**
    * @brief Initialize the CartesianState to a zero value
    */
-  void initialize();
+  void initialize() override;
 
   /**
    * @brief Set the State to a zero value
@@ -411,14 +411,14 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param state CartesianState to substract
+   * @param state CartesianState to subtract
    * @return the current CartesianState minus the CartesianState given in argument
    */
   CartesianState& operator-=(const CartesianState& state);
 
   /**
    * @brief Overload the - operator
-   * @param state CartesianState to substract
+   * @param state CartesianState to subtract
    * @return the current CartesianState minus the CartesianState given in argument
    */
   CartesianState operator-(const CartesianState& state) const;
@@ -461,7 +461,7 @@ public:
 
   /**
    * @brief Overload the ostream operator for printing
-   * @param os the ostream to happend the string representing the state to
+   * @param os the ostream to append the string representing the state to
    * @param state the state to print
    * @return the appended ostream
    */
@@ -509,11 +509,11 @@ inline CartesianState& CartesianState::operator=(const CartesianState& state) {
 }
 
 inline const Eigen::Vector3d& CartesianState::get_position() const {
-  return this->position;
+  return this->position_;
 }
 
 inline const Eigen::Quaterniond& CartesianState::get_orientation() const {
-  return this->orientation;
+  return this->orientation_;
 }
 
 inline Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
@@ -531,16 +531,16 @@ inline Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {
 
 inline Eigen::Matrix4d CartesianState::get_transformation_matrix() const {
   Eigen::Matrix4d pose;
-  pose << this->orientation.toRotationMatrix(), this->position, 0., 0., 0., 1;
+  pose << this->orientation_.toRotationMatrix(), this->position_, 0., 0., 0., 1;
   return pose;
 }
 
 inline const Eigen::Vector3d& CartesianState::get_linear_velocity() const {
-  return this->linear_velocity;
+  return this->linear_velocity_;
 }
 
 inline const Eigen::Vector3d& CartesianState::get_angular_velocity() const {
-  return this->angular_velocity;
+  return this->angular_velocity_;
 }
 
 inline Eigen::Matrix<double, 6, 1> CartesianState::get_twist() const {
@@ -550,11 +550,11 @@ inline Eigen::Matrix<double, 6, 1> CartesianState::get_twist() const {
 }
 
 inline const Eigen::Vector3d& CartesianState::get_linear_acceleration() const {
-  return this->linear_acceleration;
+  return this->linear_acceleration_;
 }
 
 inline const Eigen::Vector3d& CartesianState::get_angular_acceleration() const {
-  return this->angular_acceleration;
+  return this->angular_acceleration_;
 }
 
 inline Eigen::Matrix<double, 6, 1> CartesianState::get_accelerations() const {
@@ -564,11 +564,11 @@ inline Eigen::Matrix<double, 6, 1> CartesianState::get_accelerations() const {
 }
 
 inline const Eigen::Vector3d& CartesianState::get_force() const {
-  return this->force;
+  return this->force_;
 }
 
 inline const Eigen::Vector3d& CartesianState::get_torque() const {
-  return this->torque;
+  return this->torque_;
 }
 
 inline Eigen::Matrix<double, 6, 1> CartesianState::get_wrench() const {
@@ -648,11 +648,11 @@ inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_var
 }
 
 inline void CartesianState::set_position(const Eigen::Vector3d& position) {
-  this->set_state_variable(this->position, position);
+  this->set_state_variable(this->position_, position);
 }
 
 inline void CartesianState::set_position(const std::vector<double>& position) {
-  this->set_state_variable(this->position, position);
+  this->set_state_variable(this->position_, position);
 }
 
 inline void CartesianState::set_position(const double& x, const double& y, const double& z) {
@@ -661,7 +661,7 @@ inline void CartesianState::set_position(const double& x, const double& y, const
 
 inline void CartesianState::set_orientation(const Eigen::Quaterniond& orientation) {
   this->set_filled();
-  this->orientation = orientation.normalized();
+  this->orientation_ = orientation.normalized();
 }
 
 inline void CartesianState::set_orientation(const Eigen::Vector4d& orientation) {
@@ -694,39 +694,39 @@ inline void CartesianState::set_pose(const std::vector<double>& pose) {
 }
 
 inline void CartesianState::set_linear_velocity(const Eigen::Vector3d& linear_velocity) {
-  this->set_state_variable(this->linear_velocity, linear_velocity);
+  this->set_state_variable(this->linear_velocity_, linear_velocity);
 }
 
 inline void CartesianState::set_angular_velocity(const Eigen::Vector3d& angular_velocity) {
-  this->set_state_variable(this->angular_velocity, angular_velocity);
+  this->set_state_variable(this->angular_velocity_, angular_velocity);
 }
 
 inline void CartesianState::set_twist(const Eigen::Matrix<double, 6, 1>& twist) {
-  this->set_state_variable(this->linear_velocity, this->angular_velocity, twist);
+  this->set_state_variable(this->linear_velocity_, this->angular_velocity_, twist);
 }
 
 inline void CartesianState::set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) {
-  this->set_state_variable(this->linear_acceleration, linear_acceleration);
+  this->set_state_variable(this->linear_acceleration_, linear_acceleration);
 }
 
 inline void CartesianState::set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) {
-  this->set_state_variable(this->angular_acceleration, angular_acceleration);
+  this->set_state_variable(this->angular_acceleration_, angular_acceleration);
 }
 
 inline void CartesianState::set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) {
-  this->set_state_variable(this->linear_acceleration, this->angular_acceleration, accelerations);
+  this->set_state_variable(this->linear_acceleration_, this->angular_acceleration_, accelerations);
 }
 
 inline void CartesianState::set_force(const Eigen::Vector3d& force) {
-  this->set_state_variable(this->force, force);
+  this->set_state_variable(this->force_, force);
 }
 
 inline void CartesianState::set_torque(const Eigen::Vector3d& torque) {
-  this->set_state_variable(this->torque, torque);
+  this->set_state_variable(this->torque_, torque);
 }
 
 inline void CartesianState::set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) {
-  this->set_state_variable(this->force, this->torque, wrench);
+  this->set_state_variable(this->force_, this->torque_, wrench);
 }
 
 inline void CartesianState::set_state_variable(const Eigen::VectorXd& new_value,

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -147,6 +147,13 @@ public:
   static CartesianState Random(const std::string& name, const std::string& reference = "world");
 
   /**
+   * @brief Swap the values of the two CartesianState
+   * @param state1 CartesianState to be swapped with 2
+   * @param state2 CartesianState to be swapped with 1
+   */
+  friend void swap(CartesianState& state1, CartesianState& state2);
+
+  /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param state the state with value to assign
    * @return reference to the current state with new values
@@ -499,13 +506,22 @@ public:
   virtual void from_std_vector(const std::vector<double>& value);
 };
 
+inline void swap(CartesianState& state1, CartesianState& state2) {
+  swap(static_cast<SpatialState&>(state1), static_cast<SpatialState&>(state2));
+  std::swap(state1.position_, state2.position_);
+  std::swap(state1.orientation_, state2.orientation_);
+  std::swap(state1.linear_velocity_, state2.linear_velocity_);
+  std::swap(state1.angular_velocity_, state2.angular_velocity_);
+  std::swap(state1.linear_acceleration_, state2.linear_acceleration_);
+  std::swap(state1.angular_acceleration_, state2.angular_acceleration_);
+  std::swap(state1.force_, state2.force_);
+  std::swap(state1.torque_, state2.torque_);
+}
+
 inline CartesianState& CartesianState::operator=(const CartesianState& state) {
-  SpatialState::operator=(state);
-  this->set_pose(state.get_pose());
-  this->set_twist(state.get_twist());
-  this->set_accelerations(state.get_accelerations());
-  this->set_wrench(state.get_wrench());
-  return (*this);
+  CartesianState tmp(state);
+  swap(*this, tmp);
+  return *this;
 }
 
 inline const Eigen::Vector3d& CartesianState::get_position() const {

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -20,7 +20,7 @@ public:
   /**
    * Empty constructor
    */
-  explicit CartesianTwist();
+  explicit CartesianTwist() = default;
 
   /**
    * @brief Empty constructor for a CartesianTwist

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -74,7 +74,7 @@ public:
   static CartesianTwist Random(const std::string& name, const std::string& reference = "world");
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param twist the twist with value to assign
    * @return reference to the current twist with new values
    */
@@ -116,14 +116,14 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param twist CartesianTwist to substract
+   * @param twist CartesianTwist to subtract
    * @return the current CartesianTwist minus the CartesianTwist given in argument
    */
   CartesianTwist& operator-=(const CartesianTwist& twist);
 
   /**
    * @brief Overload the - operator with a twist
-   * @param twist CartesianTwist to substract
+   * @param twist CartesianTwist to subtract
    * @return the current CartesianTwist minus the CartesianTwist given in argument
    */
   CartesianTwist operator-(const CartesianTwist& twist) const;
@@ -207,7 +207,7 @@ public:
 
   /**
    * @brief Overload the ostream operator for printing
-   * @param os the ostream to happend the string representing the CartesianTwist to
+   * @param os the ostream to append the string representing the CartesianTwist to
    * @param CartesianTwist the CartesianTwist to print
    * @return the appended ostream
    */

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -17,7 +17,7 @@ public:
   /**
    * Empty constructor
    */
-  explicit CartesianWrench();
+  explicit CartesianWrench() = default;
 
   /**
    * @brief Empty constructor for a CartesianWrench

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -66,7 +66,7 @@ public:
   static CartesianWrench Random(const std::string& name, const std::string& reference = "world");
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
    * @param pose the pose with value to assign
    * @return reference to the current pose with new values
    */
@@ -108,14 +108,14 @@ public:
 
   /**
    * @brief Overload the -= operator
-   * @param wrench CartesianWrench to substract
+   * @param wrench CartesianWrench to subtract
    * @return the current CartesianWrench minus the CartesianWrench given in argument
    */
   CartesianWrench& operator-=(const CartesianWrench& wrench);
 
   /**
    * @brief Overload the - operator
-   * @param wrench CartesianWrench to substract
+   * @param wrench CartesianWrench to subtract
    * @return the current CartesianWrench minus the CartesianWrench given in argument
    */
   CartesianWrench operator-(const CartesianWrench& wrench) const;
@@ -185,7 +185,7 @@ public:
 
   /**
    * @brief Overload the ostream operator for printing
-   * @param os the ostream to happend the string representing the CartesianWrench to
+   * @param os the ostream to append the string representing the CartesianWrench to
    * @param CartesianWrench the CartesianWrench to print
    * @return the appended ostream
    */

--- a/source/state_representation/src/space/SpatialState.cpp
+++ b/source/state_representation/src/space/SpatialState.cpp
@@ -10,8 +10,6 @@ SpatialState::SpatialState(const StateType& type,
                            const bool& empty) :
     State(type, name, empty), reference_frame_(reference_frame) {}
 
-SpatialState::SpatialState(const SpatialState& state) = default;
-
 std::ostream& operator<<(std::ostream& os, const SpatialState& state) {
   if (state.is_empty()) {
     os << "Empty ";

--- a/source/state_representation/src/space/SpatialState.cpp
+++ b/source/state_representation/src/space/SpatialState.cpp
@@ -2,16 +2,15 @@
 
 namespace state_representation {
 SpatialState::SpatialState(const StateType& type) :
-    State(type), reference_frame("world") {}
+    State(type), reference_frame_("world") {}
 
 SpatialState::SpatialState(const StateType& type,
                            const std::string& name,
                            const std::string& reference_frame,
                            const bool& empty) :
-    State(type, name, empty), reference_frame(reference_frame) {}
+    State(type, name, empty), reference_frame_(reference_frame) {}
 
-SpatialState::SpatialState(const SpatialState& state) :
-    State(state.get_type(), state.get_name(), state.is_empty()), reference_frame(state.reference_frame) {}
+SpatialState::SpatialState(const SpatialState& state) = default;
 
 std::ostream& operator<<(std::ostream& os, const SpatialState& state) {
   if (state.is_empty()) {

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -5,7 +5,7 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-CartesianPose::CartesianPose() {}
+CartesianPose::CartesianPose() = default;
 
 CartesianPose::CartesianPose(const std::string& name, const std::string& reference) : CartesianState(name, reference) {}
 
@@ -30,11 +30,16 @@ CartesianPose::CartesianPose(const std::string& name,
   this->set_orientation(orientation);
 }
 
-CartesianPose::CartesianPose(const CartesianPose& pose) : CartesianState(pose) {}
+CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state) {
+  // set all the state variables to 0 except position and orientation
+  this->set_zero();
+  this->set_position(state.get_position());
+  this->set_orientation(state.get_orientation());
+}
 
-CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state) {}
+CartesianPose::CartesianPose(const CartesianPose& pose) : CartesianPose(static_cast<const CartesianState&>(pose)) {}
 
-CartesianPose::CartesianPose(const CartesianTwist& twist) : CartesianState(std::chrono::seconds(1) * twist) {}
+CartesianPose::CartesianPose(const CartesianTwist& twist) : CartesianPose(std::chrono::seconds(1) * twist) {}
 
 CartesianPose CartesianPose::Identity(const std::string& name, const std::string& reference) {
   return CartesianState::Identity(name, reference);

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -5,8 +5,6 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-CartesianPose::CartesianPose() = default;
-
 CartesianPose::CartesianPose(const std::string& name, const std::string& reference) : CartesianState(name, reference) {}
 
 CartesianPose::CartesianPose(const std::string& name, const Eigen::Vector3d& position, const std::string& reference) :

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -33,8 +33,7 @@ CartesianPose::CartesianPose(const std::string& name,
 CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state) {
   // set all the state variables to 0 except position and orientation
   this->set_zero();
-  this->set_position(state.get_position());
-  this->set_orientation(state.get_orientation());
+  this->set_pose(state.get_pose());
 }
 
 CartesianPose::CartesianPose(const CartesianPose& pose) : CartesianPose(static_cast<const CartesianState&>(pose)) {}

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -16,14 +16,14 @@ CartesianState::CartesianState(const std::string& robot_name, const std::string&
 }
 
 CartesianState::CartesianState(const CartesianState& state) : SpatialState(state),
-                                                              position(state.position),
-                                                              orientation(state.orientation),
-                                                              linear_velocity(state.linear_velocity),
-                                                              angular_velocity(state.angular_velocity),
-                                                              linear_acceleration(state.linear_acceleration),
-                                                              angular_acceleration(state.angular_acceleration),
-                                                              force(state.force),
-                                                              torque(state.torque) {}
+                                                              position_(state.position_),
+                                                              orientation_(state.orientation_),
+                                                              linear_velocity_(state.linear_velocity_),
+                                                              angular_velocity_(state.angular_velocity_),
+                                                              linear_acceleration_(state.linear_acceleration_),
+                                                              angular_acceleration_(state.angular_acceleration_),
+                                                              force_(state.force_),
+                                                              torque_(state.torque_) {}
 
 void CartesianState::initialize() {
   this->State::initialize();
@@ -31,14 +31,14 @@ void CartesianState::initialize() {
 }
 
 void CartesianState::set_zero() {
-  this->position.setZero();
-  this->orientation.setIdentity();
-  this->linear_velocity.setZero();
-  this->angular_velocity.setZero();
-  this->linear_acceleration.setZero();
-  this->angular_acceleration.setZero();
-  this->force.setZero();
-  this->torque.setZero();
+  this->position_.setZero();
+  this->orientation_.setIdentity();
+  this->linear_velocity_.setZero();
+  this->angular_velocity_.setZero();
+  this->linear_acceleration_.setZero();
+  this->angular_acceleration_.setZero();
+  this->force_.setZero();
+  this->torque_.setZero();
 }
 
 CartesianState CartesianState::Identity(const std::string& name, const std::string& reference) {
@@ -349,38 +349,38 @@ std::vector<double> CartesianState::norms(const CartesianStateVariable& state_va
 void CartesianState::normalize(const CartesianStateVariable& state_variable_type) {
   if (state_variable_type == CartesianStateVariable::POSITION || state_variable_type == CartesianStateVariable::POSE
       || state_variable_type == CartesianStateVariable::ALL) {
-    this->position.normalize();
+    this->position_.normalize();
   }
   // there shouldn't be a need to renormalize orientation as it is already normalized
   if (state_variable_type == CartesianStateVariable::ORIENTATION || state_variable_type == CartesianStateVariable::POSE
       || state_variable_type == CartesianStateVariable::ALL) {
-    this->orientation.normalize();
+    this->orientation_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::LINEAR_VELOCITY
       || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
-    this->linear_velocity.normalize();
+    this->linear_velocity_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::ANGULAR_VELOCITY
       || state_variable_type == CartesianStateVariable::TWIST || state_variable_type == CartesianStateVariable::ALL) {
-    this->angular_velocity.normalize();
+    this->angular_velocity_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION
       || state_variable_type == CartesianStateVariable::ACCELERATIONS
       || state_variable_type == CartesianStateVariable::ALL) {
-    this->linear_acceleration.normalize();
+    this->linear_acceleration_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION
       || state_variable_type == CartesianStateVariable::ACCELERATIONS
       || state_variable_type == CartesianStateVariable::ALL) {
-    this->angular_acceleration.normalize();
+    this->angular_acceleration_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::FORCE || state_variable_type == CartesianStateVariable::WRENCH
       || state_variable_type == CartesianStateVariable::ALL) {
-    this->force.normalize();
+    this->force_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::TORQUE || state_variable_type == CartesianStateVariable::WRENCH
       || state_variable_type == CartesianStateVariable::ALL) {
-    this->torque.normalize();
+    this->torque_.normalize();
   }
 }
 
@@ -395,36 +395,36 @@ std::ostream& operator<<(std::ostream& os, const CartesianState& state) {
     os << "Empty CartesianState";
   } else {
     os << state.get_name() << " CartesianState expressed in " << state.get_reference_frame() << " frame" << std::endl;
-    os << "position: (" << state.position(0) << ", ";
-    os << state.position(1) << ", ";
-    os << state.position(2) << ")" << std::endl;
-    os << "orientation: (" << state.orientation.w() << ", ";
-    os << state.orientation.x() << ", ";
-    os << state.orientation.y() << ", ";
-    os << state.orientation.z() << ")";
-    Eigen::AngleAxisd axis_angle(state.orientation);
+    os << "position: (" << state.position_(0) << ", ";
+    os << state.position_(1) << ", ";
+    os << state.position_(2) << ")" << std::endl;
+    os << "orientation: (" << state.orientation_.w() << ", ";
+    os << state.orientation_.x() << ", ";
+    os << state.orientation_.y() << ", ";
+    os << state.orientation_.z() << ")";
+    Eigen::AngleAxisd axis_angle(state.orientation_);
     os << " <=> theta: " << axis_angle.angle() << ", ";
     os << "axis: (" << axis_angle.axis()(0) << ", ";
     os << axis_angle.axis()(1) << ", ";
     os << axis_angle.axis()(2) << ")" << std::endl;
-    os << "linear velocity: (" << state.linear_velocity(0) << ", ";
-    os << state.linear_velocity(1) << ", ";
-    os << state.linear_velocity(2) << ")" << std::endl;
-    os << "angular velocity: (" << state.angular_velocity(0) << ", ";
-    os << state.angular_velocity(1) << ", ";
-    os << state.angular_velocity(2) << ")" << std::endl;
-    os << "linear acceleration: (" << state.linear_acceleration(0) << ", ";
-    os << state.linear_acceleration(1) << ", ";
-    os << state.linear_acceleration(2) << ")" << std::endl;
-    os << "angular acceleration: (" << state.angular_acceleration(0) << ", ";
-    os << state.angular_acceleration(1) << ", ";
-    os << state.angular_acceleration(2) << ")" << std::endl;
-    os << "force: (" << state.force(0) << ", ";
-    os << state.force(1) << ", ";
-    os << state.force(2) << ")" << std::endl;
-    os << "torque: (" << state.torque(0) << ", ";
-    os << state.torque(1) << ", ";
-    os << state.torque(2) << ")";
+    os << "linear velocity: (" << state.linear_velocity_(0) << ", ";
+    os << state.linear_velocity_(1) << ", ";
+    os << state.linear_velocity_(2) << ")" << std::endl;
+    os << "angular velocity: (" << state.angular_velocity_(0) << ", ";
+    os << state.angular_velocity_(1) << ", ";
+    os << state.angular_velocity_(2) << ")" << std::endl;
+    os << "linear acceleration: (" << state.linear_acceleration_(0) << ", ";
+    os << state.linear_acceleration_(1) << ", ";
+    os << state.linear_acceleration_(2) << ")" << std::endl;
+    os << "angular acceleration: (" << state.angular_acceleration_(0) << ", ";
+    os << state.angular_acceleration_(1) << ", ";
+    os << state.angular_acceleration_(2) << ")" << std::endl;
+    os << "force: (" << state.force_(0) << ", ";
+    os << state.force_(1) << ", ";
+    os << state.force_(2) << ")" << std::endl;
+    os << "torque: (" << state.torque_(0) << ", ";
+    os << state.torque_(1) << ", ";
+    os << state.torque_(2) << ")";
   }
   return os;
 }

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -15,15 +15,7 @@ CartesianState::CartesianState(const std::string& robot_name, const std::string&
   this->initialize();
 }
 
-CartesianState::CartesianState(const CartesianState& state) : SpatialState(state),
-                                                              position_(state.position_),
-                                                              orientation_(state.orientation_),
-                                                              linear_velocity_(state.linear_velocity_),
-                                                              angular_velocity_(state.angular_velocity_),
-                                                              linear_acceleration_(state.linear_acceleration_),
-                                                              angular_acceleration_(state.angular_acceleration_),
-                                                              force_(state.force_),
-                                                              torque_(state.torque_) {}
+CartesianState::CartesianState(const CartesianState& state) = default;
 
 void CartesianState::initialize() {
   this->State::initialize();

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -15,8 +15,6 @@ CartesianState::CartesianState(const std::string& robot_name, const std::string&
   this->initialize();
 }
 
-CartesianState::CartesianState(const CartesianState& state) = default;
-
 void CartesianState::initialize() {
   this->State::initialize();
   this->set_zero();

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -4,8 +4,6 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-CartesianTwist::CartesianTwist() {}
-
 CartesianTwist::CartesianTwist(const std::string& name, const std::string& reference) :
     CartesianState(name, reference) {}
 

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -35,8 +35,7 @@ CartesianTwist::CartesianTwist(const std::string& name,
 CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(state) {
   // set all the state variables to 0 except linear and angular velocities
   this->set_zero();
-  this->set_linear_velocity(state.get_linear_velocity());
-  this->set_angular_velocity(state.get_angular_velocity());
+  this->set_twist(state.get_twist());
 }
 
 CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianTwist(static_cast<const CartesianState&>(twist)) {}

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -32,11 +32,16 @@ CartesianTwist::CartesianTwist(const std::string& name,
   this->set_twist(twist);
 }
 
-CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianState(twist) {}
+CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(state) {
+  // set all the state variables to 0 except linear and angular velocities
+  this->set_zero();
+  this->set_linear_velocity(state.get_linear_velocity());
+  this->set_angular_velocity(state.get_angular_velocity());
+}
 
-CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(state) {}
+CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianTwist(static_cast<const CartesianState&>(twist)) {}
 
-CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianState(pose / std::chrono::seconds(1)) {}
+CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianTwist(pose / std::chrono::seconds(1)) {}
 
 CartesianTwist CartesianTwist::Zero(const std::string& name, const std::string& reference) {
   return CartesianState::Identity(name, reference);

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -28,9 +28,13 @@ CartesianWrench::CartesianWrench(const std::string& name,
   this->set_wrench(wrench);
 }
 
-CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianState(wrench) {}
+CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(state) {
+  // set all the state variables to 0 except force and torque
+  this->set_zero();
+  this->set_wrench(state.get_wrench());
+}
 
-CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(state) {}
+CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianWrench(static_cast<const CartesianState&>(wrench)) {}
 
 CartesianWrench CartesianWrench::Zero(const std::string& name, const std::string& reference) {
   return CartesianState::Identity(name, reference);

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -4,8 +4,6 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-CartesianWrench::CartesianWrench() {}
-
 CartesianWrench::CartesianWrench(const std::string& name, const std::string& reference) :
     CartesianState(name, reference) {}
 

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -68,6 +68,50 @@ TEST(CartesianStateTest, RandomWrenchInitialization) {
   EXPECT_TRUE(random.get_wrench().norm() > 0);
 }
 
+TEST(CartesianStateTest, CopyState) {
+  CartesianState state1 = CartesianState::Random("test");
+  CartesianState state2(state1);
+  EXPECT_EQ(state1.get_name(), state2.get_name());
+  EXPECT_EQ(state1.get_reference_frame(), state2.get_reference_frame());
+  EXPECT_TRUE(state1.data().isApprox(state2.data()));
+  CartesianState state3 = state1;
+  EXPECT_EQ(state1.get_name(), state3.get_name());
+  EXPECT_EQ(state1.get_reference_frame(), state3.get_reference_frame());
+  EXPECT_TRUE(state1.data().isApprox(state3.data()));
+}
+
+TEST(CartesianStateTest, CopyPose) {
+  CartesianPose pose1 = CartesianPose::Random("test");
+  CartesianPose pose2(pose1);
+  EXPECT_EQ(pose1.get_name(), pose2.get_name());
+  EXPECT_EQ(pose1.get_reference_frame(), pose2.get_reference_frame());
+  EXPECT_TRUE(pose1.data().isApprox(pose2.data()));
+  EXPECT_TRUE(pose2.get_twist().norm() == 0);
+  EXPECT_TRUE(pose2.get_accelerations().norm() == 0);
+  EXPECT_TRUE(pose2.get_wrench().norm() == 0);
+  CartesianPose pose3 = pose1;
+  EXPECT_EQ(pose1.get_name(), pose3.get_name());
+  EXPECT_EQ(pose1.get_reference_frame(), pose3.get_reference_frame());
+  EXPECT_TRUE(pose1.data().isApprox(pose3.data()));
+  EXPECT_TRUE(pose3.get_twist().norm() == 0);
+  EXPECT_TRUE(pose3.get_accelerations().norm() == 0);
+  EXPECT_TRUE(pose3.get_wrench().norm() == 0);
+  // try to change non pose variables prior to the copy, those should be discarded
+  pose1.set_linear_velocity(Eigen::Vector3d::Random());
+  pose1.set_linear_acceleration(Eigen::Vector3d::Random());
+  pose1.set_force(Eigen::Vector3d::Random());
+  CartesianPose pose4 = pose1;
+  EXPECT_TRUE(pose1.data().isApprox(pose4.data()));
+  EXPECT_TRUE(pose4.get_twist().norm() == 0);
+  EXPECT_TRUE(pose4.get_accelerations().norm() == 0);
+  EXPECT_TRUE(pose4.get_wrench().norm() == 0);
+  // copy a state, only the pose variables should be non 0
+  CartesianPose pose5 = CartesianState::Random("test");
+  EXPECT_TRUE(pose5.get_twist().norm() == 0);
+  EXPECT_TRUE(pose5.get_accelerations().norm() == 0);
+  EXPECT_TRUE(pose5.get_wrench().norm() == 0);
+}
+
 TEST(CartesianStateTest, GetData) {
   CartesianState cs = CartesianState::Random("test");
   Eigen::VectorXd concatenated_state(25);

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -127,7 +127,6 @@ TEST(CartesianStateTest, CopyTwist) {
   EXPECT_EQ(twist1.get_name(), twist3.get_name());
   EXPECT_EQ(twist1.get_reference_frame(), twist3.get_reference_frame());
   EXPECT_TRUE(twist1.data().isApprox(twist3.data()));
-  EXPECT_TRUE(twist1.data().isApprox(twist2.data()));
   EXPECT_TRUE(twist3.get_position().norm() == 0);
   EXPECT_TRUE(twist3.get_orientation().norm() == 1);
   EXPECT_TRUE(twist3.get_orientation().w() == 1);
@@ -152,6 +151,47 @@ TEST(CartesianStateTest, CopyTwist) {
   EXPECT_TRUE(twist5.get_orientation().w() == 1);
   EXPECT_TRUE(twist5.get_accelerations().norm() == 0);
   EXPECT_TRUE(twist5.get_wrench().norm() == 0);
+}
+
+TEST(CartesianStateTest, CopyWrench) {
+  CartesianWrench wrench1 = CartesianWrench::Random("test");
+  CartesianWrench wrench2(wrench1);
+  EXPECT_EQ(wrench1.get_name(), wrench2.get_name());
+  EXPECT_EQ(wrench1.get_reference_frame(), wrench2.get_reference_frame());
+  EXPECT_TRUE(wrench1.data().isApprox(wrench2.data()));
+  EXPECT_TRUE(wrench2.get_position().norm() == 0);
+  EXPECT_TRUE(wrench2.get_orientation().norm() == 1);
+  EXPECT_TRUE(wrench2.get_orientation().w() == 1);
+  EXPECT_TRUE(wrench2.get_twist().norm() == 0);
+  EXPECT_TRUE(wrench2.get_accelerations().norm() == 0);
+  CartesianWrench wrench3 = wrench1;
+  EXPECT_EQ(wrench1.get_name(), wrench3.get_name());
+  EXPECT_EQ(wrench1.get_reference_frame(), wrench3.get_reference_frame());
+  EXPECT_TRUE(wrench1.data().isApprox(wrench3.data()));
+  EXPECT_TRUE(wrench3.get_position().norm() == 0);
+  EXPECT_TRUE(wrench3.get_orientation().norm() == 1);
+  EXPECT_TRUE(wrench3.get_orientation().w() == 1);
+  EXPECT_TRUE(wrench3.get_twist().norm() == 0);
+  EXPECT_TRUE(wrench3.get_accelerations().norm() == 0);
+  // try to change non pose variables prior to the copy, those should be discarded
+  wrench1.set_position(Eigen::Vector3d::Random());
+  wrench1.set_orientation(Eigen::Quaterniond::UnitRandom());
+  wrench1.set_linear_velocity(Eigen::Vector3d::Random());
+  wrench1.set_linear_acceleration(Eigen::Vector3d::Random());
+  CartesianWrench wrench4 = wrench1;
+  EXPECT_TRUE(wrench1.data().isApprox(wrench4.data()));
+  EXPECT_TRUE(wrench4.get_position().norm() == 0);
+  EXPECT_TRUE(wrench4.get_orientation().norm() == 1);
+  EXPECT_TRUE(wrench4.get_orientation().w() == 1);
+  EXPECT_TRUE(wrench4.get_twist().norm() == 0);
+  EXPECT_TRUE(wrench4.get_accelerations().norm() == 0);
+  // copy a state, only the pose variables should be non 0
+  CartesianWrench wrench5 = CartesianState::Random("test");
+  EXPECT_TRUE(wrench5.get_position().norm() == 0);
+  EXPECT_TRUE(wrench5.get_orientation().norm() == 1);
+  EXPECT_TRUE(wrench5.get_orientation().w() == 1);
+  EXPECT_TRUE(wrench5.get_twist().norm() == 0);
+  EXPECT_TRUE(wrench5.get_accelerations().norm() == 0);
 }
 
 TEST(CartesianStateTest, GetData) {

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -12,60 +12,60 @@ TEST(CartesianStateTest, IdentityInitialization) {
   // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(identity.is_empty());
   // all data should be zero except for orientation that should be identity
-  EXPECT_TRUE(identity.get_position().norm() == 0);
-  EXPECT_TRUE(identity.get_orientation().norm() == 1);
-  EXPECT_TRUE(identity.get_orientation().w() == 1);
-  EXPECT_TRUE(identity.get_twist().norm() == 0);
-  EXPECT_TRUE(identity.get_accelerations().norm() == 0);
-  EXPECT_TRUE(identity.get_wrench().norm() == 0);
+  EXPECT_EQ(identity.get_position().norm(), 0);
+  EXPECT_EQ(identity.get_orientation().norm(), 1);
+  EXPECT_EQ(identity.get_orientation().w(), 1);
+  EXPECT_EQ(identity.get_twist().norm(), 0);
+  EXPECT_EQ(identity.get_accelerations().norm(), 0);
+  EXPECT_EQ(identity.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, RandomStateInitialization) {
   CartesianState random = CartesianState::Random("test");
   // all data should be random (non 0)
-  EXPECT_TRUE(random.get_position().norm() > 0);
-  EXPECT_TRUE(abs(random.get_orientation().w()) > 0);
-  EXPECT_TRUE(abs(random.get_orientation().x()) > 0);
-  EXPECT_TRUE(abs(random.get_orientation().y()) > 0);
-  EXPECT_TRUE(abs(random.get_orientation().z()) > 0);
-  EXPECT_TRUE(random.get_twist().norm() > 0);
-  EXPECT_TRUE(random.get_accelerations().norm() > 0);
-  EXPECT_TRUE(random.get_wrench().norm() > 0);
+  EXPECT_GT(random.get_position().norm(), 0);
+  EXPECT_GT(abs(random.get_orientation().w()), 0);
+  EXPECT_GT(abs(random.get_orientation().x()), 0);
+  EXPECT_GT(abs(random.get_orientation().y()), 0);
+  EXPECT_GT(abs(random.get_orientation().z()), 0);
+  EXPECT_GT(random.get_twist().norm(), 0);
+  EXPECT_GT(random.get_accelerations().norm(), 0);
+  EXPECT_GT(random.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, RandomPoseInitialization) {
   CartesianPose random = CartesianPose::Random("test");
   // only position should be random
-  EXPECT_TRUE(random.get_position().norm() > 0);
-  EXPECT_TRUE(abs(random.get_orientation().w()) > 0);
-  EXPECT_TRUE(abs(random.get_orientation().x()) > 0);
-  EXPECT_TRUE(abs(random.get_orientation().y()) > 0);
-  EXPECT_TRUE(abs(random.get_orientation().z()) > 0);
-  EXPECT_TRUE(random.get_twist().norm() == 0);
-  EXPECT_TRUE(random.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random.get_wrench().norm() == 0);
+  EXPECT_GT(random.get_position().norm(), 0);
+  EXPECT_GT(abs(random.get_orientation().w()), 0);
+  EXPECT_GT(abs(random.get_orientation().x()), 0);
+  EXPECT_GT(abs(random.get_orientation().y()), 0);
+  EXPECT_GT(abs(random.get_orientation().z()), 0);
+  EXPECT_EQ(random.get_twist().norm(), 0);
+  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_EQ(random.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, RandomTwistInitialization) {
   CartesianTwist random = CartesianTwist::Random("test");
   // only position should be random
-  EXPECT_TRUE(random.get_position().norm() == 0);
-  EXPECT_TRUE(random.get_orientation().norm() == 1);
-  EXPECT_TRUE(random.get_orientation().w() == 1);
-  EXPECT_TRUE(random.get_twist().norm() > 0);
-  EXPECT_TRUE(random.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random.get_wrench().norm() == 0);
+  EXPECT_EQ(random.get_position().norm(), 0);
+  EXPECT_EQ(random.get_orientation().norm(), 1);
+  EXPECT_EQ(random.get_orientation().w(), 1);
+  EXPECT_GT(random.get_twist().norm(), 0);
+  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_EQ(random.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, RandomWrenchInitialization) {
   CartesianWrench random = CartesianWrench::Random("test");
   // only position should be random
-  EXPECT_TRUE(random.get_position().norm() == 0);
-  EXPECT_TRUE(random.get_orientation().norm() == 1);
-  EXPECT_TRUE(random.get_orientation().w() == 1);
-  EXPECT_TRUE(random.get_twist().norm() == 0);
-  EXPECT_TRUE(random.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random.get_wrench().norm() > 0);
+  EXPECT_EQ(random.get_position().norm(), 0);
+  EXPECT_EQ(random.get_orientation().norm(), 1);
+  EXPECT_EQ(random.get_orientation().w(), 1);
+  EXPECT_EQ(random.get_twist().norm(), 0);
+  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_GT(random.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, CopyState) {
@@ -86,30 +86,30 @@ TEST(CartesianStateTest, CopyPose) {
   EXPECT_EQ(pose1.get_name(), pose2.get_name());
   EXPECT_EQ(pose1.get_reference_frame(), pose2.get_reference_frame());
   EXPECT_TRUE(pose1.data().isApprox(pose2.data()));
-  EXPECT_TRUE(pose2.get_twist().norm() == 0);
-  EXPECT_TRUE(pose2.get_accelerations().norm() == 0);
-  EXPECT_TRUE(pose2.get_wrench().norm() == 0);
+  EXPECT_EQ(pose2.get_twist().norm(), 0);
+  EXPECT_EQ(pose2.get_accelerations().norm(), 0);
+  EXPECT_EQ(pose2.get_wrench().norm(), 0);
   CartesianPose pose3 = pose1;
   EXPECT_EQ(pose1.get_name(), pose3.get_name());
   EXPECT_EQ(pose1.get_reference_frame(), pose3.get_reference_frame());
   EXPECT_TRUE(pose1.data().isApprox(pose3.data()));
-  EXPECT_TRUE(pose3.get_twist().norm() == 0);
-  EXPECT_TRUE(pose3.get_accelerations().norm() == 0);
-  EXPECT_TRUE(pose3.get_wrench().norm() == 0);
+  EXPECT_EQ(pose3.get_twist().norm(), 0);
+  EXPECT_EQ(pose3.get_accelerations().norm(), 0);
+  EXPECT_EQ(pose3.get_wrench().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
   pose1.set_linear_velocity(Eigen::Vector3d::Random());
   pose1.set_linear_acceleration(Eigen::Vector3d::Random());
   pose1.set_force(Eigen::Vector3d::Random());
   CartesianPose pose4 = pose1;
   EXPECT_TRUE(pose1.data().isApprox(pose4.data()));
-  EXPECT_TRUE(pose4.get_twist().norm() == 0);
-  EXPECT_TRUE(pose4.get_accelerations().norm() == 0);
-  EXPECT_TRUE(pose4.get_wrench().norm() == 0);
+  EXPECT_EQ(pose4.get_twist().norm(), 0);
+  EXPECT_EQ(pose4.get_accelerations().norm(), 0);
+  EXPECT_EQ(pose4.get_wrench().norm(), 0);
   // copy a state, only the pose variables should be non 0
   CartesianPose pose5 = CartesianState::Random("test");
-  EXPECT_TRUE(pose5.get_twist().norm() == 0);
-  EXPECT_TRUE(pose5.get_accelerations().norm() == 0);
-  EXPECT_TRUE(pose5.get_wrench().norm() == 0);
+  EXPECT_EQ(pose5.get_twist().norm(), 0);
+  EXPECT_EQ(pose5.get_accelerations().norm(), 0);
+  EXPECT_EQ(pose5.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, CopyTwist) {
@@ -118,20 +118,20 @@ TEST(CartesianStateTest, CopyTwist) {
   EXPECT_EQ(twist1.get_name(), twist2.get_name());
   EXPECT_EQ(twist1.get_reference_frame(), twist2.get_reference_frame());
   EXPECT_TRUE(twist1.data().isApprox(twist2.data()));
-  EXPECT_TRUE(twist2.get_position().norm() == 0);
-  EXPECT_TRUE(twist2.get_orientation().norm() == 1);
-  EXPECT_TRUE(twist2.get_orientation().w() == 1);
-  EXPECT_TRUE(twist2.get_accelerations().norm() == 0);
-  EXPECT_TRUE(twist2.get_wrench().norm() == 0);
+  EXPECT_EQ(twist2.get_position().norm(), 0);
+  EXPECT_EQ(twist2.get_orientation().norm(), 1);
+  EXPECT_EQ(twist2.get_orientation().w(), 1);
+  EXPECT_EQ(twist2.get_accelerations().norm(), 0);
+  EXPECT_EQ(twist2.get_wrench().norm(), 0);
   CartesianTwist twist3 = twist1;
   EXPECT_EQ(twist1.get_name(), twist3.get_name());
   EXPECT_EQ(twist1.get_reference_frame(), twist3.get_reference_frame());
   EXPECT_TRUE(twist1.data().isApprox(twist3.data()));
-  EXPECT_TRUE(twist3.get_position().norm() == 0);
-  EXPECT_TRUE(twist3.get_orientation().norm() == 1);
-  EXPECT_TRUE(twist3.get_orientation().w() == 1);
-  EXPECT_TRUE(twist3.get_accelerations().norm() == 0);
-  EXPECT_TRUE(twist3.get_wrench().norm() == 0);
+  EXPECT_EQ(twist3.get_position().norm(), 0);
+  EXPECT_EQ(twist3.get_orientation().norm(), 1);
+  EXPECT_EQ(twist3.get_orientation().w(), 1);
+  EXPECT_EQ(twist3.get_accelerations().norm(), 0);
+  EXPECT_EQ(twist3.get_wrench().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
   twist1.set_position(Eigen::Vector3d::Random());
   twist1.set_orientation(Eigen::Quaterniond::UnitRandom());
@@ -139,18 +139,18 @@ TEST(CartesianStateTest, CopyTwist) {
   twist1.set_force(Eigen::Vector3d::Random());
   CartesianTwist twist4 = twist1;
   EXPECT_TRUE(twist1.data().isApprox(twist4.data()));
-  EXPECT_TRUE(twist4.get_position().norm() == 0);
-  EXPECT_TRUE(twist4.get_orientation().norm() == 1);
-  EXPECT_TRUE(twist4.get_orientation().w() == 1);
-  EXPECT_TRUE(twist4.get_accelerations().norm() == 0);
-  EXPECT_TRUE(twist4.get_wrench().norm() == 0);
+  EXPECT_EQ(twist4.get_position().norm(), 0);
+  EXPECT_EQ(twist4.get_orientation().norm(), 1);
+  EXPECT_EQ(twist4.get_orientation().w(), 1);
+  EXPECT_EQ(twist4.get_accelerations().norm(), 0);
+  EXPECT_EQ(twist4.get_wrench().norm(), 0);
   // copy a state, only the pose variables should be non 0
   CartesianTwist twist5 = CartesianState::Random("test");
-  EXPECT_TRUE(twist5.get_position().norm() == 0);
-  EXPECT_TRUE(twist5.get_orientation().norm() == 1);
-  EXPECT_TRUE(twist5.get_orientation().w() == 1);
-  EXPECT_TRUE(twist5.get_accelerations().norm() == 0);
-  EXPECT_TRUE(twist5.get_wrench().norm() == 0);
+  EXPECT_EQ(twist5.get_position().norm(), 0);
+  EXPECT_EQ(twist5.get_orientation().norm(), 1);
+  EXPECT_EQ(twist5.get_orientation().w(), 1);
+  EXPECT_EQ(twist5.get_accelerations().norm(), 0);
+  EXPECT_EQ(twist5.get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, CopyWrench) {
@@ -159,20 +159,20 @@ TEST(CartesianStateTest, CopyWrench) {
   EXPECT_EQ(wrench1.get_name(), wrench2.get_name());
   EXPECT_EQ(wrench1.get_reference_frame(), wrench2.get_reference_frame());
   EXPECT_TRUE(wrench1.data().isApprox(wrench2.data()));
-  EXPECT_TRUE(wrench2.get_position().norm() == 0);
-  EXPECT_TRUE(wrench2.get_orientation().norm() == 1);
-  EXPECT_TRUE(wrench2.get_orientation().w() == 1);
-  EXPECT_TRUE(wrench2.get_twist().norm() == 0);
-  EXPECT_TRUE(wrench2.get_accelerations().norm() == 0);
+  EXPECT_EQ(wrench2.get_position().norm(), 0);
+  EXPECT_EQ(wrench2.get_orientation().norm(), 1);
+  EXPECT_EQ(wrench2.get_orientation().w(), 1);
+  EXPECT_EQ(wrench2.get_twist().norm(), 0);
+  EXPECT_EQ(wrench2.get_accelerations().norm(), 0);
   CartesianWrench wrench3 = wrench1;
   EXPECT_EQ(wrench1.get_name(), wrench3.get_name());
   EXPECT_EQ(wrench1.get_reference_frame(), wrench3.get_reference_frame());
   EXPECT_TRUE(wrench1.data().isApprox(wrench3.data()));
-  EXPECT_TRUE(wrench3.get_position().norm() == 0);
-  EXPECT_TRUE(wrench3.get_orientation().norm() == 1);
-  EXPECT_TRUE(wrench3.get_orientation().w() == 1);
-  EXPECT_TRUE(wrench3.get_twist().norm() == 0);
-  EXPECT_TRUE(wrench3.get_accelerations().norm() == 0);
+  EXPECT_EQ(wrench3.get_position().norm(), 0);
+  EXPECT_EQ(wrench3.get_orientation().norm(), 1);
+  EXPECT_EQ(wrench3.get_orientation().w(), 1);
+  EXPECT_EQ(wrench3.get_twist().norm(), 0);
+  EXPECT_EQ(wrench3.get_accelerations().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
   wrench1.set_position(Eigen::Vector3d::Random());
   wrench1.set_orientation(Eigen::Quaterniond::UnitRandom());
@@ -180,18 +180,18 @@ TEST(CartesianStateTest, CopyWrench) {
   wrench1.set_linear_acceleration(Eigen::Vector3d::Random());
   CartesianWrench wrench4 = wrench1;
   EXPECT_TRUE(wrench1.data().isApprox(wrench4.data()));
-  EXPECT_TRUE(wrench4.get_position().norm() == 0);
-  EXPECT_TRUE(wrench4.get_orientation().norm() == 1);
-  EXPECT_TRUE(wrench4.get_orientation().w() == 1);
-  EXPECT_TRUE(wrench4.get_twist().norm() == 0);
-  EXPECT_TRUE(wrench4.get_accelerations().norm() == 0);
+  EXPECT_EQ(wrench4.get_position().norm(), 0);
+  EXPECT_EQ(wrench4.get_orientation().norm(), 1);
+  EXPECT_EQ(wrench4.get_orientation().w(), 1);
+  EXPECT_EQ(wrench4.get_twist().norm(), 0);
+  EXPECT_EQ(wrench4.get_accelerations().norm(), 0);
   // copy a state, only the pose variables should be non 0
   CartesianWrench wrench5 = CartesianState::Random("test");
-  EXPECT_TRUE(wrench5.get_position().norm() == 0);
-  EXPECT_TRUE(wrench5.get_orientation().norm() == 1);
-  EXPECT_TRUE(wrench5.get_orientation().w() == 1);
-  EXPECT_TRUE(wrench5.get_twist().norm() == 0);
-  EXPECT_TRUE(wrench5.get_accelerations().norm() == 0);
+  EXPECT_EQ(wrench5.get_position().norm(), 0);
+  EXPECT_EQ(wrench5.get_orientation().norm(), 1);
+  EXPECT_EQ(wrench5.get_orientation().w(), 1);
+  EXPECT_EQ(wrench5.get_twist().norm(), 0);
+  EXPECT_EQ(wrench5.get_accelerations().norm(), 0);
 }
 
 TEST(CartesianStateTest, GetData) {
@@ -205,42 +205,44 @@ TEST(CartesianStateTest, CartesianStateToStdVector) {
   CartesianState cs = CartesianState::Random("test");
   std::vector<double> vec_data = cs.to_std_vector();
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(cs.data()(i) == vec_data[i]);
+    EXPECT_EQ(cs.data()(i), vec_data[i]);
   }
 }
 
 TEST(CartesianStateTest, CartesianPoseToStdVector) {
   CartesianPose cp = CartesianPose::Random("test");
   std::vector<double> vec_data = cp.to_std_vector();
-  EXPECT_TRUE(vec_data.size() == 7);
+  EXPECT_EQ(vec_data.size(), 7);
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(cp.data()(i) == vec_data[i]);
+    EXPECT_EQ(cp.data()(i), vec_data[i]);
   }
 }
 
 TEST(CartesianStateTest, CartesianTwistToStdVector) {
   CartesianTwist ct = CartesianTwist::Random("test");
   std::vector<double> vec_data = ct.to_std_vector();
-  EXPECT_TRUE(vec_data.size() == 6);
+  EXPECT_EQ(vec_data.size(), 6);
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(ct.data()(i) == vec_data[i]);
+    EXPECT_EQ(ct.data()(i), vec_data[i]);
   }
 }
 
 TEST(CartesianStateTest, CartesianWrenchToStdVector) {
   CartesianWrench cw = CartesianWrench::Random("test");
   std::vector<double> vec_data = cw.to_std_vector();
-  EXPECT_TRUE(vec_data.size() == 6);
+  EXPECT_EQ(vec_data.size(), 6);
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(cw.data()(i) == vec_data[i]);
+    EXPECT_EQ(cw.data()(i), vec_data[i]);
   }
 }
 
 TEST(CartesianStateTest, NegateQuaternion) {
   Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
   Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());
-  EXPECT_TRUE(q.w() == -q2.w());
-  for (int i = 0; i < 3; ++i) EXPECT_TRUE(q.vec()(i) == -q2.vec()(i));
+  EXPECT_EQ(q.w(), -q2.w());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(q.vec()(i), -q2.vec()(i));
+  }
 }
 
 TEST(CartesianStateTest, MultiplyTransformsBothOperators) {
@@ -268,7 +270,9 @@ TEST(CartesianStateTest, MultiplyTransformsSameOrientation) {
   CartesianPose tf2("t2", pos2, rot2, "t1");
   tf1 *= tf2;
   Eigen::Vector3d pos_truth(5, 7, 9);
-  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  for (int i = 0; i < pos_truth.size(); ++i) {
+    EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  }
 }
 
 TEST(CartesianStateTest, MultiplyTransformsDifferentOrientation) {
@@ -281,8 +285,10 @@ TEST(CartesianStateTest, MultiplyTransformsDifferentOrientation) {
   tf1 *= tf2;
   Eigen::Vector3d pos_truth(5, -4, 8);
   Eigen::Quaterniond rot_truth(0., 0., 0., 1.);
-  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
+  for (int i = 0; i < pos_truth.size(); ++i) {
+    EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  }
+  EXPECT_GT(abs(tf1.get_orientation().dot(rot_truth)), 1 - 10E-4);
 }
 
 TEST(CartesianStateTest, TestInverseNullOrientation) {
@@ -294,8 +300,10 @@ TEST(CartesianStateTest, TestInverseNullOrientation) {
   Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
   EXPECT_EQ(tf1.get_name(), "world");
   EXPECT_EQ(tf1.get_reference_frame(), "t1");
-  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
+  for (int i = 0; i < pos_truth.size(); ++i) {
+    EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  }
+  EXPECT_GT(abs(tf1.get_orientation().dot(rot_truth)), 1 - 10E-4);
 }
 
 TEST(CartesianStateTest, TestInverseNonNullOrientation) {
@@ -305,8 +313,10 @@ TEST(CartesianStateTest, TestInverseNonNullOrientation) {
   tf1 = tf1.inverse();
   Eigen::Vector3d pos_truth(-1, -3, 2);
   Eigen::Quaterniond rot_truth(0.70710678, -0.70710678, 0., 0.);
-  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
+  for (int i = 0; i < pos_truth.size(); ++i) {
+    EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  }
+  EXPECT_GT(abs(tf1.get_orientation().dot(rot_truth)), 1 - 10E-4);
 }
 
 TEST(CartesianStateTest, TestMultiplyInverseNonNullOrientation) {
@@ -316,8 +326,10 @@ TEST(CartesianStateTest, TestMultiplyInverseNonNullOrientation) {
   tf1 *= tf1.inverse();
   Eigen::Vector3d pos_truth(0, 0, 0);
   Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
-  for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
-  EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
+  for (int i = 0; i < pos_truth.size(); ++i) {
+    EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
+  }
+  EXPECT_GT(abs(tf1.get_orientation().dot(rot_truth)), 1 - 10E-4);
 }
 
 TEST(CartesianStateTest, MultiplyPoseAndState) {
@@ -325,11 +337,12 @@ TEST(CartesianStateTest, MultiplyPoseAndState) {
   CartesianState s = CartesianPose::Random("test2", "test");
   CartesianState res = p * s;
   CartesianPose res2 = p * static_cast<CartesianPose>(s);
-  for (int i = 0; i < res.get_position().size(); ++i)
+  for (int i = 0; i < res.get_position().size(); ++i) {
     EXPECT_NEAR(res.get_position()(i),
                 res2.get_position()(i),
                 0.00001);
-  EXPECT_TRUE(abs(res.get_orientation().dot(res2.get_orientation())) > 1 - 10E-4);
+  }
+  EXPECT_GT(abs(res.get_orientation().dot(res2.get_orientation())), 1 - 10E-4);
 }
 
 TEST(CartesianStateTest, TestAddTwoPoses) {
@@ -339,7 +352,6 @@ TEST(CartesianStateTest, TestAddTwoPoses) {
   Eigen::Vector3d pos2(1, 0, 0);
   Eigen::Quaterniond rot2(0, 1, 0, 0);
   CartesianPose tf2("t1", pos2, rot2);
-
 }
 
 TEST(CartesianStateTest, TestAddDisplacement) {
@@ -384,12 +396,12 @@ TEST(CartesianStateTest, TestImplicitConversion) {
 TEST(CartesianStateTest, TestVelocityClamping) {
   CartesianTwist vel("test", Eigen::Vector3d(1, -2, 3), Eigen::Vector3d(1, 2, -3));
   vel.clamp(1, 0.5);
-  EXPECT_TRUE(vel.get_linear_velocity().norm() <= 1);
-  EXPECT_TRUE(vel.get_angular_velocity().norm() <= 0.5);
+  EXPECT_LE(vel.get_linear_velocity().norm(), 1);
+  EXPECT_LE(vel.get_angular_velocity().norm(), 0.5);
   vel *= 0.01;
   for (int i = 0; i < 3; ++i) {
-    EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_linear_velocity()(i) == 0);
-    EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_angular_velocity()(i) == 0);
+    EXPECT_EQ(vel.clamped(1, 0.5, 0.1, 0.1).get_linear_velocity()(i), 0);
+    EXPECT_EQ(vel.clamped(1, 0.5, 0.1, 0.1).get_angular_velocity()(i), 0);
   }
 }
 
@@ -399,12 +411,12 @@ TEST(CartesianStateTest, TestPoseDistance) {
   CartesianPose p3("test", Eigen::Vector3d(1, 0, 0), Eigen::Quaterniond(0, 1, 0, 0));
   double d1 = dist(p1, p2);
   double d2 = p1.dist(p2);
-  EXPECT_TRUE(abs(d1 - d2) < 1e-4);
-  EXPECT_TRUE(abs(d1 - 1.0) < 1e-4);
+  EXPECT_LT(abs(d1 - d2), 1e-4);
+  EXPECT_LT(abs(d1 - 1.0), 1e-4);
   double d3 = dist(p1, p3, CartesianStateVariable::ORIENTATION);
-  EXPECT_TRUE(abs(d3 - 3.14159) < 1e10-3);
+  EXPECT_LT(abs(d3 - 3.14159), 1e10 - 3);
   double d4 = dist(p2, p3);
-  EXPECT_TRUE(abs(d3 - d4) < 1e10-3);
+  EXPECT_LT(abs(d3 - d4), 1e10 - 3);
 }
 
 TEST(CartesianStateTest, TestFilter) {
@@ -414,14 +426,16 @@ TEST(CartesianStateTest, TestFilter) {
     CartesianPose temp = tf1;
     double alpha = 0.1;
     tf1 = (1 - alpha) * tf1 + alpha * tf2;
-    EXPECT_TRUE((tf1.get_position() - ((1 - alpha) * temp.get_position() + alpha * tf2.get_position())).norm() < 1e-4);
+    EXPECT_LT((tf1.get_position() - ((1 - alpha) * temp.get_position() + alpha * tf2.get_position())).norm(), 1e-4);
   }
 }
 
 TEST(CartesianStateTest, TestToSTDVector) {
   CartesianPose p = CartesianPose::Random("t1");
   std::vector<double> v = p.to_std_vector();
-  for (unsigned int i = 0; i < 3; ++i) EXPECT_NEAR(p.get_position()(i), v[i], 0.00001);
+  for (unsigned int i = 0; i < 3; ++i) {
+    EXPECT_NEAR(p.get_position()(i), v[i], 0.00001);
+  }
   EXPECT_NEAR(p.get_orientation().w(), v[3], 0.00001);
   EXPECT_NEAR(p.get_orientation().x(), v[4], 0.00001);
   EXPECT_NEAR(p.get_orientation().y(), v[5], 0.00001);
@@ -498,14 +512,14 @@ TEST(CartesianStateTest, TestAccelerationNorms) {
   CartesianState cs = CartesianState::Random("cs");
   // independent variables first
   norms = cs.norms(CartesianStateVariable::LINEAR_ACCELERATION);
-  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_EQ(norms.size(), 1);
   EXPECT_NEAR(norms[0], cs.get_linear_acceleration().norm(), tolerance);
   norms = cs.norms(CartesianStateVariable::ANGULAR_ACCELERATION);
-  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_EQ(norms.size(), 1);
   EXPECT_NEAR(norms[0], cs.get_angular_acceleration().norm(), tolerance);
   // then grouped by two
   norms = cs.norms(CartesianStateVariable::ACCELERATIONS);
-  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_EQ(norms.size(), 2);
   EXPECT_NEAR(norms[0], cs.get_linear_acceleration().norm(), tolerance);
   EXPECT_NEAR(norms[1], cs.get_angular_acceleration().norm(), tolerance);
 }
@@ -516,20 +530,20 @@ TEST(CartesianStateTest, TestWrenchNorms) {
   CartesianState cs = CartesianState::Random("cs");
   // independent variables first
   norms = cs.norms(CartesianStateVariable::FORCE);
-  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_EQ(norms.size(), 1);
   EXPECT_NEAR(norms[0], cs.get_force().norm(), tolerance);
   norms = cs.norms(CartesianStateVariable::TORQUE);
-  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_EQ(norms.size(), 1);
   EXPECT_NEAR(norms[0], cs.get_torque().norm(), tolerance);
   // then grouped by two
   norms = cs.norms(CartesianStateVariable::WRENCH);
-  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_EQ(norms.size(), 2);
   EXPECT_NEAR(norms[0], cs.get_force().norm(), tolerance);
   EXPECT_NEAR(norms[1], cs.get_torque().norm(), tolerance);
   // test with CartesianTwist default variable
   CartesianWrench cw = CartesianWrench::Random("cw");
   std::vector<double> wrench_norms = cw.norms();
-  EXPECT_TRUE(wrench_norms.size() == 2);
+  EXPECT_EQ(wrench_norms.size(), 2);
   EXPECT_NEAR(wrench_norms[0], cw.get_force().norm(), tolerance);
   EXPECT_NEAR(wrench_norms[1], cw.get_torque().norm(), tolerance);
 }

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -112,6 +112,48 @@ TEST(CartesianStateTest, CopyPose) {
   EXPECT_TRUE(pose5.get_wrench().norm() == 0);
 }
 
+TEST(CartesianStateTest, CopyTwist) {
+  CartesianTwist twist1 = CartesianTwist::Random("test");
+  CartesianTwist twist2(twist1);
+  EXPECT_EQ(twist1.get_name(), twist2.get_name());
+  EXPECT_EQ(twist1.get_reference_frame(), twist2.get_reference_frame());
+  EXPECT_TRUE(twist1.data().isApprox(twist2.data()));
+  EXPECT_TRUE(twist2.get_position().norm() == 0);
+  EXPECT_TRUE(twist2.get_orientation().norm() == 1);
+  EXPECT_TRUE(twist2.get_orientation().w() == 1);
+  EXPECT_TRUE(twist2.get_accelerations().norm() == 0);
+  EXPECT_TRUE(twist2.get_wrench().norm() == 0);
+  CartesianTwist twist3 = twist1;
+  EXPECT_EQ(twist1.get_name(), twist3.get_name());
+  EXPECT_EQ(twist1.get_reference_frame(), twist3.get_reference_frame());
+  EXPECT_TRUE(twist1.data().isApprox(twist3.data()));
+  EXPECT_TRUE(twist1.data().isApprox(twist2.data()));
+  EXPECT_TRUE(twist3.get_position().norm() == 0);
+  EXPECT_TRUE(twist3.get_orientation().norm() == 1);
+  EXPECT_TRUE(twist3.get_orientation().w() == 1);
+  EXPECT_TRUE(twist3.get_accelerations().norm() == 0);
+  EXPECT_TRUE(twist3.get_wrench().norm() == 0);
+  // try to change non pose variables prior to the copy, those should be discarded
+  twist1.set_position(Eigen::Vector3d::Random());
+  twist1.set_orientation(Eigen::Quaterniond::UnitRandom());
+  twist1.set_linear_acceleration(Eigen::Vector3d::Random());
+  twist1.set_force(Eigen::Vector3d::Random());
+  CartesianTwist twist4 = twist1;
+  EXPECT_TRUE(twist1.data().isApprox(twist4.data()));
+  EXPECT_TRUE(twist4.get_position().norm() == 0);
+  EXPECT_TRUE(twist4.get_orientation().norm() == 1);
+  EXPECT_TRUE(twist4.get_orientation().w() == 1);
+  EXPECT_TRUE(twist4.get_accelerations().norm() == 0);
+  EXPECT_TRUE(twist4.get_wrench().norm() == 0);
+  // copy a state, only the pose variables should be non 0
+  CartesianTwist twist5 = CartesianState::Random("test");
+  EXPECT_TRUE(twist5.get_position().norm() == 0);
+  EXPECT_TRUE(twist5.get_orientation().norm() == 1);
+  EXPECT_TRUE(twist5.get_orientation().w() == 1);
+  EXPECT_TRUE(twist5.get_accelerations().norm() == 0);
+  EXPECT_TRUE(twist5.get_wrench().norm() == 0);
+}
+
 TEST(CartesianStateTest, GetData) {
   CartesianState cs = CartesianState::Random("test");
   Eigen::VectorXd concatenated_state(25);

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -113,7 +113,6 @@ TEST(CartesianStateTest, CartesianWrenchToStdVector) {
 TEST(CartesianStateTest, NegateQuaternion) {
   Eigen::Quaterniond q = Eigen::Quaterniond::UnitRandom();
   Eigen::Quaterniond q2 = Eigen::Quaterniond(-q.coeffs());
-
   EXPECT_TRUE(q.w() == -q2.w());
   for (int i = 0; i < 3; ++i) EXPECT_TRUE(q.vec()(i) == -q2.vec()(i));
 }
@@ -122,14 +121,11 @@ TEST(CartesianStateTest, MultiplyTransformsBothOperators) {
   Eigen::Vector3d pos1(1, 2, 3);
   Eigen::Quaterniond rot1(1, 0, 0, 0);
   CartesianPose tf1("t1", pos1, rot1);
-
   Eigen::Vector3d pos2(4, 5, 6);
   Eigen::Quaterniond rot2(1, 0, 0, 0);
   CartesianPose tf2("t2", pos2, rot2, "t1");
-
   CartesianPose tf3 = tf1 * tf2;
   tf1 *= tf2;
-
   EXPECT_EQ(tf3.get_name(), "t2");
   for (int i = 0; i < tf1.get_position().size(); ++i)
     EXPECT_NEAR(tf1.get_position()(i),
@@ -141,13 +137,10 @@ TEST(CartesianStateTest, MultiplyTransformsSameOrientation) {
   Eigen::Vector3d pos1(1, 2, 3);
   Eigen::Quaterniond rot1(1, 0, 0, 0);
   CartesianPose tf1("t1", pos1, rot1);
-
   Eigen::Vector3d pos2(4, 5, 6);
   Eigen::Quaterniond rot2(1, 0, 0, 0);
   CartesianPose tf2("t2", pos2, rot2, "t1");
-
   tf1 *= tf2;
-
   Eigen::Vector3d pos_truth(5, 7, 9);
   for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
 }
@@ -156,21 +149,12 @@ TEST(CartesianStateTest, MultiplyTransformsDifferentOrientation) {
   Eigen::Vector3d pos1(1, 2, 3);
   Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
   CartesianPose tf1("t1", pos1, rot1);
-
   Eigen::Vector3d pos2(4, 5, 6);
   Eigen::Quaterniond rot2(0., 0., 0.70710678, 0.70710678);
   CartesianPose tf2("t2", pos2, rot2, "t1");
-
   tf1 *= tf2;
-
   Eigen::Vector3d pos_truth(5, -4, 8);
   Eigen::Quaterniond rot_truth(0., 0., 0., 1.);
-
-  std::cerr << "position" << std::endl;
-  std::cerr << tf1.get_position() << std::endl;
-  std::cerr << "orientation" << std::endl;
-  std::cerr << tf1.get_orientation().coeffs() << std::endl;
-
   for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
   EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
@@ -179,17 +163,9 @@ TEST(CartesianStateTest, TestInverseNullOrientation) {
   Eigen::Vector3d pos1(1, 2, 3);
   Eigen::Quaterniond rot1(1., 0., 0., 0.);
   CartesianPose tf1("t1", pos1, rot1);
-
   tf1 = tf1.inverse();
-
   Eigen::Vector3d pos_truth(-1, -2, -3);
   Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
-
-  std::cerr << "position" << std::endl;
-  std::cerr << tf1.get_position() << std::endl;
-  std::cerr << "orientation" << std::endl;
-  std::cerr << tf1.get_orientation().coeffs() << std::endl;
-
   EXPECT_EQ(tf1.get_name(), "world");
   EXPECT_EQ(tf1.get_reference_frame(), "t1");
   for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
@@ -200,17 +176,9 @@ TEST(CartesianStateTest, TestInverseNonNullOrientation) {
   Eigen::Vector3d pos1(1, 2, 3);
   Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
   CartesianPose tf1("t1", pos1, rot1);
-
   tf1 = tf1.inverse();
-
   Eigen::Vector3d pos_truth(-1, -3, 2);
   Eigen::Quaterniond rot_truth(0.70710678, -0.70710678, 0., 0.);
-
-  std::cerr << "position" << std::endl;
-  std::cerr << tf1.get_position() << std::endl;
-  std::cerr << "orientation" << std::endl;
-  std::cerr << tf1.get_orientation().coeffs() << std::endl;
-
   for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
   EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
@@ -219,17 +187,9 @@ TEST(CartesianStateTest, TestMultiplyInverseNonNullOrientation) {
   Eigen::Vector3d pos1(1, 2, 3);
   Eigen::Quaterniond rot1(0.70710678, 0.70710678, 0., 0.);
   CartesianPose tf1("t1", pos1, rot1);
-
   tf1 *= tf1.inverse();
-
   Eigen::Vector3d pos_truth(0, 0, 0);
   Eigen::Quaterniond rot_truth(1., 0., 0., 0.);
-
-  std::cerr << "position" << std::endl;
-  std::cerr << tf1.get_position() << std::endl;
-  std::cerr << "orientation" << std::endl;
-  std::cerr << tf1.get_orientation().coeffs() << std::endl;
-
   for (int i = 0; i < pos_truth.size(); ++i) EXPECT_NEAR(tf1.get_position()(i), pos_truth(i), 0.00001);
   EXPECT_TRUE(abs(tf1.get_orientation().dot(rot_truth)) > 1 - 10E-4);
 }
@@ -237,10 +197,8 @@ TEST(CartesianStateTest, TestMultiplyInverseNonNullOrientation) {
 TEST(CartesianStateTest, MultiplyPoseAndState) {
   CartesianPose p = CartesianPose::Random("test");
   CartesianState s = CartesianPose::Random("test2", "test");
-
   CartesianState res = p * s;
   CartesianPose res2 = p * static_cast<CartesianPose>(s);
-
   for (int i = 0; i < res.get_position().size(); ++i)
     EXPECT_NEAR(res.get_position()(i),
                 res2.get_position()(i),
@@ -252,85 +210,57 @@ TEST(CartesianStateTest, TestAddTwoPoses) {
   Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
   Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
   CartesianPose tf1("t1", pos1, rot1);
-
   Eigen::Vector3d pos2(1, 0, 0);
   Eigen::Quaterniond rot2(0, 1, 0, 0);
   CartesianPose tf2("t1", pos2, rot2);
 
-  std::cout << tf1 + tf2 << std::endl;
-  std::cout << tf1 - tf2 << std::endl;
 }
 
 TEST(CartesianStateTest, TestAddDisplacement) {
   Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
   Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
   CartesianPose tf1("t1", pos1, rot1);
-
   CartesianTwist vel("t1");
   vel.set_linear_velocity(Eigen::Vector3d(0.1, 0.1, 0.1));
   vel.set_angular_velocity(Eigen::Vector3d(0.1, 0.1, 0));
-
   std::chrono::milliseconds dt1(10);
-  std::cout << tf1 + dt1 * vel << std::endl;
-
   std::chrono::milliseconds dt2(1000);
-  std::cout << tf1 + dt2 * vel << std::endl;
-
   std::chrono::seconds dt3(1);
-  std::cout << tf1 + dt3 * vel << std::endl;
 }
 
 TEST(CartesianStateTest, TestPoseToVelocity) {
   Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
   Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
   CartesianPose tf1("t1", pos1, rot1);
-
   Eigen::Vector3d pos2(1, 0, 0);
   Eigen::Quaterniond rot2(0, 1, 0, 0);
   CartesianPose tf2("t1", pos2, rot2);
-
   std::chrono::seconds dt1(1);
-  std::cout << (tf1 - tf2) / dt1 << std::endl;
-
   std::chrono::seconds dt2(10);
-  std::cout << (tf1 - tf2) / dt2 << std::endl;
-
   std::chrono::milliseconds dt3(100);
-  std::cout << (tf1 - tf2) / dt3 << std::endl;
 }
 
 TEST(CartesianStateTest, TestTwistStateMultiplication) {
   CartesianTwist twist = CartesianTwist::Random("test");
   CartesianState state = CartesianTwist::Random("test2", "test");
-
-  std::cout << twist * state << std::endl;
 }
 
 TEST(CartesianStateTest, TestImplicitConversion) {
   Eigen::Vector3d pos1 = Eigen::Vector3d::Zero();
   Eigen::Quaterniond rot1 = Eigen::Quaterniond::Identity();
   CartesianPose tf1("t1", pos1, rot1);
-
   CartesianTwist vel("t1");
   vel.set_linear_velocity(Eigen::Vector3d(0.1, 0.1, 0.1));
   vel.set_angular_velocity(Eigen::Vector3d(0.1, 0.1, 0));
-
   tf1 += vel;
-
-  std::cout << tf1 << std::endl;
 }
 
 TEST(CartesianStateTest, TestVelocityClamping) {
   CartesianTwist vel("test", Eigen::Vector3d(1, -2, 3), Eigen::Vector3d(1, 2, -3));
   vel.clamp(1, 0.5);
-
-  std::cout << vel << std::endl;
   EXPECT_TRUE(vel.get_linear_velocity().norm() <= 1);
   EXPECT_TRUE(vel.get_angular_velocity().norm() <= 0.5);
-
   vel *= 0.01;
-
-  std::cout << vel.clamped(1, 0.5, 0.1, 0.1) << std::endl;
   for (int i = 0; i < 3; ++i) {
     EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_linear_velocity()(i) == 0);
     EXPECT_TRUE(vel.clamped(1, 0.5, 0.1, 0.1).get_angular_velocity()(i) == 0);
@@ -341,15 +271,12 @@ TEST(CartesianStateTest, TestPoseDistance) {
   CartesianPose p1("test", Eigen::Vector3d::Zero());
   CartesianPose p2("test", Eigen::Vector3d(1, 0, 0));
   CartesianPose p3("test", Eigen::Vector3d(1, 0, 0), Eigen::Quaterniond(0, 1, 0, 0));
-
   double d1 = dist(p1, p2);
   double d2 = p1.dist(p2);
   EXPECT_TRUE(abs(d1 - d2) < 1e-4);
   EXPECT_TRUE(abs(d1 - 1.0) < 1e-4);
-
   double d3 = dist(p1, p3, CartesianStateVariable::ORIENTATION);
   EXPECT_TRUE(abs(d3 - 3.14159) < 1e10-3);
-
   double d4 = dist(p2, p3);
   EXPECT_TRUE(abs(d3 - d4) < 1e10-3);
 }
@@ -357,16 +284,12 @@ TEST(CartesianStateTest, TestPoseDistance) {
 TEST(CartesianStateTest, TestFilter) {
   CartesianPose tf1("t1", Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
   CartesianPose tf2("t1", Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
-
   for (int i = 0; i < 1000; ++i) {
     CartesianPose temp = tf1;
-
     double alpha = 0.1;
     tf1 = (1 - alpha) * tf1 + alpha * tf2;
     EXPECT_TRUE((tf1.get_position() - ((1 - alpha) * temp.get_position() + alpha * tf2.get_position())).norm() < 1e-4);
   }
-
-  //EXPECT_TRUE(dist(tf1, tf2) < 1e-4);
 }
 
 TEST(CartesianStateTest, TestToSTDVector) {
@@ -393,7 +316,6 @@ TEST(CartesianStateTest, TestAllNorms) {
   EXPECT_NEAR(norms[5], cs.get_angular_acceleration().norm(), tolerance);
   EXPECT_NEAR(norms[6], cs.get_force().norm(), tolerance);
   EXPECT_NEAR(norms[7], cs.get_torque().norm(), tolerance);
-
 }
 
 TEST(CartesianStateTest, TestPoseNorms) {


### PR DESCRIPTION
This PR addresses issue #99 for the `CartesianState` and its derivatives. I tried to avoid code duplication as much as possible. It is probably not optimal as it first copy all the state variables, set them to 0 and then copy again the one we are interested in. We could probably avoid one operation but the code would be more verbose. I will implement the same for `JointState` in a subsequent PR.