### PR TITLE
Delete joint derivatives inaccessible getters and setters 

### DIFF
--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -20,6 +20,16 @@ private:
   using JointState::clamp_state_variable;
 
 public:
+  const Eigen::VectorXd& get_velocities() const = delete;
+  void set_velocities(const Eigen::VectorXd& velocities) = delete;
+  void set_velocities(const std::vector<double>& velocities) = delete;
+  const Eigen::VectorXd& get_accelerations() const = delete;
+  void set_accelerations(const Eigen::VectorXd& accelerations) = delete;
+  void set_accelerations(const std::vector<double>& accelerations) = delete;
+  const Eigen::VectorXd& get_torques() const = delete;
+  void set_torques(const Eigen::VectorXd& torques) = delete;
+  void set_torques(const std::vector<double>& torques) = delete;
+
   /**
    * @brief Empty constructor
    */

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -16,6 +16,9 @@ class JointVelocities;
  * @brief Class to define a positions of the joints
  */
 class JointPositions : public JointState {
+private:
+  using JointState::clamp_state_variable;
+
 public:
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -18,7 +18,7 @@ class JointVelocities;
 class JointPositions : public JointState {
 public:
   /**
-   * Empty constructor
+   * @brief Empty constructor
    */
   explicit JointPositions() = default;
 
@@ -104,7 +104,7 @@ public:
    * @param positions the state with value to assign
    * @return reference to the current state with new values
    */
-  JointPositions& operator=(const JointPositions& positions);
+  JointPositions& operator=(const JointPositions& positions) = default;
 
   /**
    * @brief Overload the += operator
@@ -244,9 +244,4 @@ public:
    */
   void from_std_vector(const std::vector<double>& value);
 };
-
-inline JointPositions& JointPositions::operator=(const JointPositions& state) {
-  JointState::operator=(state);
-  return (*this);
-}
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -95,6 +95,20 @@ protected:
    */
   void multiply_state_variable(const Eigen::MatrixXd& lambda, const JointStateVariable& state_variable_type);
 
+  /**
+   * @brief Getter of the variable value corresponding to the input
+   * @param state_variable_type the type of variable to get
+   * @return the value of the variable as a vector
+   */
+  Eigen::VectorXd get_state_variable(const JointStateVariable& state_variable_type) const;
+
+  /**
+   * @brief Setter of the variable value corresponding to the input
+   * @param new_value the new value of the variable
+   * @param state_variable_type the type of variable to get
+   */
+  void set_state_variable(const Eigen::VectorXd& new_value, const JointStateVariable& state_variable_type);
+
 public:
   /**
    * @brief Empty constructor for a JointState
@@ -245,20 +259,6 @@ public:
    * @brief Setter of the torques from std vector
    */
   void set_torques(const std::vector<double>& torques);
-
-  /**
-   * @brief Getter of the variable value corresponding to the input
-   * @param state_variable_type the type of variable to get
-   * @return the value of the variable as a vector
-   */
-  Eigen::VectorXd get_state_variable(const JointStateVariable& state_variable_type) const;
-
-  /**
-   * @brief Setter of the variable value corresponding to the input
-   * @param new_value the new value of the variable
-   * @param state_variable_type the type of variable to get
-   */
-  void set_state_variable(const Eigen::VectorXd& new_value, const JointStateVariable& state_variable_type);
 
   /**
    * @brief Check if the state is compatible for operations with the state given as argument

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -39,7 +39,8 @@ enum class JointStateVariable {
  * the distance on. Default ALL for full distance across all dimensions
  * @return the distance between the two states
  */
-double dist(const JointState& s1, const JointState& s2,
+double dist(const JointState& s1,
+            const JointState& s2,
             const JointStateVariable& state_variable_type = JointStateVariable::ALL);
 
 /**
@@ -282,7 +283,8 @@ public:
    * @param noise_ratio if provided, this value will be used to apply a dead zone under which
    * the velocity will be set to 0
    */
-  void clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type,
+  void clamp_state_variable(double max_absolute_value,
+                            const JointStateVariable& state_variable_type,
                             double noise_ratio = 0);
 
   /**
@@ -294,7 +296,8 @@ public:
    * the velocity will be set to 0
    */
   void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
-                            const JointStateVariable& state_variable_type, const Eigen::ArrayXd& noise_ratio_array);
+                            const JointStateVariable& state_variable_type,
+                            const Eigen::ArrayXd& noise_ratio_array);
 
   /**
    * @brief Return a copy of the JointState
@@ -475,7 +478,7 @@ inline void JointState::set_state_variable(Eigen::VectorXd& state_variable, cons
   if (new_value.size() != this->get_size()) {
     throw IncompatibleSizeException(
         "Input vector is of incorrect size: expected " + std::to_string(this->get_size()) + ", given "
-        + std::to_string(new_value.size()));
+            + std::to_string(new_value.size()));
   }
   this->set_filled();
   state_variable = new_value;

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -13,6 +13,9 @@ namespace state_representation {
  * @brief Class to define torques of the joints
  */
 class JointTorques : public JointState {
+private:
+  using JointState::clamp_state_variable;
+
 public:
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -17,6 +17,16 @@ private:
   using JointState::clamp_state_variable;
 
 public:
+  const Eigen::VectorXd& get_positions() const = delete;
+  void set_positions(const Eigen::VectorXd& positions) = delete;
+  void set_positions(const std::vector<double>& positions) = delete;
+  const Eigen::VectorXd& get_velocities() const = delete;
+  void set_velocities(const Eigen::VectorXd& velocities) = delete;
+  void set_velocities(const std::vector<double>& velocities) = delete;
+  const Eigen::VectorXd& get_accelerations() const = delete;
+  void set_accelerations(const Eigen::VectorXd& accelerations) = delete;
+  void set_accelerations(const std::vector<double>& accelerations) = delete;
+
   /**
    * @brief Empty constructor
    */

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -15,7 +15,7 @@ namespace state_representation {
 class JointTorques : public JointState {
 public:
   /**
-   * Empty constructor
+   * @brief Empty constructor
    */
   explicit JointTorques() = default;
 
@@ -93,10 +93,10 @@ public:
 
   /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
-   * @param state the state with value to assign
+   * @param torques the state with value to assign
    * @return reference to the current state with new values
    */
-  JointTorques& operator=(const JointTorques& state);
+  JointTorques& operator=(const JointTorques& torques) = default;
 
   /**
    * @brief Overload the += operator
@@ -263,9 +263,4 @@ public:
    */
   friend JointTorques operator*(const Eigen::MatrixXd& lambda, const JointTorques& torques);
 };
-
-inline JointTorques& JointTorques::operator=(const JointTorques& state) {
-  JointState::operator=(state);
-  return (*this);
-}
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/robot/JointVelocities.hpp
@@ -16,6 +16,9 @@ class JointPositions;
  * @brief Class to define velocities of the joints
  */
 class JointVelocities : public JointState {
+private:
+  using JointState::clamp_state_variable;
+
 public:
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/robot/JointVelocities.hpp
@@ -20,6 +20,16 @@ private:
   using JointState::clamp_state_variable;
 
 public:
+  const Eigen::VectorXd& get_positions() const = delete;
+  void set_positions(const Eigen::VectorXd& positions) = delete;
+  void set_positions(const std::vector<double>& positions) = delete;
+  const Eigen::VectorXd& get_accelerations() const = delete;
+  void set_accelerations(const Eigen::VectorXd& accelerations) = delete;
+  void set_accelerations(const std::vector<double>& accelerations) = delete;
+  const Eigen::VectorXd& get_torques() const = delete;
+  void set_torques(const Eigen::VectorXd& torques) = delete;
+  void set_torques(const std::vector<double>& torques) = delete;
+
   /**
    * @brief Empty constructor
    */

--- a/source/state_representation/include/state_representation/robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/robot/JointVelocities.hpp
@@ -18,7 +18,7 @@ class JointPositions;
 class JointVelocities : public JointState {
 public:
   /**
-   * Empty constructor
+   * @brief Empty constructor
    */
   explicit JointVelocities() = default;
 
@@ -101,10 +101,10 @@ public:
 
   /**
    * @brief Copy assignment operator that have to be defined to the custom assignment operator
-   * @param state the state with value to assign
+   * @param velocities the state with value to assign
    * @return reference to the current state with new values
    */
-  JointVelocities& operator=(const JointVelocities& state);
+  JointVelocities& operator=(const JointVelocities& velocities) = default;
 
   /**
    * @brief Overload the += operator
@@ -280,9 +280,4 @@ public:
    */
   friend JointPositions operator*(const std::chrono::nanoseconds& dt, const JointVelocities& velocities);
 };
-
-inline JointVelocities& JointVelocities::operator=(const JointVelocities& state) {
-  JointState::operator=(state);
-  return (*this);
-}
 }// namespace state_representation

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -44,53 +44,53 @@ TEST(JointStateTest, RandomPositionsInitialization) {
   JointPositions random = JointPositions::Random("test", 3);
   // only position should be random
   EXPECT_GT(random.get_positions().norm(), 0);
-  EXPECT_EQ(random.get_velocities().norm(), 0);
-  EXPECT_EQ(random.get_accelerations().norm(), 0);
-  EXPECT_EQ(random.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
   // same for the second initializer
   JointPositions random2 =
       JointPositions::Random("test",
                              std::vector<std::string>{"j0", "j1"});
   // only position should be random
   EXPECT_GT(random2.get_positions().norm(), 0);
-  EXPECT_EQ(random2.get_velocities().norm(), 0);
-  EXPECT_EQ(random2.get_accelerations().norm(), 0);
-  EXPECT_EQ(random2.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, RandomVelocitiesInitialization) {
   JointVelocities random = JointVelocities::Random("test", 3);
   // only velocities should be random
-  EXPECT_EQ(random.get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
   EXPECT_GT(random.get_velocities().norm(), 0);
-  EXPECT_EQ(random.get_accelerations().norm(), 0);
-  EXPECT_EQ(random.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
   // same for the second initializer
   JointVelocities random2 =
       JointVelocities::Random("test",
                               std::vector<std::string>{"j0", "j1"});
   // only velocities should be random
-  EXPECT_EQ(random2.get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_GT(random2.get_velocities().norm(), 0);
-  EXPECT_EQ(random2.get_accelerations().norm(), 0);
-  EXPECT_EQ(random2.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, RandomTorquesInitialization) {
   JointTorques random = JointTorques::Random("test", 3);
   // only torques should be random
-  EXPECT_EQ(random.get_positions().norm(), 0);
-  EXPECT_EQ(random.get_velocities().norm(), 0);
-  EXPECT_EQ(random.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
   EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
   JointTorques random2 =
       JointTorques::Random("test",
                            std::vector<std::string>{"j0", "j1"});
   // only torques should be random
-  EXPECT_EQ(random2.get_positions().norm(), 0);
-  EXPECT_EQ(random2.get_velocities().norm(), 0);
-  EXPECT_EQ(random2.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
   EXPECT_GT(random2.get_torques().norm(), 0);
 }
 
@@ -109,29 +109,29 @@ TEST(JointStateTest, CopyPosisitions) {
   JointPositions positions2(positions1);
   EXPECT_EQ(positions1.get_name(), positions2.get_name());
   EXPECT_TRUE(positions1.data().isApprox(positions2.data()));
-  EXPECT_EQ(positions2.get_velocities().norm(), 0);
-  EXPECT_EQ(positions2.get_accelerations().norm(), 0);
-  EXPECT_EQ(positions2.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions2).get_torques().norm(), 0);
   JointPositions positions3 = positions1;
   EXPECT_EQ(positions1.get_name(), positions3.get_name());
   EXPECT_TRUE(positions1.data().isApprox(positions3.data()));
-  EXPECT_EQ(positions3.get_velocities().norm(), 0);
-  EXPECT_EQ(positions3.get_accelerations().norm(), 0);
-  EXPECT_EQ(positions3.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions3).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions3).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions3).get_torques().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  positions1.set_velocities(Eigen::Vector3d::Random());
-  positions1.set_accelerations(Eigen::Vector3d::Random());
-  positions1.set_torques(Eigen::Vector3d::Random());
+  static_cast<JointState&>(positions1).set_velocities(Eigen::Vector3d::Random());
+  static_cast<JointState&>(positions1).set_accelerations(Eigen::Vector3d::Random());
+  static_cast<JointState&>(positions1).set_torques(Eigen::Vector3d::Random());
   JointPositions positions4 = positions1;
   EXPECT_TRUE(positions1.data().isApprox(positions4.data()));
-  EXPECT_EQ(positions4.get_velocities().norm(), 0);
-  EXPECT_EQ(positions4.get_accelerations().norm(), 0);
-  EXPECT_EQ(positions4.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions4).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions4).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions4).get_torques().norm(), 0);
   // copy a state, only the pose variables should be non 0
   JointPositions positions5 = JointState::Random("test", 3);
-  EXPECT_EQ(positions5.get_velocities().norm(), 0);
-  EXPECT_EQ(positions5.get_accelerations().norm(), 0);
-  EXPECT_EQ(positions5.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions5).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions5).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(positions5).get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, CopyVelocities) {
@@ -139,29 +139,29 @@ TEST(JointStateTest, CopyVelocities) {
   JointVelocities velocities2(velocities1);
   EXPECT_EQ(velocities1.get_name(), velocities2.get_name());
   EXPECT_TRUE(velocities1.data().isApprox(velocities2.data()));
-  EXPECT_EQ(velocities2.get_positions().norm(), 0);
-  EXPECT_EQ(velocities2.get_accelerations().norm(), 0);
-  EXPECT_EQ(velocities2.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities2).get_torques().norm(), 0);
   JointVelocities velocities3 = velocities1;
   EXPECT_EQ(velocities1.get_name(), velocities3.get_name());
   EXPECT_TRUE(velocities1.data().isApprox(velocities3.data()));
-  EXPECT_EQ(velocities3.get_positions().norm(), 0);
-  EXPECT_EQ(velocities3.get_accelerations().norm(), 0);
-  EXPECT_EQ(velocities3.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities3).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities3).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities3).get_torques().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  velocities1.set_positions(Eigen::Vector3d::Random());
-  velocities1.set_accelerations(Eigen::Vector3d::Random());
-  velocities1.set_torques(Eigen::Vector3d::Random());
+  static_cast<JointState&>(velocities1).set_positions(Eigen::Vector3d::Random());
+  static_cast<JointState&>(velocities1).set_accelerations(Eigen::Vector3d::Random());
+  static_cast<JointState&>(velocities1).set_torques(Eigen::Vector3d::Random());
   JointVelocities velocities4 = velocities1;
   EXPECT_TRUE(velocities1.data().isApprox(velocities4.data()));
-  EXPECT_EQ(velocities4.get_positions().norm(), 0);
-  EXPECT_EQ(velocities4.get_accelerations().norm(), 0);
-  EXPECT_EQ(velocities4.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities4).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities4).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities4).get_torques().norm(), 0);
   // copy a state, only the pose variables should be non 0
   JointVelocities velocities5 = JointState::Random("test", 3);
