### PR TITLE
Delete inaccessible getters and setters

### DIFF
--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -16,7 +16,30 @@ class CartesianTwist;
  * @brief Class to define CartesianPose in cartesian space as 3D position and quaternion based orientation
  */
 class CartesianPose : public CartesianState {
+private:
+  using CartesianState::clamp_state_variable;
+
 public:
+  // delete inaccessible getter and setters
+  const Eigen::Vector3d& get_linear_velocity() const = delete;
+  const Eigen::Vector3d& get_angular_velocity() const = delete;
+  Eigen::Matrix<double, 6, 1> get_twist() const = delete;
+  const Eigen::Vector3d& get_linear_acceleration() const = delete;
+  const Eigen::Vector3d& get_angular_acceleration() const = delete;
+  Eigen::Matrix<double, 6, 1> get_accelerations() const = delete;
+  const Eigen::Vector3d& get_force() const = delete;
+  const Eigen::Vector3d& get_torque() const = delete;
+  Eigen::Matrix<double, 6, 1> get_wrench() const = delete;
+  void set_linear_velocity(const Eigen::Vector3d& linear_velocity) = delete;
+  void set_angular_velocity(const Eigen::Vector3d& angular_velocity) = delete;
+  void set_twist(const Eigen::Matrix<double, 6, 1>& twist) = delete;
+  void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
+  void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
+  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  void set_force(const Eigen::Vector3d& force) = delete;
+  void set_torque(const Eigen::Vector3d& torque) = delete;
+  void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
+
   /**
    * Empty constructor
    */

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -41,7 +41,7 @@ public:
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
 
   /**
-   * Empty constructor
+   * @brief Empty constructor
    */
   explicit CartesianPose() = default;
 
@@ -70,17 +70,26 @@ public:
   /**
    * @brief Construct a CartesianPose from a position given as a vector of coordinates.
    */
-  explicit CartesianPose(const std::string& name, const Eigen::Vector3d& position, const std::string& reference = "world");
+  explicit CartesianPose(const std::string& name,
+                         const Eigen::Vector3d& position,
+                         const std::string& reference = "world");
 
   /**
    * @brief Construct a CartesianPose from a position given as three scalar coordinates.
    */
-  explicit CartesianPose(const std::string& name, const double& x, const double& y, const double& z, const std::string& reference = "world");
+  explicit CartesianPose(const std::string& name,
+                         const double& x,
+                         const double& y,
+                         const double& z,
+                         const std::string& reference = "world");
 
   /**
    * @brief Construct a CartesianPose from a position given as a vector of coordinates and a quaternion.
    */
-  explicit CartesianPose(const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation, const std::string& reference = "world");
+  explicit CartesianPose(const std::string& name,
+                         const Eigen::Vector3d& position,
+                         const Eigen::Quaterniond& orientation,
+                         const std::string& reference = "world");
 
   /**
    * @brief Constructor for the identity pose
@@ -103,14 +112,7 @@ public:
    * @param pose the pose with value to assign
    * @return reference to the current pose with new values
    */
-  CartesianPose& operator=(const CartesianPose& pose);
-
-  /**
-   * @brief Copy assignment operator from a state
-   * @param state the state with value to assign
-   * @return reference to the current pose with new values
-   */
-  CartesianPose& operator=(const CartesianState& state);
+  CartesianPose& operator=(const CartesianPose& pose) = default;
 
   /**
    * @brief Overload the * operator for a vector input
@@ -244,12 +246,7 @@ public:
   void from_std_vector(const std::vector<double>& value);
 };
 
-inline CartesianPose& CartesianPose::operator=(const CartesianPose& pose) {
-  CartesianState::operator=(pose);
-  return (*this);
-}
-
-inline std::vector<double> CartesianPose::norms(const CartesianStateVariable& state_variable_type) const{
+inline std::vector<double> CartesianPose::norms(const CartesianStateVariable& state_variable_type) const {
   return CartesianState::norms(state_variable_type);
 }
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -49,12 +49,14 @@ public:
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
 
   /**
-   * Empty constructor
+   * @brief Empty constructor
    */
   explicit CartesianTwist() = default;
 
   /**
-   * @brief Empty constructor for a CartesianTwist
+   * @brief Constructor with name and reference frame provided
+   * @param name the name of the state
+   * @param reference the name of the reference frame
    */
   explicit CartesianTwist(const std::string& name, const std::string& reference = "world");
 
@@ -76,17 +78,24 @@ public:
   /**
    * @brief Construct a CartesianTwist from a linear_velocity given as a vector of coordinates for the linear velocity.
    */
-  explicit CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference = "world");
+  explicit CartesianTwist(const std::string& name,
+                          const Eigen::Vector3d& linear_velocity,
+                          const std::string& reference = "world");
 
   /**
    * @brief Construct a CartesianTwist from a linear_velocity given as a vector of coordinates and a quaternion.
    */
