### PR TITLE
 Correct copy constructor from derived Joint classes 

### DIFF
--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -20,7 +20,7 @@ public:
   /**
    * Empty constructor
    */
-  explicit JointPositions();
+  explicit JointPositions() = default;
 
   /**
    * @brief Constructor with name and number of joints provided

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -117,7 +117,7 @@ public:
   /**
    * @brief Copy constructor of a JointState
    */
-  JointState(const JointState& state);
+  JointState(const JointState& state) = default;
 
   /**
    * @brief Constructor for the zero JointState
@@ -150,6 +150,13 @@ public:
    * @return JointState with random values in all attributes
    */
   static JointState Random(const std::string& robot_name, const std::vector<std::string>& joint_names);
+
+  /**
+   * @brief Swap the values of the two JointState
+   * @param state1 JointState to be swapped with 2
+   * @param state2 JointState to be swapped with 1
+   */
+  friend void swap(JointState& state1, JointState& state2);
 
   /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
@@ -443,6 +450,20 @@ public:
   virtual void from_std_vector(const std::vector<double>& value);
 };
 
+inline void swap(JointState& state1, JointState& state2) {
+  swap(static_cast<State&>(state1), static_cast<State&>(state2));
+  std::swap(state1.positions_, state2.positions_);
+  std::swap(state1.velocities_, state2.velocities_);
+  std::swap(state1.accelerations_, state2.accelerations_);
+  std::swap(state1.torques_, state2.torques_);
+}
+
+inline JointState& JointState::operator=(const JointState& state) {
+  JointState tmp(state);
+  swap(*this, tmp);
+  return *this;
+}
+
 inline Eigen::VectorXd JointState::get_all_state_variables() const {
   Eigen::VectorXd all_fields(this->get_size() * 4);
   all_fields << this->get_positions(), this->get_velocities(), this->get_accelerations(), this->get_torques();
@@ -468,13 +489,6 @@ inline void JointState::set_all_state_variables(const Eigen::VectorXd& new_value
   this->set_velocities(new_values.segment(this->get_size(), this->get_size()));
   this->set_accelerations(new_values.segment(2 * this->get_size(), this->get_size()));
   this->set_torques(new_values.segment(3 * this->get_size(), this->get_size()));
-}
-
-inline JointState& JointState::operator=(const JointState& state) {
-  State::operator=(state);
-  this->set_names(state.get_names());
-  this->set_all_state_variables(state.get_all_state_variables());
-  return (*this);
 }
 
 inline bool JointState::is_compatible(const State& state) const {

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -452,6 +452,7 @@ public:
 
 inline void swap(JointState& state1, JointState& state2) {
   swap(static_cast<State&>(state1), static_cast<State&>(state2));
+  std::swap(state1.names_, state2.names_);
   std::swap(state1.positions_, state2.positions_);
   std::swap(state1.velocities_, state2.velocities_);
   std::swap(state1.accelerations_, state2.accelerations_);

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -479,10 +479,10 @@ inline JointState& JointState::operator=(const JointState& state) {
 
 inline bool JointState::is_compatible(const State& state) const {
   bool compatible = this->State::is_compatible(state);
-  compatible = compatible && (this->names_.size() == static_cast<const JointState&>(state).names_.size());
+  compatible = compatible && (this->names_.size() == dynamic_cast<const JointState&>(state).names_.size());
   if (compatible) {
     for (unsigned int i = 0; i < this->names_.size(); ++i) {
-      compatible = (compatible && this->names_[i] == static_cast<const JointState&>(state).names_[i]);
+      compatible = (compatible && this->names_[i] == dynamic_cast<const JointState&>(state).names_[i]);
     }
   }
   return compatible;

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -48,11 +48,11 @@ double dist(const JointState& s1, const JointState& s2,
  */
 class JointState : public State {
 private:
-  std::vector<std::string> names;///< names of the joints
-  Eigen::VectorXd positions;     ///< joints positions
-  Eigen::VectorXd velocities;    ///< joints velocities
-  Eigen::VectorXd accelerations; ///< joints accelerations
-  Eigen::VectorXd torques;       ///< joints torques
+  std::vector<std::string> names_;///< names of the joints
+  Eigen::VectorXd positions_;     ///< joints positions
+  Eigen::VectorXd velocities_;    ///< joints velocities
+  Eigen::VectorXd accelerations_; ///< joints accelerations
+  Eigen::VectorXd torques_;       ///< joints torques
 
   /**
    * @brief Getter of all the state variables (positions, velocities, accelerations and torques)
@@ -479,82 +479,82 @@ inline JointState& JointState::operator=(const JointState& state) {
 
 inline bool JointState::is_compatible(const State& state) const {
   bool compatible = this->State::is_compatible(state);
-  compatible = compatible && (this->names.size() == static_cast<const JointState&>(state).names.size());
+  compatible = compatible && (this->names_.size() == static_cast<const JointState&>(state).names_.size());
   if (compatible) {
-    for (unsigned int i = 0; i < this->names.size(); ++i) {
-      compatible = (compatible && this->names[i] == static_cast<const JointState&>(state).names[i]);
+    for (unsigned int i = 0; i < this->names_.size(); ++i) {
+      compatible = (compatible && this->names_[i] == static_cast<const JointState&>(state).names_[i]);
     }
   }
   return compatible;
 }
 
 inline unsigned int JointState::get_size() const {
-  return this->names.size();
+  return this->names_.size();
 }
 
 inline const std::vector<std::string>& JointState::get_names() const {
-  return this->names;
+  return this->names_;
 }
 
 inline void JointState::set_names(unsigned int nb_joints) {
-  this->names.resize(nb_joints);
+  this->names_.resize(nb_joints);
   for (unsigned int i = 0; i < nb_joints; ++i) {
-    this->names[i] = "joint" + std::to_string(i);
+    this->names_[i] = "joint" + std::to_string(i);
   }
   this->initialize();
 }
 
 inline void JointState::set_names(const std::vector<std::string>& names) {
-  this->names = names;
+  this->names_ = names;
   this->initialize();
 }
 
 inline const Eigen::VectorXd& JointState::get_positions() const {
-  return this->positions;
+  return this->positions_;
 }
 
 inline void JointState::set_positions(const Eigen::VectorXd& positions) {
-  this->set_state_variable(this->positions, positions);
+  this->set_state_variable(this->positions_, positions);
 }
 
 inline void JointState::set_positions(const std::vector<double>& positions) {
-  this->set_state_variable(this->positions, positions);
+  this->set_state_variable(this->positions_, positions);
 }
 
 inline const Eigen::VectorXd& JointState::get_velocities() const {
-  return this->velocities;
+  return this->velocities_;
 }
 
 inline void JointState::set_velocities(const Eigen::VectorXd& velocities) {
-  this->set_state_variable(this->velocities, velocities);
+  this->set_state_variable(this->velocities_, velocities);
 }
 
 inline void JointState::set_velocities(const std::vector<double>& velocities) {
-  this->set_state_variable(this->velocities, velocities);
+  this->set_state_variable(this->velocities_, velocities);
 }
 
 inline const Eigen::VectorXd& JointState::get_accelerations() const {
-  return this->accelerations;
+  return this->accelerations_;
 }
 
 inline void JointState::set_accelerations(const Eigen::VectorXd& accelerations) {
-  this->set_state_variable(this->accelerations, accelerations);
+  this->set_state_variable(this->accelerations_, accelerations);
 }
 
 inline void JointState::set_accelerations(const std::vector<double>& accelerations) {
-  this->set_state_variable(this->accelerations, accelerations);
+  this->set_state_variable(this->accelerations_, accelerations);
 }
 
 inline const Eigen::VectorXd& JointState::get_torques() const {
-  return this->torques;
+  return this->torques_;
 }
 
 inline void JointState::set_torques(const Eigen::VectorXd& torques) {
-  this->set_state_variable(this->torques, torques);
+  this->set_state_variable(this->torques_, torques);
 }
 
 inline void JointState::set_torques(const std::vector<double>& torques) {
-  this->set_state_variable(this->torques, torques);
+  this->set_state_variable(this->torques_, torques);
 }
 
 inline Eigen::VectorXd JointState::get_state_variable(const JointStateVariable& state_variable_type) const {

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -17,7 +17,7 @@ public:
   /**
    * Empty constructor
    */
-  explicit JointTorques();
+  explicit JointTorques() = default;
 
   /**
    * @brief Constructor with name and number of joints provided

--- a/source/state_representation/include/state_representation/robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/robot/JointVelocities.hpp
@@ -20,7 +20,7 @@ public:
   /**
    * Empty constructor
    */
-  explicit JointVelocities();
+  explicit JointVelocities() = default;
 
   /**
    * @brief Constructor with name and number of joints provided

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -5,8 +5,6 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-JointPositions::JointPositions() {}
-
 JointPositions::JointPositions(const std::string& robot_name, unsigned int nb_joints) :
     JointState(robot_name, nb_joints) {}
 

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -21,11 +21,15 @@ JointPositions::JointPositions(const std::string& robot_name, const std::vector<
   this->set_positions(positions);
 }
 
-JointPositions::JointPositions(const JointPositions& positions) : JointState(positions) {}
+JointPositions::JointPositions(const JointState& state) : JointState(state) {
+  // set all the state variables to 0 except positions
+  this->set_zero();
+  this->set_positions(state.get_positions());
+}
 
-JointPositions::JointPositions(const JointState& state) : JointState(state) {}
+JointPositions::JointPositions(const JointPositions& positions) : JointPositions(static_cast<const JointState&>(positions)) {}
 
-JointPositions::JointPositions(const JointVelocities& velocities) : JointState(std::chrono::seconds(1) * velocities) {}
+JointPositions::JointPositions(const JointVelocities& velocities) : JointPositions(std::chrono::seconds(1) * velocities) {}
 
 JointPositions JointPositions::Zero(const std::string& robot_name, unsigned int nb_joints) {
   return JointState::Zero(robot_name, nb_joints);

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -18,14 +18,6 @@ JointState::JointState(const std::string& robot_name, const std::vector<std::str
   this->set_names(joint_names);
 }
 
-JointState::JointState(const JointState& state) :
-    State(state),
-    names_(state.names_),
-    positions_(state.positions_),
-    velocities_(state.velocities_),
-    accelerations_(state.accelerations_),
-    torques_(state.torques_) {}
-
 void JointState::initialize() {
   this->State::initialize();
   // resize

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -9,7 +9,7 @@ JointState::JointState() : State(StateType::JOINTSTATE) {
 }
 
 JointState::JointState(const std::string& robot_name, unsigned int nb_joints) :
-    State(StateType::JOINTSTATE, robot_name), names(nb_joints) {
+    State(StateType::JOINTSTATE, robot_name), names_(nb_joints) {
   this->set_names(nb_joints);
 }
 
@@ -20,29 +20,29 @@ JointState::JointState(const std::string& robot_name, const std::vector<std::str
 
 JointState::JointState(const JointState& state) :
     State(state),
-    names(state.names),
-    positions(state.positions),
-    velocities(state.velocities),
-    accelerations(state.accelerations),
-    torques(state.torques) {}
+    names_(state.names_),
+    positions_(state.positions_),
+    velocities_(state.velocities_),
+    accelerations_(state.accelerations_),
+    torques_(state.torques_) {}
 
 void JointState::initialize() {
   this->State::initialize();
   // resize
-  unsigned int size = this->names.size();
-  this->positions.resize(size);
-  this->velocities.resize(size);
-  this->accelerations.resize(size);
-  this->torques.resize(size);
+  unsigned int size = this->names_.size();
+  this->positions_.resize(size);
+  this->velocities_.resize(size);
+  this->accelerations_.resize(size);
+  this->torques_.resize(size);
   // set to zeros
   this->set_zero();
 }
 
 void JointState::set_zero() {
-  this->positions.setZero();
-  this->velocities.setZero();
-  this->accelerations.setZero();
-  this->torques.setZero();
+  this->positions_.setZero();
+  this->velocities_.setZero();
+  this->accelerations_.setZero();
+  this->torques_.setZero();
 }
 
 JointState JointState::Zero(const std::string& robot_name, unsigned int nb_joints) {
@@ -255,19 +255,19 @@ std::ostream& operator<<(std::ostream& os, const JointState& state) {
   } else {
     os << state.get_name() << " JointState" << std::endl;
     os << "names: [";
-    for (auto& n : state.names) { os << n << ", "; }
+    for (auto& n : state.names_) { os << n << ", "; }
     os << "]" << std::endl;
     os << "positions: [";
-    for (unsigned int i = 0; i < state.positions.size(); ++i) { os << state.positions(i) << ", "; }
+    for (unsigned int i = 0; i < state.positions_.size(); ++i) { os << state.positions_(i) << ", "; }
     os << "]" << std::endl;
     os << "velocities: [";
-    for (unsigned int i = 0; i < state.velocities.size(); ++i) { os << state.velocities(i) << ", "; }
+    for (unsigned int i = 0; i < state.velocities_.size(); ++i) { os << state.velocities_(i) << ", "; }
     os << "]" << std::endl;
     os << "accelerations: [";
-    for (unsigned int i = 0; i < state.accelerations.size(); ++i) { os << state.accelerations(i) << ", "; }
+    for (unsigned int i = 0; i < state.accelerations_.size(); ++i) { os << state.accelerations_(i) << ", "; }
     os << "]" << std::endl;
     os << "torques: [";
-    for (unsigned int i = 0; i < state.torques.size(); ++i) { os << state.torques(i) << ", "; }
+    for (unsigned int i = 0; i < state.torques_.size(); ++i) { os << state.torques_(i) << ", "; }
     os << "]";
   }
   return os;

--- a/source/state_representation/src/robot/JointTorques.cpp
+++ b/source/state_representation/src/robot/JointTorques.cpp
@@ -5,8 +5,6 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-JointTorques::JointTorques() {}
-
 JointTorques::JointTorques(const std::string& robot_name, unsigned int nb_joints) : JointState(robot_name, nb_joints) {}
 
 JointTorques::JointTorques(const std::string& robot_name, const Eigen::VectorXd& torques) :

--- a/source/state_representation/src/robot/JointTorques.cpp
+++ b/source/state_representation/src/robot/JointTorques.cpp
@@ -20,9 +20,13 @@ JointTorques::JointTorques(const std::string& robot_name, const std::vector<std:
   this->set_torques(torques);
 }
 
-JointTorques::JointTorques(const JointTorques& torques) : JointState(torques) {}
+JointTorques::JointTorques(const JointState& state) : JointState(state) {
+  // set all the state variables to 0 except torques
+  this->set_zero();
+  this->set_torques(state.get_torques());
+}
 
-JointTorques::JointTorques(const JointState& state) : JointState(state) {}
+JointTorques::JointTorques(const JointTorques& torques) : JointTorques(static_cast<const JointState&>(torques)) {}
 
 JointTorques JointTorques::Zero(const std::string& robot_name, unsigned int nb_joints) {
   return JointState::Zero(robot_name, nb_joints);

--- a/source/state_representation/src/robot/JointVelocities.cpp
+++ b/source/state_representation/src/robot/JointVelocities.cpp
@@ -5,8 +5,6 @@
 using namespace state_representation::exceptions;
 
 namespace state_representation {
-JointVelocities::JointVelocities() {}
-
 JointVelocities::JointVelocities(const std::string& robot_name, unsigned int nb_joints) :
     JointState(robot_name, nb_joints) {}
 

--- a/source/state_representation/src/robot/JointVelocities.cpp
+++ b/source/state_representation/src/robot/JointVelocities.cpp
@@ -21,11 +21,15 @@ JointVelocities::JointVelocities(const std::string& robot_name, const std::vecto
   this->set_velocities(velocities);
 }
 
-JointVelocities::JointVelocities(const JointVelocities& velocities) : JointState(velocities) {}
+JointVelocities::JointVelocities(const JointState& state) : JointState(state) {
+  // set all the state variables to 0 except velocities
+  this->set_zero();
+  this->set_velocities(state.get_velocities());
+}
 
-JointVelocities::JointVelocities(const JointState& state) : JointState(state) {}
+JointVelocities::JointVelocities(const JointVelocities& velocities) : JointVelocities(static_cast<const JointState&>(velocities)) {}
 
-JointVelocities::JointVelocities(const JointPositions& positions) : JointState(positions / std::chrono::seconds(1)) {}
+JointVelocities::JointVelocities(const JointPositions& positions) : JointVelocities(positions / std::chrono::seconds(1)) {}
 
 JointVelocities JointVelocities::Zero(const std::string& robot_name, unsigned int nb_joints) {
   return JointState::Zero(robot_name, nb_joints);

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -97,9 +97,9 @@ TEST(CartesianStateTest, CopyPose) {
   EXPECT_EQ(pose3.get_accelerations().norm(), 0);
   EXPECT_EQ(pose3.get_wrench().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  pose1.set_linear_velocity(Eigen::Vector3d::Random());
-  pose1.set_linear_acceleration(Eigen::Vector3d::Random());
-  pose1.set_force(Eigen::Vector3d::Random());
+  pose1.set_twist(Eigen::VectorXd::Random(6));
+  pose1.set_accelerations(Eigen::VectorXd::Random(6));
+  pose1.set_wrench(Eigen::VectorXd::Random(6));
   CartesianPose pose4 = pose1;
   EXPECT_TRUE(pose1.data().isApprox(pose4.data()));
   EXPECT_EQ(pose4.get_twist().norm(), 0);
@@ -133,10 +133,9 @@ TEST(CartesianStateTest, CopyTwist) {
   EXPECT_EQ(twist3.get_accelerations().norm(), 0);
   EXPECT_EQ(twist3.get_wrench().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  twist1.set_position(Eigen::Vector3d::Random());
-  twist1.set_orientation(Eigen::Quaterniond::UnitRandom());
-  twist1.set_linear_acceleration(Eigen::Vector3d::Random());
-  twist1.set_force(Eigen::Vector3d::Random());
+  twist1.set_pose(Eigen::VectorXd::Random(7));
+  twist1.set_accelerations(Eigen::VectorXd::Random(6));
+  twist1.set_wrench(Eigen::VectorXd::Random(6));
   CartesianTwist twist4 = twist1;
   EXPECT_TRUE(twist1.data().isApprox(twist4.data()));
   EXPECT_EQ(twist4.get_position().norm(), 0);
@@ -174,10 +173,9 @@ TEST(CartesianStateTest, CopyWrench) {
   EXPECT_EQ(wrench3.get_twist().norm(), 0);
   EXPECT_EQ(wrench3.get_accelerations().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  wrench1.set_position(Eigen::Vector3d::Random());
-  wrench1.set_orientation(Eigen::Quaterniond::UnitRandom());
-  wrench1.set_linear_velocity(Eigen::Vector3d::Random());
-  wrench1.set_linear_acceleration(Eigen::Vector3d::Random());
+  wrench1.set_pose(Eigen::VectorXd::Random(7));
+  wrench1.set_twist(Eigen::VectorXd::Random(6));
+  wrench1.set_accelerations(Eigen::VectorXd::Random(6));
   CartesianWrench wrench4 = wrench1;
   EXPECT_TRUE(wrench1.data().isApprox(wrench4.data()));
   EXPECT_EQ(wrench4.get_position().norm(), 0);

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -10,86 +10,86 @@ TEST(JointStateTest, ZeroInitialization) {
   // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(zero.is_empty());
   // all data should be zero
-  EXPECT_TRUE(zero.data().norm() == 0);
+  EXPECT_EQ(zero.data().norm(), 0);
   // same for the second initializer
   state_representation::JointState zero2 = state_representation::JointState::Zero("test",
                                                                                   std::vector<std::string>{"j0", "j1"});
   // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(zero2.is_empty());
   // all data should be zero
-  EXPECT_TRUE(zero2.data().norm() == 0);
+  EXPECT_EQ(zero2.data().norm(), 0);
 }
 
 TEST(JointStateTest, RandomStateInitialization) {
   state_representation::JointState random = state_representation::JointState::Random("test", 3);
   // all data should be random (non 0)
-  EXPECT_TRUE(random.get_positions().norm() > 0);
-  EXPECT_TRUE(random.get_velocities().norm() > 0);
-  EXPECT_TRUE(random.get_accelerations().norm() > 0);
-  EXPECT_TRUE(random.get_torques().norm() > 0);
+  EXPECT_GT(random.get_positions().norm(), 0);
+  EXPECT_GT(random.get_velocities().norm(), 0);
+  EXPECT_GT(random.get_accelerations().norm(), 0);
+  EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
   state_representation::JointState random2 =
       state_representation::JointState::Random("test",
                                                std::vector<std::string>{"j0", "j1"});
   // all data should be random (non 0)
-  EXPECT_TRUE(random2.get_positions().norm() > 0);
-  EXPECT_TRUE(random2.get_velocities().norm() > 0);
-  EXPECT_TRUE(random2.get_accelerations().norm() > 0);
-  EXPECT_TRUE(random2.get_torques().norm() > 0);
+  EXPECT_GT(random2.get_positions().norm(), 0);
+  EXPECT_GT(random2.get_velocities().norm(), 0);
+  EXPECT_GT(random2.get_accelerations().norm(), 0);
+  EXPECT_GT(random2.get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, RandomPositionsInitialization) {
   state_representation::JointPositions random = state_representation::JointPositions::Random("test", 3);
   // only position should be random
-  EXPECT_TRUE(random.get_positions().norm() > 0);
-  EXPECT_TRUE(random.get_velocities().norm() == 0);
-  EXPECT_TRUE(random.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random.get_torques().norm() == 0);
+  EXPECT_GT(random.get_positions().norm(), 0);
+  EXPECT_EQ(random.get_velocities().norm(), 0);
+  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_EQ(random.get_torques().norm(), 0);
   // same for the second initializer
   state_representation::JointPositions random2 =
       state_representation::JointPositions::Random("test",
                                                    std::vector<std::string>{"j0", "j1"});
   // only position should be random
-  EXPECT_TRUE(random2.get_positions().norm() > 0);
-  EXPECT_TRUE(random2.get_velocities().norm() == 0);
-  EXPECT_TRUE(random2.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random2.get_torques().norm() == 0);
+  EXPECT_GT(random2.get_positions().norm(), 0);
+  EXPECT_EQ(random2.get_velocities().norm(), 0);
+  EXPECT_EQ(random2.get_accelerations().norm(), 0);
+  EXPECT_EQ(random2.get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, RandomVelocitiesInitialization) {
   state_representation::JointVelocities random = state_representation::JointVelocities::Random("test", 3);
   // only velocities should be random
-  EXPECT_TRUE(random.get_positions().norm() == 0);
-  EXPECT_TRUE(random.get_velocities().norm() > 0);
-  EXPECT_TRUE(random.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random.get_torques().norm() == 0);
+  EXPECT_EQ(random.get_positions().norm(), 0);
+  EXPECT_GT(random.get_velocities().norm(), 0);
+  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_EQ(random.get_torques().norm(), 0);
   // same for the second initializer
   state_representation::JointVelocities random2 =
       state_representation::JointVelocities::Random("test",
                                                     std::vector<std::string>{"j0", "j1"});
   // only velocities should be random
-  EXPECT_TRUE(random2.get_positions().norm() == 0);
-  EXPECT_TRUE(random2.get_velocities().norm() > 0);
-  EXPECT_TRUE(random2.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random2.get_torques().norm() == 0);
+  EXPECT_EQ(random2.get_positions().norm(), 0);
+  EXPECT_GT(random2.get_velocities().norm(), 0);
+  EXPECT_EQ(random2.get_accelerations().norm(), 0);
+  EXPECT_EQ(random2.get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, RandomTorquesInitialization) {
   state_representation::JointTorques random = state_representation::JointTorques::Random("test", 3);
   // only torques should be random
-  EXPECT_TRUE(random.get_positions().norm() == 0);
-  EXPECT_TRUE(random.get_velocities().norm() == 0);
-  EXPECT_TRUE(random.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random.get_torques().norm() > 0);
+  EXPECT_EQ(random.get_positions().norm(), 0);
+  EXPECT_EQ(random.get_velocities().norm(), 0);
+  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
   state_representation::JointTorques random2 =
       state_representation::JointTorques::Random("test",
                                                  std::vector<std::string>{"j0", "j1"});
   // only torques should be random
-  EXPECT_TRUE(random2.get_positions().norm() == 0);
-  EXPECT_TRUE(random2.get_velocities().norm() == 0);
-  EXPECT_TRUE(random2.get_accelerations().norm() == 0);
-  EXPECT_TRUE(random2.get_torques().norm() > 0);
+  EXPECT_EQ(random2.get_positions().norm(), 0);
+  EXPECT_EQ(random2.get_velocities().norm(), 0);
+  EXPECT_EQ(random2.get_accelerations().norm(), 0);
+  EXPECT_GT(random2.get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, GetData) {
@@ -103,34 +103,34 @@ TEST(JointStateTest, JointStateToStdVector) {
   state_representation::JointState js = state_representation::JointState::Random("test_robot", 4);
   std::vector<double> vec_data = js.to_std_vector();
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(js.data()(i) == vec_data[i]);
+    EXPECT_EQ(js.data()(i), vec_data[i]);
   }
 }
 
 TEST(JointStateTest, JointPositionsToStdVector) {
   state_representation::JointPositions jp = state_representation::JointPositions::Random("test_robot", 4);
   std::vector<double> vec_data = jp.to_std_vector();
-  EXPECT_TRUE(vec_data.size() == jp.get_size());
+  EXPECT_EQ(vec_data.size(), jp.get_size());
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(jp.get_positions()(i) == vec_data[i]);
+    EXPECT_EQ(jp.get_positions()(i), vec_data[i]);
   }
 }
 
 TEST(JointStateTest, JointVelocitiesToStdVector) {
   state_representation::JointVelocities jv = state_representation::JointVelocities::Random("test_robot", 4);
   std::vector<double> vec_data = jv.to_std_vector();
-  EXPECT_TRUE(vec_data.size() == jv.get_size());
+  EXPECT_EQ(vec_data.size(), jv.get_size());
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(jv.get_velocities()(i) == vec_data[i]);
+    EXPECT_EQ(jv.get_velocities()(i), vec_data[i]);
   }
 }
 
 TEST(JointStateTest, JointTorquesToStdVector) {
   state_representation::JointTorques jt = state_representation::JointTorques::Random("test_robot", 4);
   std::vector<double> vec_data = jt.to_std_vector();
-  EXPECT_TRUE(vec_data.size() == jt.get_size());
+  EXPECT_EQ(vec_data.size(), jt.get_size());
   for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_TRUE(jt.get_torques()(i) == vec_data[i]);
+    EXPECT_EQ(jt.get_torques()(i), vec_data[i]);
   }
 }
 

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -5,15 +5,17 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+using namespace state_representation;
+
 TEST(JointStateTest, ZeroInitialization) {
-  state_representation::JointState zero = state_representation::JointState::Zero("test", 3);
+  JointState zero = JointState::Zero("test", 3);
   // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(zero.is_empty());
   // all data should be zero
   EXPECT_EQ(zero.data().norm(), 0);
   // same for the second initializer
-  state_representation::JointState zero2 = state_representation::JointState::Zero("test",
-                                                                                  std::vector<std::string>{"j0", "j1"});
+  JointState zero2 = JointState::Zero("test",
+                                      std::vector<std::string>{"j0", "j1"});
   // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(zero2.is_empty());
   // all data should be zero
@@ -21,16 +23,16 @@ TEST(JointStateTest, ZeroInitialization) {
 }
 
 TEST(JointStateTest, RandomStateInitialization) {
-  state_representation::JointState random = state_representation::JointState::Random("test", 3);
+  JointState random = JointState::Random("test", 3);
   // all data should be random (non 0)
   EXPECT_GT(random.get_positions().norm(), 0);
   EXPECT_GT(random.get_velocities().norm(), 0);
   EXPECT_GT(random.get_accelerations().norm(), 0);
   EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
-  state_representation::JointState random2 =
-      state_representation::JointState::Random("test",
-                                               std::vector<std::string>{"j0", "j1"});
+  JointState random2 =
+      JointState::Random("test",
+                         std::vector<std::string>{"j0", "j1"});
   // all data should be random (non 0)
   EXPECT_GT(random2.get_positions().norm(), 0);
   EXPECT_GT(random2.get_velocities().norm(), 0);
@@ -39,16 +41,16 @@ TEST(JointStateTest, RandomStateInitialization) {
 }
 
 TEST(JointStateTest, RandomPositionsInitialization) {
-  state_representation::JointPositions random = state_representation::JointPositions::Random("test", 3);
+  JointPositions random = JointPositions::Random("test", 3);
   // only position should be random
   EXPECT_GT(random.get_positions().norm(), 0);
   EXPECT_EQ(random.get_velocities().norm(), 0);
   EXPECT_EQ(random.get_accelerations().norm(), 0);
   EXPECT_EQ(random.get_torques().norm(), 0);
   // same for the second initializer
-  state_representation::JointPositions random2 =
-      state_representation::JointPositions::Random("test",
-                                                   std::vector<std::string>{"j0", "j1"});
+  JointPositions random2 =
+      JointPositions::Random("test",
+                             std::vector<std::string>{"j0", "j1"});
   // only position should be random
   EXPECT_GT(random2.get_positions().norm(), 0);
   EXPECT_EQ(random2.get_velocities().norm(), 0);
@@ -57,16 +59,16 @@ TEST(JointStateTest, RandomPositionsInitialization) {
 }
 
 TEST(JointStateTest, RandomVelocitiesInitialization) {
-  state_representation::JointVelocities random = state_representation::JointVelocities::Random("test", 3);
+  JointVelocities random = JointVelocities::Random("test", 3);
   // only velocities should be random
   EXPECT_EQ(random.get_positions().norm(), 0);
   EXPECT_GT(random.get_velocities().norm(), 0);
   EXPECT_EQ(random.get_accelerations().norm(), 0);
   EXPECT_EQ(random.get_torques().norm(), 0);
   // same for the second initializer
-  state_representation::JointVelocities random2 =
-      state_representation::JointVelocities::Random("test",
-                                                    std::vector<std::string>{"j0", "j1"});
+  JointVelocities random2 =
+      JointVelocities::Random("test",
+                              std::vector<std::string>{"j0", "j1"});
   // only velocities should be random
   EXPECT_EQ(random2.get_positions().norm(), 0);
   EXPECT_GT(random2.get_velocities().norm(), 0);
@@ -75,16 +77,16 @@ TEST(JointStateTest, RandomVelocitiesInitialization) {
 }
 
 TEST(JointStateTest, RandomTorquesInitialization) {
-  state_representation::JointTorques random = state_representation::JointTorques::Random("test", 3);
+  JointTorques random = JointTorques::Random("test", 3);
   // only torques should be random
   EXPECT_EQ(random.get_positions().norm(), 0);
   EXPECT_EQ(random.get_velocities().norm(), 0);
   EXPECT_EQ(random.get_accelerations().norm(), 0);
   EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
-  state_representation::JointTorques random2 =
-      state_representation::JointTorques::Random("test",
-                                                 std::vector<std::string>{"j0", "j1"});
+  JointTorques random2 =
+      JointTorques::Random("test",
+                           std::vector<std::string>{"j0", "j1"});
   // only torques should be random
   EXPECT_EQ(random2.get_positions().norm(), 0);
   EXPECT_EQ(random2.get_velocities().norm(), 0);
@@ -92,15 +94,115 @@ TEST(JointStateTest, RandomTorquesInitialization) {
   EXPECT_GT(random2.get_torques().norm(), 0);
 }
 
+TEST(JointStateTest, CopyState) {
+  JointState state1 = JointState::Random("test", 7);
+  JointState state2(state1);
+  EXPECT_EQ(state1.get_name(), state2.get_name());
+  EXPECT_TRUE(state1.data().isApprox(state2.data()));
+  JointState state3 = state1;
+  EXPECT_EQ(state1.get_name(), state3.get_name());
+  EXPECT_TRUE(state1.data().isApprox(state3.data()));
+}
+
+TEST(JointStateTest, CopyPosisitions) {
+  JointPositions positions1 = JointPositions::Random("test", 3);
+  JointPositions positions2(positions1);
+  EXPECT_EQ(positions1.get_name(), positions2.get_name());
+  EXPECT_TRUE(positions1.data().isApprox(positions2.data()));
+  EXPECT_EQ(positions2.get_velocities().norm(), 0);
+  EXPECT_EQ(positions2.get_accelerations().norm(), 0);
+  EXPECT_EQ(positions2.get_torques().norm(), 0);
+  JointPositions positions3 = positions1;
+  EXPECT_EQ(positions1.get_name(), positions3.get_name());
+  EXPECT_TRUE(positions1.data().isApprox(positions3.data()));
+  EXPECT_EQ(positions3.get_velocities().norm(), 0);
+  EXPECT_EQ(positions3.get_accelerations().norm(), 0);
+  EXPECT_EQ(positions3.get_torques().norm(), 0);
+  // try to change non pose variables prior to the copy, those should be discarded
+  positions1.set_velocities(Eigen::Vector3d::Random());
+  positions1.set_accelerations(Eigen::Vector3d::Random());
+  positions1.set_torques(Eigen::Vector3d::Random());
+  JointPositions positions4 = positions1;
+  EXPECT_TRUE(positions1.data().isApprox(positions4.data()));
+  EXPECT_EQ(positions4.get_velocities().norm(), 0);
+  EXPECT_EQ(positions4.get_accelerations().norm(), 0);
+  EXPECT_EQ(positions4.get_torques().norm(), 0);
+  // copy a state, only the pose variables should be non 0
+  JointPositions positions5 = JointState::Random("test", 3);
+  EXPECT_EQ(positions5.get_velocities().norm(), 0);
+  EXPECT_EQ(positions5.get_accelerations().norm(), 0);
+  EXPECT_EQ(positions5.get_torques().norm(), 0);
+}
+
+TEST(JointStateTest, CopyVelocities) {
+  JointVelocities velocities1 = JointVelocities::Random("test", 3);
+  JointVelocities velocities2(velocities1);
+  EXPECT_EQ(velocities1.get_name(), velocities2.get_name());
+  EXPECT_TRUE(velocities1.data().isApprox(velocities2.data()));
+  EXPECT_EQ(velocities2.get_positions().norm(), 0);
+  EXPECT_EQ(velocities2.get_accelerations().norm(), 0);
+  EXPECT_EQ(velocities2.get_torques().norm(), 0);
+  JointVelocities velocities3 = velocities1;
+  EXPECT_EQ(velocities1.get_name(), velocities3.get_name());
+  EXPECT_TRUE(velocities1.data().isApprox(velocities3.data()));
+  EXPECT_EQ(velocities3.get_positions().norm(), 0);
+  EXPECT_EQ(velocities3.get_accelerations().norm(), 0);
+  EXPECT_EQ(velocities3.get_torques().norm(), 0);
+  // try to change non pose variables prior to the copy, those should be discarded
+  velocities1.set_positions(Eigen::Vector3d::Random());
+  velocities1.set_accelerations(Eigen::Vector3d::Random());
+  velocities1.set_torques(Eigen::Vector3d::Random());
+  JointVelocities velocities4 = velocities1;
+  EXPECT_TRUE(velocities1.data().isApprox(velocities4.data()));
+  EXPECT_EQ(velocities4.get_positions().norm(), 0);
+  EXPECT_EQ(velocities4.get_accelerations().norm(), 0);
+  EXPECT_EQ(velocities4.get_torques().norm(), 0);
+  // copy a state, only the pose variables should be non 0
+  JointVelocities velocities5 = JointState::Random("test", 3);
+  EXPECT_EQ(velocities5.get_positions().norm(), 0);
+  EXPECT_EQ(velocities5.get_accelerations().norm(), 0);
+  EXPECT_EQ(velocities5.get_torques().norm(), 0);
+}
+
+TEST(JointStateTest, CopyTorques) {
+  JointTorques torques1 = JointTorques::Random("test", 3);
+  JointTorques torques2(torques1);
+  EXPECT_EQ(torques1.get_name(), torques2.get_name());
+  EXPECT_TRUE(torques1.data().isApprox(torques2.data()));
+  EXPECT_EQ(torques2.get_positions().norm(), 0);
+  EXPECT_EQ(torques2.get_velocities().norm(), 0);
+  EXPECT_EQ(torques2.get_accelerations().norm(), 0);
+  JointTorques torques3 = torques1;
+  EXPECT_EQ(torques1.get_name(), torques3.get_name());
+  EXPECT_TRUE(torques1.data().isApprox(torques3.data()));
+  EXPECT_EQ(torques3.get_positions().norm(), 0);
+  EXPECT_EQ(torques3.get_velocities().norm(), 0);
+  EXPECT_EQ(torques3.get_accelerations().norm(), 0);
+  // try to change non pose variables prior to the copy, those should be discarded
+  torques1.set_positions(Eigen::Vector3d::Random());
+  torques1.set_velocities(Eigen::Vector3d::Random());
+  torques1.set_accelerations(Eigen::Vector3d::Random());
+  JointTorques torques4 = torques1;
+  EXPECT_TRUE(torques1.data().isApprox(torques4.data()));
+  EXPECT_EQ(torques4.get_positions().norm(), 0);
+  EXPECT_EQ(torques4.get_velocities().norm(), 0);
+  EXPECT_EQ(torques4.get_accelerations().norm(), 0);
+  // copy a state, only the pose variables should be non 0
+  JointTorques torques5 = JointState::Random("test", 3);
+  EXPECT_EQ(torques5.get_positions().norm(), 0);
+  EXPECT_EQ(torques5.get_velocities().norm(), 0);
+  EXPECT_EQ(torques5.get_accelerations().norm(), 0);
+}
+
 TEST(JointStateTest, GetData) {
-  state_representation::JointState js = state_representation::JointState::Random("test_robot", 4);
+  JointState js = JointState::Random("test_robot", 4);
   Eigen::VectorXd concatenated_state(js.get_size() * 4);
   concatenated_state << js.get_positions(), js.get_velocities(), js.get_accelerations(), js.get_torques();
   EXPECT_NEAR(concatenated_state.norm(), js.data().norm(), 1e-4);
 }
 
 TEST(JointStateTest, JointStateToStdVector) {
-  state_representation::JointState js = state_representation::JointState::Random("test_robot", 4);
+  JointState js = JointState::Random("test_robot", 4);
   std::vector<double> vec_data = js.to_std_vector();
   for (size_t i = 0; i < vec_data.size(); ++i) {
     EXPECT_EQ(js.data()(i), vec_data[i]);
@@ -108,7 +210,7 @@ TEST(JointStateTest, JointStateToStdVector) {
 }
 
 TEST(JointStateTest, JointPositionsToStdVector) {
-  state_representation::JointPositions jp = state_representation::JointPositions::Random("test_robot", 4);
+  JointPositions jp = JointPositions::Random("test_robot", 4);
   std::vector<double> vec_data = jp.to_std_vector();
   EXPECT_EQ(vec_data.size(), jp.get_size());
   for (size_t i = 0; i < vec_data.size(); ++i) {
@@ -117,7 +219,7 @@ TEST(JointStateTest, JointPositionsToStdVector) {
 }
 
 TEST(JointStateTest, JointVelocitiesToStdVector) {
-  state_representation::JointVelocities jv = state_representation::JointVelocities::Random("test_robot", 4);
+  JointVelocities jv = JointVelocities::Random("test_robot", 4);
   std::vector<double> vec_data = jv.to_std_vector();
   EXPECT_EQ(vec_data.size(), jv.get_size());
   for (size_t i = 0; i < vec_data.size(); ++i) {
@@ -126,7 +228,7 @@ TEST(JointStateTest, JointVelocitiesToStdVector) {
 }
 
 TEST(JointStateTest, JointTorquesToStdVector) {
-  state_representation::JointTorques jt = state_representation::JointTorques::Random("test_robot", 4);
+  JointTorques jt = JointTorques::Random("test_robot", 4);
   std::vector<double> vec_data = jt.to_std_vector();
   EXPECT_EQ(vec_data.size(), jt.get_size());
   for (size_t i = 0; i < vec_data.size(); ++i) {
@@ -135,28 +237,28 @@ TEST(JointStateTest, JointTorquesToStdVector) {
 }
 
 TEST(JointStateTest, AddTwoState) {
-  state_representation::JointState j1 = state_representation::JointState::Random("test_robot", 4);
-  state_representation::JointState j2 = state_representation::JointState::Random("test_robot", 4);
-  state_representation::JointState jsum = j1 + j2;
+  JointState j1 = JointState::Random("test_robot", 4);
+  JointState j2 = JointState::Random("test_robot", 4);
+  JointState jsum = j1 + j2;
   EXPECT_NEAR(jsum.data().norm(), (j1.data() + j2.data()).norm(), 1e-4);
 }
 
 TEST(JointStateTest, SubstractTwoState) {
-  state_representation::JointState j1 = state_representation::JointState::Random("test_robot", 4);
-  state_representation::JointState j2 = state_representation::JointState::Random("test_robot", 4);
-  state_representation::JointState jdiff = j1 - j2;
+  JointState j1 = JointState::Random("test_robot", 4);
+  JointState j2 = JointState::Random("test_robot", 4);
+  JointState jdiff = j1 - j2;
   EXPECT_NEAR(jdiff.data().norm(), (j1.data() - j2.data()).norm(), 1e-4);
 }
 
 TEST(JointStateTest, MultiplyByScalar) {
-  state_representation::JointState js = state_representation::JointState::Random("test_robot", 4);
-  state_representation::JointState jscaled = 0.5 * js;
+  JointState js = JointState::Random("test_robot", 4);
+  JointState jscaled = 0.5 * js;
   EXPECT_NEAR(jscaled.data().norm(), (0.5 * js.data()).norm(), 1e-4);
 }
 
 TEST(JointStateTest, MultiplyByArray) {
-  state_representation::JointState js = state_representation::JointState::Random("test_robot", 4);
+  JointState js = JointState::Random("test_robot", 4);
   Eigen::MatrixXd gain = Eigen::VectorXd::Random(16).asDiagonal();
-  state_representation::JointState jscaled = gain * js;
+  JointState jscaled = gain * js;
   EXPECT_NEAR(jscaled.data().norm(), (gain * js.data()).norm(), 1e-4);
 }


### PR DESCRIPTION
This is exactly the copy of PR #100 but for `JointState` and its derivatives. Also I slightly modified `test_cartesian` to better use all the state variables.