### PR TITLE
Remove the non defined operators that were causing linking issues

### DIFF
--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -164,13 +164,6 @@ public:
   CartesianPose operator+(const CartesianPose& pose) const;
 
   /**
-   * @brief Overload the + operator with a state
-   * @param state CartesianState to add
-   * @return the current CartesianPose added the CartesianState given in argument
-   */
-  CartesianState operator+(const CartesianState& state) const;
-
-  /**
    * @brief Overload the -= operator
    * @param pose CartesianPose to subtract
    * @return the current CartesianPose minus the CartesianPose given in argument
@@ -183,13 +176,6 @@ public:
    * @return the current CartesianPose minus the CartesianPose given in argument
    */
   CartesianPose operator-(const CartesianPose& pose) const;
-
-  /**
-   * @brief Overload the - operator with a state
-   * @param state CartesianState to subtract
-   * @return the current CartesianPose minus the CartesianState given in argument
-   */
-  CartesianState operator-(const CartesianState& state) const;
 
   /**
    * @brief Overload the / operator with a time period


### PR DESCRIPTION
In `CartesianPose` there were two operators that where non defined `CartesianState operator+(CartesianState)` and the `-` one. This caused linking issue if using those. Those operations are actually defined thanks to state conversions. The only drawback is that the result is a `CartesianPose` not a `CartesianState`. I am actually not so sure if we want a `CartesianState` as a result. If we do, then we need to implement those operators and add the same ones for the other derived classes.