-  explicit CartesianTwist(const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity, const std::string& reference = "world");
+  explicit CartesianTwist(const std::string& name,
+                          const Eigen::Vector3d& linear_velocity,
+                          const Eigen::Vector3d& angular_velocity,
+                          const std::string& reference = "world");
 
   /**
    * @brief Construct a CartesianTwist from a single 6d twist vector
    */
-  explicit CartesianTwist(const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference = "world");
+  explicit CartesianTwist(const std::string& name,
+                          const Eigen::Matrix<double, 6, 1>& twist,
+                          const std::string& reference = "world");
 
   /**
    * @brief Constructor for the zero twist
@@ -109,13 +118,7 @@ public:
    * @param twist the twist with value to assign
    * @return reference to the current twist with new values
    */
-  CartesianTwist& operator=(const CartesianTwist& twist);
-
-  /**
-   * @brief Overload the = operator from a CartesianState
-   * @param state CartesianState to get velocity from
-   */
-  CartesianTwist& operator=(const CartesianState& state);
+  CartesianTwist& operator=(const CartesianTwist& twist) = default;
 
   /**
    * @brief Overload the *= operator
@@ -208,7 +211,10 @@ public:
    * the angular velocity will be set to 0
    * @return the clamped twist
    */
-  CartesianTwist clamped(double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0) const;
+  CartesianTwist clamped(double max_linear,
+                         double max_angular,
+                         double noise_ratio = 0,
+                         double angular_noise_ratio = 0) const;
 
   /**
    * @brief Return a copy of the CartesianTwist
@@ -266,12 +272,7 @@ public:
   friend CartesianPose operator*(const std::chrono::nanoseconds& dt, const CartesianTwist& twist);
 };
 
-inline CartesianTwist& CartesianTwist::operator=(const CartesianTwist& twist) {
-  CartesianState::operator=(twist);
-  return (*this);
-}
-
-inline std::vector<double> CartesianTwist::norms(const CartesianStateVariable& state_variable_type) const{
+inline std::vector<double> CartesianTwist::norms(const CartesianStateVariable& state_variable_type) const {
   return CartesianState::norms(state_variable_type);
 }
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -16,7 +16,38 @@ class CartesianPose;
  * @brief Class to define twist in cartesian space as 3D linear and angular velocity vectors
  */
 class CartesianTwist : public CartesianState {
+private:
+  using CartesianState::clamp_state_variable;
+
 public:
+  // delete inaccessible getter and setters
+  const Eigen::Vector3d& get_position() const = delete;
+  const Eigen::Quaterniond& get_orientation() const = delete;
+  Eigen::Vector4d get_orientation_coefficients() const = delete;
+  Eigen::Matrix<double, 7, 1> get_pose() const = delete;
+  Eigen::Matrix4d get_transformation_matrix() const = delete;
+  const Eigen::Vector3d& get_linear_acceleration() const = delete;
+  const Eigen::Vector3d& get_angular_acceleration() const = delete;
+  Eigen::Matrix<double, 6, 1> get_accelerations() const = delete;
+  const Eigen::Vector3d& get_force() const = delete;
+  const Eigen::Vector3d& get_torque() const = delete;
+  Eigen::Matrix<double, 6, 1> get_wrench() const = delete;
+  void set_position(const Eigen::Vector3d& position) = delete;
+  void set_position(const std::vector<double>& position) = delete;
+  void set_position(const double& x, const double& y, const double& z) = delete;
+  void set_orientation(const Eigen::Quaterniond& orientation) = delete;
+  void set_orientation(const Eigen::Vector4d& orientation) = delete;
+  void set_orientation(const std::vector<double>& orientation) = delete;
+  void set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation) = delete;
+  void set_pose(const Eigen::Matrix<double, 7, 1>& pose) = delete;
+  void set_pose(const std::vector<double>& pose) = delete;
+  void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
+  void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
+  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  void set_force(const Eigen::Vector3d& force) = delete;
+  void set_torque(const Eigen::Vector3d& torque) = delete;
+  void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
+
   /**
    * Empty constructor
    */

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -46,13 +46,15 @@ public:
   void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
 
   /**
-   * Empty constructor
+   * @brief Empty constructor
    */
   explicit CartesianWrench() = default;
 
   /**
-   * @brief Empty constructor for a CartesianWrench
-   */
+    * @brief Constructor with name and reference frame provided
+    * @param name the name of the state
+    * @param reference the name of the reference frame
+    */
   explicit CartesianWrench(const std::string& name, const std::string& reference = "world");
 
   /**
@@ -68,17 +70,24 @@ public:
   /**
    * @brief Construct a CartesianWrench from a force given as a vector of coordinates.
    */
