### PR TITLE
Refactor kinematics and geometry

### DIFF
--- a/demos/scripts/robot_kinematics_control_loop.cpp
+++ b/demos/scripts/robot_kinematics_control_loop.cpp
@@ -31,12 +31,12 @@ public:
   void read_robot_state() {
     // this is a dummy robot, we assume the joint state is executed but add a bit of noise
     this->joint_state += 0.001 * JointState::Random(this->joint_state.get_name(), this->robot_.get_joint_frames());
-    this->eef_state = this->robot_.forward_geometry(this->joint_state);
+    this->eef_state = this->robot_.forward_kinematics(this->joint_state);
   }
 
   void send_control_command(const CartesianTwist& desired_eef_twist, const std::chrono::nanoseconds& dt) {
     // apply the inverse kinematics
-    JointVelocities desired_joint_velocities = this->robot_.inverse_kinematic(this->joint_state, desired_eef_twist);
+    JointVelocities desired_joint_velocities = this->robot_.inverse_velocity(desired_eef_twist, this->joint_state);
     // integrate the new position
     this->joint_state = dt * desired_joint_velocities + this->joint_state;
   }

--- a/source/robot_model/README.md
+++ b/source/robot_model/README.md
@@ -28,16 +28,16 @@ Most common robotics functionalities are implemented such `forward_kinematics`, 
 `forward_velocity, `inverse_velocity`, ...
 
 ```cpp
-// forward kinematics: pose of a robot frame from the robot joint positions
+// forward kinematics: pose of end-effector frame from the robot joint positions
 state_representation::JointPositions jp = state_representation::JointPositions::Random("myrobot", 7);
 state_representation::CartesianPose pose = model.forward_kinematics(jp);
-// inverse kinematics: joint positions from a pose
+// inverse kinematics: joint positions from end-effector pose
 state_representation::CartesianPose cp = state_representation::CartesianPose::Random("eef");
 state_representation::JointPositions jp = model.inverse_kinematics(cp);
-// forward velocity kinematic: twist of a robot frame from the robot joint velocities and positions
+// forward velocity kinematics: twist of end-effector frame from the robot joint velocities and positions
 state_representation::JointState js = state_representation::JointState::Random("myrobot", 7);
 state_representation::CartesianTwist twist = model.forward_velocity(js);
-// inverse velocity kinematic: joint velocities from a twist and current state of the robot
+// inverse velocity kinematics: joint velocities from end-effector twist and current state of the robot
 state_representation::CartesianTwist ct = state_representation::CartesianTwist::Random("eef");
 state_representation::JointPositions jp = state_representation::JointPositions::Random("myrobot", 7);
 state_representation::JointVelocities jv = model.inverse_velocity(ct, jp);

--- a/source/robot_model/README.md
+++ b/source/robot_model/README.md
@@ -24,23 +24,23 @@ At creation, it uses the parser from `pinocchio` to read the `URDF` file and fil
 
 ## Robot kinematics
 
-Most common robotics functionalities are implemented such `forward_geometry`, `inverse_geometry` (in development),
-`forward_kinematic`, `inverse_kinematic`, ...
+Most common robotics functionalities are implemented such `forward_kinematics`, `inverse_kinematics`,
+`forward_velocity, `inverse_velocity`, ...
 
 ```cpp
-// forward geometry: pose of a robot frame from the robot joint positions
+// forward kinematics: pose of a robot frame from the robot joint positions
 state_representation::JointPositions jp = state_representation::JointPositions::Random("myrobot", 7);
-state_representation::CartesianPose pose = model.forward_geometry(jp);
-// inverse geometry: joint positions from a pose
+state_representation::CartesianPose pose = model.forward_kinematics(jp);
+// inverse kinematics: joint positions from a pose
 state_representation::CartesianPose cp = state_representation::CartesianPose::Random("eef");