-  EXPECT_EQ(velocities5.get_positions().norm(), 0);
-  EXPECT_EQ(velocities5.get_accelerations().norm(), 0);
-  EXPECT_EQ(velocities5.get_torques().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities5).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities5).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(velocities5).get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, CopyTorques) {
@@ -169,29 +169,29 @@ TEST(JointStateTest, CopyTorques) {
   JointTorques torques2(torques1);
   EXPECT_EQ(torques1.get_name(), torques2.get_name());
   EXPECT_TRUE(torques1.data().isApprox(torques2.data()));
-  EXPECT_EQ(torques2.get_positions().norm(), 0);
-  EXPECT_EQ(torques2.get_velocities().norm(), 0);
-  EXPECT_EQ(torques2.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques2).get_accelerations().norm(), 0);
   JointTorques torques3 = torques1;
   EXPECT_EQ(torques1.get_name(), torques3.get_name());
   EXPECT_TRUE(torques1.data().isApprox(torques3.data()));
-  EXPECT_EQ(torques3.get_positions().norm(), 0);
-  EXPECT_EQ(torques3.get_velocities().norm(), 0);
-  EXPECT_EQ(torques3.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques3).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques3).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques3).get_accelerations().norm(), 0);
   // try to change non pose variables prior to the copy, those should be discarded