-  explicit CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const std::string& reference = "world");
+  explicit CartesianWrench(const std::string& name,
+                           const Eigen::Vector3d& force,
+                           const std::string& reference = "world");
 
   /**
    * @brief Construct a CartesianWrench from a force given as a vector of coordinates and a quaternion.
    */
-  explicit CartesianWrench(const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque, const std::string& reference = "world");
+  explicit CartesianWrench(const std::string& name,
+                           const Eigen::Vector3d& force,
+                           const Eigen::Vector3d& torque,
+                           const std::string& reference = "world");
 
   /**
    * @brief Construct a CartesianWrench from a single 6d wrench vector
    */
-  explicit CartesianWrench(const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference = "world");
+  explicit CartesianWrench(const std::string& name,
+                           const Eigen::Matrix<double, 6, 1>& wrench,
+                           const std::string& reference = "world");
 
   /**
    * @brief Constructor for the zero wrench
@@ -101,13 +110,7 @@ public:
    * @param pose the pose with value to assign
    * @return reference to the current pose with new values
    */
-  CartesianWrench& operator=(const CartesianWrench& pose);
-
-  /**
-   * @brief Overload the = operator from a CartesianState
-   * @param state CartesianState to get the wrench from
-   */
-  CartesianWrench& operator=(const CartesianState& state);
+  CartesianWrench& operator=(const CartesianWrench& pose) = default;
 
   /**
    * @brief Overload the *= operator
@@ -186,7 +189,10 @@ public:
    * the torque will be set to 0
    * @return the clamped wrench
    */
-  CartesianWrench clamped(double max_force, double max_torque, double force_noise_ratio = 0, double torque_noise_ratio = 0) const;
+  CartesianWrench clamped(double max_force,
+                          double max_torque,
+                          double force_noise_ratio = 0,
+                          double torque_noise_ratio = 0) const;
 
   /**
    * @brief Return a copy of the CartesianWrench
@@ -230,12 +236,7 @@ public:
   friend CartesianWrench operator*(double lambda, const CartesianWrench& wrench);
 };
 
-inline CartesianWrench& CartesianWrench::operator=(const CartesianWrench& wrench) {
-  CartesianState::operator=(wrench);
-  return (*this);
-}
-
-inline std::vector<double> CartesianWrench::norms(const CartesianStateVariable& state_variable_type) const{
+inline std::vector<double> CartesianWrench::norms(const CartesianStateVariable& state_variable_type) const {
   return CartesianState::norms(state_variable_type);
 }
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -13,7 +13,38 @@ namespace state_representation {
  * @brief Class to define wrench in cartesian space as 3D force and torque vectors
  */
 class CartesianWrench : public CartesianState {
+private:
+  using CartesianState::clamp_state_variable;
+
 public:
+  // delete inaccessible getter and setters
+  const Eigen::Vector3d& get_linear_velocity() const = delete;
+  const Eigen::Vector3d& get_angular_velocity() const = delete;
+  Eigen::Matrix<double, 6, 1> get_twist() const = delete;
+  const Eigen::Vector3d& get_position() const = delete;
+  const Eigen::Quaterniond& get_orientation() const = delete;
+  Eigen::Vector4d get_orientation_coefficients() const = delete;
+  Eigen::Matrix<double, 7, 1> get_pose() const = delete;
+  Eigen::Matrix4d get_transformation_matrix() const = delete;
+  const Eigen::Vector3d& get_linear_acceleration() const = delete;
+  const Eigen::Vector3d& get_angular_acceleration() const = delete;
+  Eigen::Matrix<double, 6, 1> get_accelerations() const = delete;
+  void set_position(const Eigen::Vector3d& position) = delete;
+  void set_position(const std::vector<double>& position) = delete;
+  void set_position(const double& x, const double& y, const double& z) = delete;
+  void set_orientation(const Eigen::Quaterniond& orientation) = delete;
+  void set_orientation(const Eigen::Vector4d& orientation) = delete;
+  void set_orientation(const std::vector<double>& orientation) = delete;
+  void set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation) = delete;
+  void set_pose(const Eigen::Matrix<double, 7, 1>& pose) = delete;
+  void set_pose(const std::vector<double>& pose) = delete;
+  void set_linear_velocity(const Eigen::Vector3d& linear_velocity) = delete;
+  void set_angular_velocity(const Eigen::Vector3d& angular_velocity) = delete;
+  void set_twist(const Eigen::Matrix<double, 6, 1>& twist) = delete;
+  void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
+  void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
+  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+
   /**
    * Empty constructor
    */

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -46,11 +46,6 @@ CartesianPose CartesianPose::Random(const std::string& name, const std::string& 
   return CartesianPose(name, Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom(), reference);
 }
 