-state_representation::JointPositions jp = model.forward_geometry(cp);
-// forward kinematic: twist of a robot frame from the robot joint velocities and positions
+state_representation::JointPositions jp = model.inverse_kinematics(cp);
+// forward velocity kinematic: twist of a robot frame from the robot joint velocities and positions
 state_representation::JointState js = state_representation::JointState::Random("myrobot", 7);
-state_representation::CartesianTwist twist = model.forward_kinematic(js);
-// inverse kinematic: joint velocities from a twist and current state of the robot
+state_representation::CartesianTwist twist = model.forward_velocity(js);
+// inverse velocity kinematic: joint velocities from a twist and current state of the robot
 state_representation::CartesianTwist ct = state_representation::CartesianTwist::Random("eef");
 state_representation::JointPositions jp = state_representation::JointPositions::Random("myrobot", 7);
-state_representation::JointVelocities jv = model.inverse_kinematic(jp, ct);
+state_representation::JointVelocities jv = model.inverse_velocity(ct, jp);
 ```
 
 All of those functions check for inconsistencies between the model and the inputs (incompatibility of joints, frame
@@ -51,7 +51,7 @@ for bulk operations.
 ```cpp
 // pose of multiple robot frames from the robot joint positions
 state_representation::JointPositions jp = state_representation::JointPositions::Random("myrobot", 7);