-  torques1.set_positions(Eigen::Vector3d::Random());
-  torques1.set_velocities(Eigen::Vector3d::Random());
-  torques1.set_accelerations(Eigen::Vector3d::Random());
+  static_cast<JointState&>(torques1).set_positions(Eigen::Vector3d::Random());
+  static_cast<JointState&>(torques1).set_velocities(Eigen::Vector3d::Random());
+  static_cast<JointState&>(torques1).set_accelerations(Eigen::Vector3d::Random());
   JointTorques torques4 = torques1;
   EXPECT_TRUE(torques1.data().isApprox(torques4.data()));
-  EXPECT_EQ(torques4.get_positions().norm(), 0);
-  EXPECT_EQ(torques4.get_velocities().norm(), 0);
-  EXPECT_EQ(torques4.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques4).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques4).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques4).get_accelerations().norm(), 0);
   // copy a state, only the pose variables should be non 0
   JointTorques torques5 = JointState::Random("test", 3);
-  EXPECT_EQ(torques5.get_positions().norm(), 0);
-  EXPECT_EQ(torques5.get_velocities().norm(), 0);
-  EXPECT_EQ(torques5.get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques5).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques5).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(torques5).get_accelerations().norm(), 0);
 }
 
 TEST(JointStateTest, GetData) {


### PR DESCRIPTION
Same as #102 but this time for `JointState` and its derivative.