-CartesianPose& CartesianPose::operator=(const CartesianState& state) {
-  this->CartesianState::operator=(state);
-  return (*this);
-}
-
 Eigen::Vector3d CartesianPose::operator*(const Eigen::Vector3d& vector) const {
   return this->get_orientation() * vector + this->get_position();
 }

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -50,11 +50,6 @@ CartesianTwist CartesianTwist::Random(const std::string& name, const std::string
   return CartesianTwist(name, random, reference);
 }
 
-CartesianTwist& CartesianTwist::operator=(const CartesianState& state) {
-  this->CartesianState::operator=(state);
-  return (*this);
-}
-
 CartesianTwist& CartesianTwist::operator*=(const CartesianTwist& twist) {
   this->CartesianState::operator*=(twist);
   return (*this);

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -44,11 +44,6 @@ CartesianWrench CartesianWrench::Random(const std::string& name, const std::stri
   return CartesianWrench(name, random, reference);
 }
 
-CartesianWrench& CartesianWrench::operator=(const CartesianState& state) {
-  this->CartesianState::operator=(state);
-  return (*this);
-}
-
 CartesianWrench& CartesianWrench::operator*=(const CartesianWrench& wrench) {
   this->CartesianState::operator*=(wrench);
   return (*this);

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -41,30 +41,30 @@ TEST(CartesianStateTest, RandomPoseInitialization) {
   EXPECT_GT(abs(random.get_orientation().x()), 0);
   EXPECT_GT(abs(random.get_orientation().y()), 0);
   EXPECT_GT(abs(random.get_orientation().z()), 0);
-  EXPECT_EQ(random.get_twist().norm(), 0);
-  EXPECT_EQ(random.get_accelerations().norm(), 0);
-  EXPECT_EQ(random.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, RandomTwistInitialization) {
   CartesianTwist random = CartesianTwist::Random("test");
   // only position should be random
-  EXPECT_EQ(random.get_position().norm(), 0);
-  EXPECT_EQ(random.get_orientation().norm(), 1);
-  EXPECT_EQ(random.get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_orientation().w(), 1);
   EXPECT_GT(random.get_twist().norm(), 0);
-  EXPECT_EQ(random.get_accelerations().norm(), 0);
-  EXPECT_EQ(random.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, RandomWrenchInitialization) {
   CartesianWrench random = CartesianWrench::Random("test");
   // only position should be random
-  EXPECT_EQ(random.get_position().norm(), 0);
-  EXPECT_EQ(random.get_orientation().norm(), 1);
-  EXPECT_EQ(random.get_orientation().w(), 1);
-  EXPECT_EQ(random.get_twist().norm(), 0);
-  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(random).get_accelerations().norm(), 0);
   EXPECT_GT(random.get_wrench().norm(), 0);
 }
 
@@ -86,30 +86,30 @@ TEST(CartesianStateTest, CopyPose) {
   EXPECT_EQ(pose1.get_name(), pose2.get_name());
   EXPECT_EQ(pose1.get_reference_frame(), pose2.get_reference_frame());
   EXPECT_TRUE(pose1.data().isApprox(pose2.data()));
-  EXPECT_EQ(pose2.get_twist().norm(), 0);
-  EXPECT_EQ(pose2.get_accelerations().norm(), 0);
-  EXPECT_EQ(pose2.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose2).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose2).get_wrench().norm(), 0);
   CartesianPose pose3 = pose1;
   EXPECT_EQ(pose1.get_name(), pose3.get_name());
   EXPECT_EQ(pose1.get_reference_frame(), pose3.get_reference_frame());
   EXPECT_TRUE(pose1.data().isApprox(pose3.data()));
-  EXPECT_EQ(pose3.get_twist().norm(), 0);
-  EXPECT_EQ(pose3.get_accelerations().norm(), 0);
-  EXPECT_EQ(pose3.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose3).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose3).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose3).get_wrench().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  pose1.set_twist(Eigen::VectorXd::Random(6));
-  pose1.set_accelerations(Eigen::VectorXd::Random(6));
-  pose1.set_wrench(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(pose1).set_twist(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(pose1).set_accelerations(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(pose1).set_wrench(Eigen::VectorXd::Random(6));
   CartesianPose pose4 = pose1;
   EXPECT_TRUE(pose1.data().isApprox(pose4.data()));
-  EXPECT_EQ(pose4.get_twist().norm(), 0);
-  EXPECT_EQ(pose4.get_accelerations().norm(), 0);
-  EXPECT_EQ(pose4.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose4).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose4).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose4).get_wrench().norm(), 0);
   // copy a state, only the pose variables should be non 0
   CartesianPose pose5 = CartesianState::Random("test");
