### PR TITLE
Feature/revise install script

### DIFF
--- a/source/install.sh
+++ b/source/install.sh
@@ -17,17 +17,17 @@ An install script for the control libraries.
 
 Options:
   --dir [path]             Configure the installation directory
-                           (default: /usr/local)
-  --no-controllers         Exclude the controllers library
-  --no-dynamical-systems   Exclude the dynamical systems library
-  --no-robot-model         Exclude the robot model library
-  --build-tests            Build the unittest targets
-  --help                   Show this help message
-  --clean                  Delete any previously installed
-                           header files from /usr/local/include and any
-                           shared library files from /usr/local/lib
-  --cleandir [path]        Delete any previously installed
-                           header and library files from the specified path"
+                           (default: /usr/local).
+  --no-controllers         Exclude the controllers library.
+  --no-dynamical-systems   Exclude the dynamical systems library.
+  --no-robot-model         Exclude the robot model library.
+  --build-tests            Build the unittest targets.
+  --help                   Show this help message.
+  --clean                  Delete any previously installed header
+                           files from /usr/local/include and any
+                           shared library files from /usr/local/lib.
+  --cleandir [path]        Delete any previously installed header
+                           and library files from the specified path."
 
 function uninstall {
   function delete_components {
@@ -62,10 +62,12 @@ while [ "$#" -gt 0 ]; do
 done
 
 # install base dependencies
+echo ">>> INSTALLING BASE DEPENDENCIES"
 apt-get update && apt-get install libeigen3-dev
 
 # install module-specific dependencies
 if [ "${BUILD_ROBOT_MODEL}" == "ON" ]; then
+  echo ">>> INSTALLING ROBOT MODEL DEPENDENCIES"
   apt-get install lsb-release gnupg2 curl
 
   # install pinocchio
@@ -95,14 +97,16 @@ fi
 
 # install testing dependencies
 if [ "${BUILD_TESTING}" == "ON" ]; then
+  echo ">>> INSTALLING TEST DEPENDENCIES"
   apt-get update && apt-get install libgtest-dev
 
-  mkdir -p "${SOURCE_PATH}"/tmp/lib && cd "${SOURCE_PATH}"/tmp/lib || exit 1
+  mkdir -p "${SOURCE_PATH}"/tmp/lib/gtest && cd "${SOURCE_PATH}"/tmp/lib/gtest || exit 1
   cmake /usr/src/gtest && make
   cp lib/* /usr/local/lib || cp ./*.a /usr/local/lib
 fi
 
 # build and install the specified modules
+echo ">>> BUILDING CONTROL LIBRARIES"
 cd "${SOURCE_PATH}" && mkdir -p build && cd build || exit 1
 
 cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" \

--- a/source/install.sh
+++ b/source/install.sh
@@ -6,23 +6,51 @@ BUILD_CONTROLLERS="ON"
 BUILD_DYNAMICAL_SYSTEMS="ON"
 BUILD_ROBOT_MODEL="ON"
 BUILD_TESTING="OFF"
+INSTALL_DESTINATION="/usr/local"
 
 FAIL_MESSAGE="The provided input arguments are not valid.
 Run the script with the '--help' argument."
 
-HELP_MESSAGE="Usage: ./install.sh [OPTIONS]
+HELP_MESSAGE="Usage: [sudo] ./install.sh [OPTIONS]
 
 An install script for the control libraries.
 
 Options:
+  --dir [path]             Configure the installation directory
+                           (default: /usr/local)
   --no-controllers         Exclude the controllers library
   --no-dynamical-systems   Exclude the dynamical systems library
   --no-robot-model         Exclude the robot model library
   --build-tests            Build the unittest targets
-  --help                   Show this help message"
+  --help                   Show this help message
+  --clean                  Delete any previously installed
+                           header files from /usr/local/include and any
+                           shared library files from /usr/local/lib
+  --cleandir [path]        Delete any previously installed
+                           header and library files from the specified path"
+
+function uninstall {
+  function delete_components {
+    rm -r "${INSTALL_DESTINATION}"/include/controllers
+    rm -r "${INSTALL_DESTINATION}"/include/dynamical_systems
+    rm -r "${INSTALL_DESTINATION}"/include/robot_model
+    rm -r "${INSTALL_DESTINATION}"/include/state_representation
+    rm -r "${INSTALL_DESTINATION}"/lib/libcontrollers*.so
+    rm -r "${INSTALL_DESTINATION}"/lib/libdynamical_systems*.so
+    rm -r "${INSTALL_DESTINATION}"/lib/librobot_model*.so
+    rm -r "${INSTALL_DESTINATION}"/lib/libstate_representation*.so
+  }
+
+  delete_components >/dev/null 2>&1
+
+  echo "Deleted any control library artefacts from ${INSTALL_DESTINATION}."
+}
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --dir) INSTALL_DESTINATION=$2; shift 2;;
+    --clean) uninstall; exit 1;;
+    --cleandir) INSTALL_DESTINATION=$2; uninstall; exit 1;;
     --no-controllers) BUILD_CONTROLLERS="OFF"; shift 1;;
     --no-dynamical-systems) BUILD_DYNAMICAL_SYSTEMS="OFF"; shift 1;;
     --no-robot-model) BUILD_ROBOT_MODEL="OFF"; shift 1;;
@@ -34,46 +62,59 @@ while [ "$#" -gt 0 ]; do
 done
 
 # install base dependencies
-apt-get update && apt-get install -y libeigen3-dev
+apt-get update && apt-get install libeigen3-dev
 
 # install module-specific dependencies
 if [ "${BUILD_ROBOT_MODEL}" == "ON" ]; then
-  apt-get install -y lsb-release gnupg2 curl
+  apt-get install lsb-release gnupg2 curl
 
   # install pinocchio
-  echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list
+  echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" \
+    | tee /etc/apt/sources.list.d/robotpkg.list
   curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | apt-key add -
 
-  apt-get update && apt-get install -y robotpkg-pinocchio
+  apt-get update && apt-get install robotpkg-pinocchio
 
   export PATH=/opt/openrobots/bin:$PATH
   export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:$PKG_CONFIG_PATH
   export LD_LIBRARY_PATH=/opt/openrobots/lib:$LD_LIBRARY_PATH
-  export PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:$PYTHONPATH # Adapt your desired python version here
   export CMAKE_PREFIX_PATH=/opt/openrobots:$CMAKE_PREFIX_PATH
 
   # install osqp
-  mkdir -p "${SOURCE_PATH}"/robot_model/lib
-  cd "${SOURCE_PATH}"/robot_model/lib && git clone --recursive https://github.com/oxfordcontrol/osqp
-  cd "${SOURCE_PATH}"/robot_model/lib/osqp/ && mkdir build && cd build && cmake -G "Unix Makefiles" .. && cmake --build . --target install
+  mkdir -p "${SOURCE_PATH}"/tmp/lib
+  cd "${SOURCE_PATH}"/tmp/lib || exit 1
+  git clone --recursive https://github.com/oxfordcontrol/osqp
+  cd "${SOURCE_PATH}"/tmp/lib/osqp/ && mkdir -p build && cd build || exit 1
+  cmake -G "Unix Makefiles" .. && cmake --build . --target install
   # install osqp eigen wrapper
-  cd "${SOURCE_PATH}"/robot_model/lib && git clone https://github.com/robotology/osqp-eigen.git
-  cd "${SOURCE_PATH}"/robot_model/lib/osqp-eigen && mkdir build && cd build && cmake .. && make -j && make install
+  cd "${SOURCE_PATH}"/tmp/lib || exit 1
+  git clone https://github.com/robotology/osqp-eigen.git
+  cd "${SOURCE_PATH}"/tmp/lib/osqp-eigen && mkdir -p build && cd build || exit 1
+  cmake .. && make -j && make install
 fi
 
 # install testing dependencies
 if [ "${BUILD_TESTING}" == "ON" ]; then
-  mkdir "${SOURCE_PATH}"/lib
-  cd "${SOURCE_PATH}"/lib && git clone --depth 1 --branch v1.10.x https://github.com/google/googletest.git
+  apt-get update && apt-get install libgtest-dev
+
+  mkdir -p "${SOURCE_PATH}"/tmp/lib && cd "${SOURCE_PATH}"/tmp/lib || exit 1
+  cmake /usr/src/gtest && make
+  cp lib/* /usr/local/lib || cp ./*.a /usr/local/lib
 fi
 
 # build and install the specified modules
-cd "${SOURCE_PATH}" && mkdir -p build && cd build \
-  && cmake -DBUILD_CONTROLLERS="${BUILD_CONTROLLERS}" \
-           -DBUILD_DYNAMICAL_SYSTEMS="${BUILD_DYNAMICAL_SYSTEMS}" \
-           -DBUILD_ROBOT_MODEL="${BUILD_ROBOT_MODEL}" \
-           -DBUILD_TESTING="${BUILD_TESTING}" .. \
-  && make -j && make install
+cd "${SOURCE_PATH}" && mkdir -p build && cd build || exit 1
+
+cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" \
+  -DBUILD_CONTROLLERS="${BUILD_CONTROLLERS}" \
+  -DBUILD_DYNAMICAL_SYSTEMS="${BUILD_DYNAMICAL_SYSTEMS}" \
+  -DBUILD_ROBOT_MODEL="${BUILD_ROBOT_MODEL}" \
+  -DBUILD_TESTING="${BUILD_TESTING}" ..
+
+make -j && make install
+
+# cleanup any temporary folders
+rm -rf "${SOURCE_PATH}"/tmp
 
 # reset location
 cd "${SOURCE_PATH}" || return

--- a/source/install.sh
+++ b/source/install.sh
@@ -70,19 +70,19 @@ done
 
 # install base dependencies
 echo ">>> INSTALLING BASE DEPENDENCIES"
-apt-get update && apt-get install "${AUTO_INSTALL}" libeigen3-dev
+apt-get update && apt-get install "${AUTO_INSTALL}" libeigen3-dev || exit 1
 
 # install module-specific dependencies
 if [ "${BUILD_ROBOT_MODEL}" == "ON" ]; then
   echo ">>> INSTALLING ROBOT MODEL DEPENDENCIES"
-  apt-get install "${AUTO_INSTALL}" lsb-release gnupg2 curl
+  apt-get install "${AUTO_INSTALL}" lsb-release gnupg2 curl || exit 1
 
   # install pinocchio
   echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" \
     | tee /etc/apt/sources.list.d/robotpkg.list
   curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | apt-key add -
 
-  apt-get update && apt-get install "${AUTO_INSTALL}" robotpkg-pinocchio
+  apt-get update && apt-get install "${AUTO_INSTALL}" robotpkg-pinocchio || exit 1
 
   export PATH=/opt/openrobots/bin:$PATH
   export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:$PKG_CONFIG_PATH
@@ -105,7 +105,7 @@ fi
 # install testing dependencies
 if [ "${BUILD_TESTING}" == "ON" ]; then
   echo ">>> INSTALLING TEST DEPENDENCIES"
-  apt-get update && apt-get install "${AUTO_INSTALL}" libgtest-dev
+  apt-get update && apt-get install "${AUTO_INSTALL}" libgtest-dev || exit 1
 
   mkdir -p "${SOURCE_PATH}"/tmp/lib/gtest && cd "${SOURCE_PATH}"/tmp/lib/gtest || exit 1
   cmake /usr/src/gtest && make


### PR DESCRIPTION
* Add installation directory option to change where
the header and library files are installed (this
can be used to avoid root requirements by installing
somewhere other than /usr/local)

* Add clean and cleandir commands to remove include
directories and library files generated by the
control libraries installation

* Install gtest through apt (like in the docker file)
instead of from source with git

* Add -p flag to all mkdir to prevent errors if the directory
already exists

* Break long lines into multiple lines, and always check
exit condition after a `cd` command

* Remove default -y argument from apt-get installations,
so that the user is fully aware of what is being installed

* Place temporary library build folders in a tmp directory
that is deleted at the end

* Remove unneeded PYTHONPATH export, since
the pinocchio python bindings are not an install
requirement

* Add echo printouts in build stages

* Add punctuation to help text

* Fixup temporary install dir for gtest

---

This change was prompted by and should close #119 , and includes a number of quality of life improvements to the install script.

I tested this by making a dummy docker container, copying the control libraries source file and running the following tests (as root):

- Run default install multiple times
- Run with build-test argument
- Run with non-default install directory
- Run clean and cleandir commands, including when nothing was installed
- Make non-empty directories at the /tmp/build locations before install

In all cases the behaviour was as expected and the installation succeeded.