-auto poses = model.forward_geometry(jp, std::vector<std::string>{"joint2", "eef_link"});
+auto poses = model.forward_kinematics(jp, std::vector<std::string>{"joint2", "eef_link"});
 ```
 
 The Jacobian of the robot can also be computed and stored in the `state_representation::Jacobian` wrapper:

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -326,7 +326,7 @@ public:
   state_representation::CartesianTwist forward_kinematics(const state_representation::JointState& joint_state);
 
   /**
-   * @brief Compute the inverse kinematic, i.e. joint velocities from the velocities of the frames in parameter
+   * @brief Compute the inverse kinematics, i.e. joint velocities from the velocities of the frames in parameter
    * @param joint_state usually the current joint state, used to compute the jacobian matrix
    * @param cartesian_twist vector of twist
    * @param parameters parameters of the inverse kinematics algorithm (default is default values of the
@@ -338,7 +338,7 @@ public:
                                                            const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
 
   /**
-   * @brief Compute the inverse kinematic, i.e. joint velocities from the twist of the end-effector
+   * @brief Compute the inverse kinematics, i.e. joint velocities from the twist of the end-effector
    * @param joint_state usually the current joint state, used to compute the jacobian matrix
    * @param cartesian_twist containing the twist of the end-effector
    * @param parameters parameters of the inverse kinematics algorithm (default is default values of the

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -23,7 +23,7 @@ namespace robot_model {
  * @param tolerance the maximum error tolerated between the desired cartesian state and the one obtained by the returned joint positions
  * @param max_number_of_iterations the maximum number of iterations that the algorithm do for solving the inverse geometry
  */
-struct InverseGeometryParameters {
+struct InverseKinematicsParameters {
   double damp = 1e-6;
   double alpha = 0.5;
   double gamma = 0.8;
@@ -33,14 +33,14 @@ struct InverseGeometryParameters {
 };
 
 /**
- * @brief parameters for the inverse kinematics function
+ * @brief parameters for the inverse velocity kinematics function
  * @param alpha for the time optimization
  * @param epsilon minimal time for the time optimization
  * @param proportional_gain gain to weight the cartesian coordinates in the gradient
  * @param linear_velocity_limit maximum linear velocity allowed in Cartesian space (m/s)
  * @param angular_velocity_limit maximum angular velocity allowed in Cartesian space (rad/s)
  */
-struct InverseKinematicsParameters {
+struct InverseVelocityParameters {
   double alpha = 0.1;
   double epsilon = 1e-2;
   double proportional_gain = 1.0;
@@ -77,34 +77,34 @@ private:
    * @brief initialize the constraints for the QP solver
    * @param parameters the parameters of the inverse kinematics algorithm
    */
-  bool init_qp_solver(const InverseKinematicsParameters& parameters);
+  bool init_qp_solver(const InverseVelocityParameters& parameters);
 
   /**
-   * @brief Compute the jacobian from a given joint state at the frame in parameter
-   * @param joint_state containing the joint values of the robot
+   * @brief Compute the jacobian from given joint positions at the frame in parameter
+   * @param joint_positions containing the joint positions of the robot
    * @param joint_id id of the frame at which to compute the jacobian
    * @return the jacobian matrix
    */
-  state_representation::Jacobian compute_jacobian(const state_representation::JointState& joint_state,
+  state_representation::Jacobian compute_jacobian(const state_representation::JointPositions& joint_positions,
                                                   unsigned int frame_id);
 
   /**
-   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
-   * @param joint_state the joint state of the robot
+   * @brief Compute the forward kinematics, i.e. the pose of certain frames from the joint values
+   * @param joint_positions the joint state of the robot
    * @param frame_ids ids of the frames at which we want to extract the pose
    * @return the desired poses
    */
-  std::vector<state_representation::CartesianPose> forward_geometry(const state_representation::JointState& joint_state,
-                                                                    const std::vector<unsigned int>& frame_ids);
+  std::vector<state_representation::CartesianPose> forward_kinematics(const state_representation::JointPositions& joint_positions,
+                                                                      const std::vector<unsigned int>& frame_ids);
 
   /**
-   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values for a single frame
-   * @param joint_state the joint state of the robot
+   * @brief Compute the forward kinematics, i.e. the pose of certain frames from the joint values for a single frame
+   * @param joint_positions the joint state of the robot
    * @param frame_id id of the frames at which we want to extract the pose
    * @return the desired pose
    */
-  state_representation::CartesianPose forward_geometry(const state_representation::JointState& joint_state,
-                                                       unsigned int frame_id);
+  state_representation::CartesianPose forward_kinematics(const state_representation::JointPositions& joint_positions,
+                                                         unsigned int frame_id);
 
   /**
    * @brief Check if the vector's elements are inside the parameter limits
@@ -230,11 +230,11 @@ public:
 
   /**
    * @brief Compute the jacobian from a given joint state at the frame given in parameter
-   * @param joint_state containing the joint values of the robot
+   * @param joint_positions containing the joint values of the robot
    * @param frame_name name of the frame at which to compute the jacobian, if empty computed for the last frame
    * @return the jacobian matrix
    */
-  state_representation::Jacobian compute_jacobian(const state_representation::JointState& joint_state,
+  state_representation::Jacobian compute_jacobian(const state_representation::JointPositions& joint_positions,
                                                   const std::string& frame_name = "");
 
   /**
@@ -275,79 +275,79 @@ public:
   state_representation::JointTorques compute_gravity_torques(const state_representation::JointPositions& joint_positions);
 
   /**
-   * @brief Compute the forward geometry, i.e. the pose of certain frames from the joint values
-   * @param joint_state the joint state of the robot
+   * @brief Compute the forward kinematics, i.e. the pose of certain frames from the joint values
+   * @param joint_positions the joint state of the robot
    * @param frame_names names of the frames at which we want to extract the pose
    * @return the pose of desired frames
    */
-  std::vector<state_representation::CartesianPose> forward_geometry(const state_representation::JointState& joint_state,
-                                                                    const std::vector<std::string>& frame_names);
+  std::vector<state_representation::CartesianPose> forward_kinematics(const state_representation::JointPositions& joint_positions,
+                                                                      const std::vector<std::string>& frame_names);
 
   /**
-   * @brief Compute the forward geometry, i.e. the pose of the frame from the joint values
-   * @param joint_state the joint state of the robot
+   * @brief Compute the forward kinematics, i.e. the pose of the frame from the joint values
+   * @param joint_positions the joint state of the robot
    * @param frame_name name of the frame at which we want to extract the pose
    * @return the pose of the desired frame
    */
-  state_representation::CartesianPose forward_geometry(const state_representation::JointState& joint_state,
-                                                       std::string frame_name = "");
+  state_representation::CartesianPose forward_kinematics(const state_representation::JointPositions& joint_positions,
+                                                         std::string frame_name = "");
 
   /**
    * @brief Compute the inverse geometry, i.e. joint values from the pose of the end-effector in a iteratively manner
-   * @param desired_cartesian_state containing the desired pose of the end-effector
+   * @param cartesian_pose containing the desired pose of the end-effector
    * @param frame_name name of the frame at which we want to extract the pose
    * @param parameters parameters of the inverse geometry algorithm (default is default values of the
    * InverseGeometryParameters structure)
    * @return the joint positions of the robot
    */
-  state_representation::JointPositions inverse_geometry(const state_representation::CartesianState& desired_cartesian_state,
-                                                        const std::string& frame_name = "",
-                                                        const InverseGeometryParameters& parameters = InverseGeometryParameters());
+  state_representation::JointPositions inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
+                                                          const std::string& frame_name = "",
+                                                          const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
 
   /**
-   * @brief Compute the inverse geometry, i.e. joint values from the pose of the end-effector
-   * @param desired_cartesian_state containing the desired pose of the end-effector
-   * @param current_joint_state current state of the robot containing the generalized position
+   * @brief Compute the inverse kinematics, i.e. joint values from the pose of the end-effector
+   * @param cartesian_pose containing the desired pose of the end-effector
+   * @param joint_positions current state of the robot containing the generalized position
    * @param frame_name name of the frame at which we want to extract the pose
    * @param parameters parameters of the inverse geometry algorithm (default is default values of the
    * InverseGeometryParameters structure)
    * @return the joint positions of the robot
    */
-  state_representation::JointPositions inverse_geometry(const state_representation::CartesianState& desired_cartesian_state,
-                                                        const state_representation::JointState& current_joint_state,
-                                                        const std::string& frame_name = "",
-                                                        const InverseGeometryParameters& parameters = InverseGeometryParameters());
+  state_representation::JointPositions inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
+                                                          const state_representation::JointPositions& joint_positions,
+                                                          const std::string& frame_name = "",
+                                                          const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
 
   /**
-   * @brief Compute the forward kinematics, i.e. the twist of the end-effector from the joint velocities
-   * @param joint_state the joint state of the robot
+   * @brief Compute the forward velocity kinematics, i.e. the twist of the end-effector from the joint velocities
+   * @param joint_state the joint state of the robot with positions to compute the Jacobian and velocities for the twist
    * @return the twist of the end-effector
    */
-  state_representation::CartesianTwist forward_kinematics(const state_representation::JointState& joint_state);
+  state_representation::CartesianTwist forward_velocity(const state_representation::JointState& joint_state);
 
   /**
-   * @brief Compute the inverse kinematics, i.e. joint velocities from the velocities of the frames in parameter
-   * @param joint_state usually the current joint state, used to compute the jacobian matrix
-   * @param cartesian_twist vector of twist
-   * @param parameters parameters of the inverse kinematics algorithm (default is default values of the
+   * @brief Compute the inverse velocity kinematics, i.e. joint velocities from the velocities of the frames in parameter
+   * @param cartesian_twists vector of twist
+   * @param joint_positions current joint positions, used to compute the jacobian matrix
+   * @param parameters parameters of the inverse velocity kinematics algorithm (default is default values of the
    * InverseKinematicsParameters structure)
    * @return the joint velocities of the robot
    */
-  state_representation::JointVelocities inverse_kinematics(const state_representation::JointState& joint_state,
-                                                           const std::vector<state_representation::CartesianTwist>& cartesian_states,
-                                                           const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
+  state_representation::JointVelocities inverse_velocity(const std::vector<state_representation::CartesianTwist>& cartesian_twists,
+                                                         const state_representation::JointPositions& joint_positions,
+                                                         const InverseVelocityParameters& parameters = InverseVelocityParameters());
 
   /**
-   * @brief Compute the inverse kinematics, i.e. joint velocities from the twist of the end-effector
-   * @param joint_state usually the current joint state, used to compute the jacobian matrix
+   * @brief Compute the inverse velocity kinematics, i.e. joint velocities from the twist of the end-effector
    * @param cartesian_twist containing the twist of the end-effector
-   * @param parameters parameters of the inverse kinematics algorithm (default is default values of the
+   * @param joint_positions current joint positions, used to compute the jacobian matrix
+   * @param parameters parameters of the inverse velocity kinematics algorithm (default is default values of the
    * InverseKinematicsParameters structure)
    * @return the joint velocities of the robot
    */
-  state_representation::JointVelocities inverse_kinematics(const state_representation::JointState& joint_state,
-                                                           const state_representation::CartesianTwist& cartesian_state,
-                                                           const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
+  state_representation::JointVelocities inverse_velocity(const state_representation::CartesianTwist& cartesian_twist,
+                                                         const state_representation::JointPositions& joint_positions,
+                                                         const InverseVelocityParameters& parameters = InverseVelocityParameters());
 
   /**
    * @brief Helper function to print the qp_problem (for debugging)

--- a/source/robot_model/include/robot_model/exceptions/InverseGeometryNotConvergingException.hpp
+++ b/source/robot_model/include/robot_model/exceptions/InverseGeometryNotConvergingException.hpp
@@ -6,7 +6,7 @@ namespace robot_model::exceptions {
 class InverseGeometryNotConvergingException : public std::exception {
 public:
   InverseGeometryNotConvergingException(unsigned int iterations, double error) :
-    msg_("The inverse kinematics algorithm did not converge.\nThe residual error after " + std::to_string(iterations) +
+    msg_("The inverse geometry algorithm did not converge.\nThe residual error after " + std::to_string(iterations) +
          " iterations is " + std::to_string(error) + ".") {}
 
    virtual char const *what() const noexcept {

--- a/source/robot_model/include/robot_model/exceptions/InverseGeometryNotConvergingException.hpp
+++ b/source/robot_model/include/robot_model/exceptions/InverseGeometryNotConvergingException.hpp
@@ -3,9 +3,9 @@
 #include <exception>
 
 namespace robot_model::exceptions {
-class IKDoesNotConverge : public std::exception {
+class InverseGeometryNotConvergingException : public std::exception {
 public:
-  IKDoesNotConverge(int iterations, double error) :
+  InverseGeometryNotConvergingException(unsigned int iterations, double error) :
     msg_("The inverse kinematics algorithm did not converge.\nThe residual error after " + std::to_string(iterations) +
          " iterations is " + std::to_string(error) + ".") {}
 

--- a/source/robot_model/include/robot_model/exceptions/InverseKinematicsNotConvergingException.hpp
+++ b/source/robot_model/include/robot_model/exceptions/InverseKinematicsNotConvergingException.hpp
@@ -6,7 +6,7 @@ namespace robot_model::exceptions {
 class InverseKinematicsNotConvergingException : public std::exception {
 public:
   InverseKinematicsNotConvergingException(unsigned int iterations, double error) :
-    msg_("The inverse geometry algorithm did not converge.\nThe residual error after " + std::to_string(iterations) +
+    msg_("The inverse kinematics algorithm did not converge.\nThe residual error after " + std::to_string(iterations) +
          " iterations is " + std::to_string(error) + ".") {}
 
    virtual char const *what() const noexcept {

--- a/source/robot_model/include/robot_model/exceptions/InverseKinematicsNotConvergingException.hpp
+++ b/source/robot_model/include/robot_model/exceptions/InverseKinematicsNotConvergingException.hpp
@@ -3,9 +3,9 @@
 #include <exception>
 
 namespace robot_model::exceptions {
-class InverseGeometryNotConvergingException : public std::exception {
+class InverseKinematicsNotConvergingException : public std::exception {
 public:
-  InverseGeometryNotConvergingException(unsigned int iterations, double error) :
+  InverseKinematicsNotConvergingException(unsigned int iterations, double error) :
     msg_("The inverse geometry algorithm did not converge.\nThe residual error after " + std::to_string(iterations) +
          " iterations is " + std::to_string(error) + ".") {}
 

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -109,21 +109,21 @@ protected:
   }
 };
 
-TEST_F(RobotModelKinematicsTest, TestForwardGeometryJointStateSize) {
+TEST_F(RobotModelKinematicsTest, TestForwardKinematicsJointStateSize) {
   state_representation::JointState dummy = state_representation::JointState(robot_name, 6);
   EXPECT_THROW(franka->forward_kinematics(dummy), exceptions::InvalidJointStateSizeException);
 }
 
-TEST_F(RobotModelKinematicsTest, TestForwardGeometryEE) {
+TEST_F(RobotModelKinematicsTest, TestForwardKinematicsEE) {
   EXPECT_EQ(franka->forward_kinematics(joint_state).get_position(),
             franka->forward_kinematics(joint_state, "panda_link8").get_position());
 }
 
-TEST_F(RobotModelKinematicsTest, TestForwardGeometryInvalidFrameName) {
+TEST_F(RobotModelKinematicsTest, TestForwardKinematicsInvalidFrameName) {
   EXPECT_THROW(franka->forward_kinematics(joint_state, "panda_link99"), exceptions::FrameNotFoundException);
 }
 
-TEST_F(RobotModelKinematicsTest, TestForwardGeometry) {
+TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
     state_representation::CartesianPose ee_pose = franka->forward_kinematics(test_configs[config]);
     EXPECT_TRUE(ee_pose.get_position().isApprox(test_fk_ee_expects.at(config).get_position()));
@@ -134,7 +134,7 @@ TEST_F(RobotModelKinematicsTest, TestForwardGeometry) {
   }
 }
 
-TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
+TEST_F(RobotModelKinematicsTest, TestForwardVelocity) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
     state_representation::CartesianTwist ee_twist = franka->forward_kinematics(test_configs[config]);
     EXPECT_TRUE(ee_twist.get_linear_velocity().isApprox(test_velocity_fk_expects.at(config).get_linear_velocity()));
@@ -142,7 +142,7 @@ TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
   }
 }
 
-TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
+TEST_F(RobotModelKinematicsTest, TestInverseVelocity) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
     state_representation::CartesianTwist ee_twist = franka->forward_velocity(test_configs[config]);
     state_representation::JointVelocities joint_twist = franka->inverse_velocity(ee_twist, test_configs[config]);
@@ -209,7 +209,7 @@ TEST_F(RobotModelKinematicsTest, TestClamp) {
   EXPECT_TRUE(franka->in_range(franka->clamp_in_range(joint_state)));
 }
 
-TEST_F(RobotModelKinematicsTest, TestInverseGeometry) {
+TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
   state_representation::JointState config1("robot", 7);
   state_representation::JointState config2("robot", 7);
   state_representation::JointState config3("robot", 7);
@@ -232,7 +232,7 @@ TEST_F(RobotModelKinematicsTest, TestInverseGeometry) {
   }
 }
 
-TEST_F(RobotModelKinematicsTest, TestInverseGeometryIKDoesNotConverge) {
+TEST_F(RobotModelKinematicsTest, TestInverseKinematicsIKDoesNotConverge) {
   state_representation::JointState config("robot", 7);
   // Random test configuration
   config.set_positions({-0.059943, 1.667088, 1.439900, -1.367141, -1.164922, 0.948034, 2.239983});

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -6,7 +6,7 @@
 
 #include "robot_model/exceptions/InvalidJointStateSizeException.hpp"
 #include "robot_model/exceptions/FrameNotFoundException.hpp"
-#include "robot_model/exceptions/IKDoesNotConverge.hpp"
+#include "robot_model/exceptions/InverseGeometryNotConvergingException.hpp"
 
 using namespace robot_model;
 
@@ -136,7 +136,7 @@ TEST_F(RobotModelKinematicsTest, TestForwardGeometry) {
 
 TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
-    state_representation::CartesianTwist ee_twist = franka->forward_kinematic(test_configs[config]);
+    state_representation::CartesianTwist ee_twist = franka->forward_kinematics(test_configs[config]);
     EXPECT_TRUE(ee_twist.get_linear_velocity().isApprox(test_velocity_fk_expects.at(config).get_linear_velocity()));
     EXPECT_TRUE(ee_twist.get_angular_velocity().isApprox(test_velocity_fk_expects.at(config).get_angular_velocity()));
   }
@@ -144,8 +144,8 @@ TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
 
 TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
-    state_representation::CartesianTwist ee_twist = franka->forward_kinematic(test_configs[config]);
-    state_representation::JointVelocities joint_twist = franka->inverse_kinematic(test_configs[config], ee_twist);
+    state_representation::CartesianTwist ee_twist = franka->forward_kinematics(test_configs[config]);
+    state_representation::JointVelocities joint_twist = franka->inverse_kinematics(test_configs[config], ee_twist);
     EXPECT_TRUE(joint_twist.get_velocities().isApprox(test_configs[config].get_velocities()));
   }
 }
@@ -240,5 +240,5 @@ TEST_F(RobotModelKinematicsTest, TestInverseGeometryIKDoesNotConverge) {
   param.max_number_of_iterations = 1;
   
   state_representation::CartesianPose reference = franka->forward_geometry(config, "panda_link8");
-  EXPECT_THROW(franka->inverse_geometry(reference, "panda_link8", param), exceptions::IKDoesNotConverge);
+  EXPECT_THROW(franka->inverse_geometry(reference, "panda_link8", param), exceptions::InverseGeometryNotConvergingException);
 }

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -136,7 +136,7 @@ TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
 
 TEST_F(RobotModelKinematicsTest, TestForwardVelocity) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
-    state_representation::CartesianTwist ee_twist = franka->forward_kinematics(test_configs[config]);
+    state_representation::CartesianTwist ee_twist = franka->forward_velocity(test_configs[config]);
     EXPECT_TRUE(ee_twist.get_linear_velocity().isApprox(test_velocity_fk_expects.at(config).get_linear_velocity()));
     EXPECT_TRUE(ee_twist.get_angular_velocity().isApprox(test_velocity_fk_expects.at(config).get_angular_velocity()));
   }

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -144,7 +144,7 @@ TEST_F(RobotModelKinematicsTest, TestForwardKinematics) {
 
 TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
   for (std::size_t config = 0; config < test_configs.size(); ++config) {
-    state_representation::CartesianTwist ee_twist = franka->forward_kinematics(test_configs[config]);
+    state_representation::CartesianTwist ee_twist = franka->forward_velocity(test_configs[config]);
     state_representation::JointVelocities joint_twist = franka->inverse_velocity(ee_twist, test_configs[config]);
     EXPECT_TRUE(joint_twist.get_velocities().isApprox(test_configs[config].get_velocities()));
   }


### PR DESCRIPTION
After merging PR #46 it became necessary to refactor the `inverse_kinematics` to follow the same structure in terms of parameter for consistency. Thanks @patr3 for introducing the structure input that is a much cleaner solution that what used to be there.

I also made some slight optimization and renamed the exception to be consistent with the current namings (although this is supposed to change in a near future).