-  EXPECT_EQ(pose5.get_twist().norm(), 0);
-  EXPECT_EQ(pose5.get_accelerations().norm(), 0);
-  EXPECT_EQ(pose5.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose5).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose5).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose5).get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, CopyTwist) {
@@ -118,38 +118,38 @@ TEST(CartesianStateTest, CopyTwist) {
   EXPECT_EQ(twist1.get_name(), twist2.get_name());
   EXPECT_EQ(twist1.get_reference_frame(), twist2.get_reference_frame());
   EXPECT_TRUE(twist1.data().isApprox(twist2.data()));
-  EXPECT_EQ(twist2.get_position().norm(), 0);
-  EXPECT_EQ(twist2.get_orientation().norm(), 1);
-  EXPECT_EQ(twist2.get_orientation().w(), 1);
-  EXPECT_EQ(twist2.get_accelerations().norm(), 0);
-  EXPECT_EQ(twist2.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist2).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist2).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist2).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist2).get_wrench().norm(), 0);
   CartesianTwist twist3 = twist1;
   EXPECT_EQ(twist1.get_name(), twist3.get_name());
   EXPECT_EQ(twist1.get_reference_frame(), twist3.get_reference_frame());
   EXPECT_TRUE(twist1.data().isApprox(twist3.data()));
-  EXPECT_EQ(twist3.get_position().norm(), 0);
-  EXPECT_EQ(twist3.get_orientation().norm(), 1);
-  EXPECT_EQ(twist3.get_orientation().w(), 1);
-  EXPECT_EQ(twist3.get_accelerations().norm(), 0);
-  EXPECT_EQ(twist3.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist3).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist3).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist3).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist3).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist3).get_wrench().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  twist1.set_pose(Eigen::VectorXd::Random(7));
-  twist1.set_accelerations(Eigen::VectorXd::Random(6));
-  twist1.set_wrench(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(twist1).set_pose(Eigen::VectorXd::Random(7));
+  static_cast<CartesianState&>(twist1).set_accelerations(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(twist1).set_wrench(Eigen::VectorXd::Random(6));
   CartesianTwist twist4 = twist1;
   EXPECT_TRUE(twist1.data().isApprox(twist4.data()));
-  EXPECT_EQ(twist4.get_position().norm(), 0);
-  EXPECT_EQ(twist4.get_orientation().norm(), 1);
-  EXPECT_EQ(twist4.get_orientation().w(), 1);
-  EXPECT_EQ(twist4.get_accelerations().norm(), 0);
-  EXPECT_EQ(twist4.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist4).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist4).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist4).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist4).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist4).get_wrench().norm(), 0);
   // copy a state, only the pose variables should be non 0
   CartesianTwist twist5 = CartesianState::Random("test");
-  EXPECT_EQ(twist5.get_position().norm(), 0);
-  EXPECT_EQ(twist5.get_orientation().norm(), 1);
-  EXPECT_EQ(twist5.get_orientation().w(), 1);
-  EXPECT_EQ(twist5.get_accelerations().norm(), 0);
-  EXPECT_EQ(twist5.get_wrench().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist5).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist5).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist5).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(twist5).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist5).get_wrench().norm(), 0);
 }
 
 TEST(CartesianStateTest, CopyWrench) {
@@ -158,38 +158,38 @@ TEST(CartesianStateTest, CopyWrench) {
   EXPECT_EQ(wrench1.get_name(), wrench2.get_name());
   EXPECT_EQ(wrench1.get_reference_frame(), wrench2.get_reference_frame());
   EXPECT_TRUE(wrench1.data().isApprox(wrench2.data()));
-  EXPECT_EQ(wrench2.get_position().norm(), 0);
-  EXPECT_EQ(wrench2.get_orientation().norm(), 1);
-  EXPECT_EQ(wrench2.get_orientation().w(), 1);
-  EXPECT_EQ(wrench2.get_twist().norm(), 0);
-  EXPECT_EQ(wrench2.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench2).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench2).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench2).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench2).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench2).get_accelerations().norm(), 0);
   CartesianWrench wrench3 = wrench1;
   EXPECT_EQ(wrench1.get_name(), wrench3.get_name());
   EXPECT_EQ(wrench1.get_reference_frame(), wrench3.get_reference_frame());
   EXPECT_TRUE(wrench1.data().isApprox(wrench3.data()));
-  EXPECT_EQ(wrench3.get_position().norm(), 0);
-  EXPECT_EQ(wrench3.get_orientation().norm(), 1);
-  EXPECT_EQ(wrench3.get_orientation().w(), 1);
-  EXPECT_EQ(wrench3.get_twist().norm(), 0);
-  EXPECT_EQ(wrench3.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench3).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench3).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench3).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench3).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench3).get_accelerations().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  wrench1.set_pose(Eigen::VectorXd::Random(7));
-  wrench1.set_twist(Eigen::VectorXd::Random(6));
-  wrench1.set_accelerations(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(wrench1).set_pose(Eigen::VectorXd::Random(7));
+  static_cast<CartesianState&>(wrench1).set_twist(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(wrench1).set_accelerations(Eigen::VectorXd::Random(6));
   CartesianWrench wrench4 = wrench1;
   EXPECT_TRUE(wrench1.data().isApprox(wrench4.data()));
-  EXPECT_EQ(wrench4.get_position().norm(), 0);
-  EXPECT_EQ(wrench4.get_orientation().norm(), 1);
-  EXPECT_EQ(wrench4.get_orientation().w(), 1);
-  EXPECT_EQ(wrench4.get_twist().norm(), 0);
-  EXPECT_EQ(wrench4.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench4).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench4).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench4).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench4).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench4).get_accelerations().norm(), 0);
   // copy a state, only the pose variables should be non 0
   CartesianWrench wrench5 = CartesianState::Random("test");
-  EXPECT_EQ(wrench5.get_position().norm(), 0);
-  EXPECT_EQ(wrench5.get_orientation().norm(), 1);
-  EXPECT_EQ(wrench5.get_orientation().w(), 1);
-  EXPECT_EQ(wrench5.get_twist().norm(), 0);
-  EXPECT_EQ(wrench5.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_accelerations().norm(), 0);
 }
 
 TEST(CartesianStateTest, GetData) {


### PR DESCRIPTION
This PR is a continuation of the refactoring started in #100 that removes the getters and setters that are not supposed to be accessed by the derived classes. Obviously, there is a workaround that uses `static_cast` that is actually helpful for the test cases. I do think this not a problem as if someone really want to use that they probably know enough to have a good reason to actually do it.