### PR TITLE
Fix the inverse velocity

### DIFF
--- a/demos/control_loop_examples/scripts/robot_kinematics_control_loop.cpp
+++ b/demos/control_loop_examples/scripts/robot_kinematics_control_loop.cpp
@@ -35,7 +35,7 @@ public:
 
   void send_control_command(const CartesianTwist& desired_eef_twist, const std::chrono::nanoseconds& dt) {
     // create the inverse velocity parameters and set the period of the control loop
-    InverseVelocityParameters parameters;
+    QPInverseVelocityParameters parameters;
     parameters.dt = dt;
     // apply the inverse velocity
     JointVelocities desired_joint_velocities = this->robot_.inverse_velocity(desired_eef_twist,

--- a/demos/control_loop_examples/scripts/robot_kinematics_control_loop.cpp
+++ b/demos/control_loop_examples/scripts/robot_kinematics_control_loop.cpp
@@ -29,14 +29,18 @@ public:
   }
 
   void read_robot_state() {
-    // this is a dummy robot, we assume the joint state is executed but add a bit of noise
-    this->joint_positions += 0.001 * JointPositions::Random(this->joint_positions.get_name(), this->robot_.get_joint_frames());
+    // this is a dummy robot, we assume the joint state is executed
     this->eef_pose = this->robot_.forward_kinematics(this->joint_positions);
   }
 
   void send_control_command(const CartesianTwist& desired_eef_twist, const std::chrono::nanoseconds& dt) {
-    // apply the inverse kinematics
-    JointVelocities desired_joint_velocities = this->robot_.inverse_velocity(desired_eef_twist, this->joint_positions);
+    // create the inverse velocity parameters and set the period of the control loop
+    InverseVelocityParameters parameters;
+    parameters.dt = dt;
+    // apply the inverse velocity
+    JointVelocities desired_joint_velocities = this->robot_.inverse_velocity(desired_eef_twist,
+                                                                             this->joint_positions,
+                                                                             parameters);
     // integrate the new position
     this->joint_positions = dt * desired_joint_velocities + this->joint_positions;
   }
@@ -59,7 +63,9 @@ void control_loop_step(DummyRobotInterface& robot,
 void control_loop(DummyRobotInterface& robot, const std::chrono::nanoseconds& dt, double tolerance) {
   // set a desired target for the robot eef and a linear ds toward the target
   CartesianPose target(robot.eef_pose.get_name(), robot.eef_pose.get_reference_frame());
-  target.set_position(.5, .0, .5);
+  target.set_position(.5, .0, .75);
+  Eigen::Quaterniond orientation(Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitY()));
+  target.set_orientation(orientation);
   Linear<CartesianState> linear_ds(target);
 
   double distance;
@@ -83,6 +89,6 @@ int main(int, char**) {
   std::string robot_name = "franka";
   std::string urdf_path = std::string(SCRIPT_FIXTURES) + "panda_arm.urdf";
   DummyRobotInterface robot("franka", urdf_path);
-  auto dt = 10ms;
+  auto dt = 100ms;
   control_loop(robot, dt, 1e-3);
 }

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -34,15 +34,15 @@ struct InverseKinematicsParameters {
 
 /**
  * @brief parameters for the inverse velocity kinematics function
- * @param alpha for the time optimization
- * @param epsilon minimal time for the time optimization
+ * @param alpha gain associated to the time slack variable
+ * @param epsilon minimal value of the time slack variable (dt of the control loop)
  * @param proportional_gain gain to weight the cartesian coordinates in the gradient
  * @param linear_velocity_limit maximum linear velocity allowed in Cartesian space (m/s)
  * @param angular_velocity_limit maximum angular velocity allowed in Cartesian space (rad/s)
  */
 struct InverseVelocityParameters {
   double alpha = 0.1;
-  double epsilon = 1e-2;
+  double epsilon = 1e-9;
   double proportional_gain = 1.0;
   double linear_velocity_limit = 2.0;
   double angular_velocity_limit = 2.0;

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -13,6 +13,8 @@
 #include <state_representation/robot/JointState.hpp>
 #include <state_representation/space/cartesian/CartesianState.hpp>
 
+using namespace std::chrono_literals;
+
 namespace robot_model {
 /**
  * @brief parameters for the inverse geometry function
@@ -35,17 +37,17 @@ struct InverseKinematicsParameters {
 /**
  * @brief parameters for the inverse velocity kinematics function
  * @param alpha gain associated to the time slack variable
- * @param epsilon minimal value of the time slack variable (dt of the control loop)
  * @param proportional_gain gain to weight the cartesian coordinates in the gradient
  * @param linear_velocity_limit maximum linear velocity allowed in Cartesian space (m/s)
  * @param angular_velocity_limit maximum angular velocity allowed in Cartesian space (rad/s)
+ * @param period of the control loop (ns)
  */
 struct InverseVelocityParameters {
   double alpha = 0.1;
-  double epsilon = 1e-9;
   double proportional_gain = 1.0;
   double linear_velocity_limit = 2.0;
   double angular_velocity_limit = 2.0;
+  std::chrono::nanoseconds dt = 1ms;
 };
 
 /**

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -340,28 +340,28 @@ public:
   /**
    * @brief Compute the inverse geometry, i.e. joint values from the pose of the end-effector in a iteratively manner
    * @param cartesian_pose containing the desired pose of the end-effector
-   * @param frame_name name of the frame at which we want to extract the pose
    * @param parameters parameters of the inverse geometry algorithm (default is default values of the
-   * InverseGeometryParameters structure)
+   * InverseKinematicsParameters structure)
+   * @param frame_name name of the frame at which we want to extract the pose
    * @return the joint positions of the robot
    */
   state_representation::JointPositions inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
-                                                          const std::string& frame_name = "",
-                                                          const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
+                                                          const InverseKinematicsParameters& parameters = InverseKinematicsParameters(),
+                                                          const std::string& frame_name = "");
 
   /**
    * @brief Compute the inverse kinematics, i.e. joint values from the pose of the end-effector
    * @param cartesian_pose containing the desired pose of the end-effector
    * @param joint_positions current state of the robot containing the generalized position
-   * @param frame_name name of the frame at which we want to extract the pose
    * @param parameters parameters of the inverse geometry algorithm (default is default values of the
-   * InverseGeometryParameters structure)
+   * InverseKinematicsParameters structure)
+   * @param frame_name name of the frame at which we want to extract the pose
    * @return the joint positions of the robot
    */
   state_representation::JointPositions inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
                                                           const state_representation::JointPositions& joint_positions,
-                                                          const std::string& frame_name = "",
-                                                          const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
+                                                          const InverseKinematicsParameters& parameters = InverseKinematicsParameters(),
+                                                          const std::string& frame_name = "");
 
   /**
    * @brief Compute the forward velocity kinematics, i.e. the twist of certain frames from the joint values

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -77,7 +77,7 @@ private:
    * @brief initialize the constraints for the QP solver
    * @param parameters the parameters of the inverse kinematics algorithm
    */
-  bool init_qp_solver(const InverseVelocityParameters& parameters);
+  bool init_qp_solver();
 
   /**
    * @brief Compute the Jacobian from given joint positions at the frame in parameter

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -413,7 +413,7 @@ public:
    * @param cartesian_twists vector of twist
    * @param joint_positions current joint positions, used to compute the jacobian matrix
    * @param parameters parameters of the inverse velocity kinematics algorithm (default is default values of the
-   * InverseVelocityParameters structure)
+   * QPInverseVelocityParameters structure)
    * @param frame_names names of the frames at which we want to compute the twists
    * @return the joint velocities of the robot
    */

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -429,7 +429,7 @@ public:
    * @param joint_positions current joint positions, used to compute the Jacobian matrix
    * @param joint_positions current joint positions, used to compute the jacobian matrix
    * @param parameters parameters of the inverse velocity kinematics algorithm (default is default values of the
-   * InverseVelocityParameters structure)
+   * QPInverseVelocityParameters structure)
    * @param frame_name name of the frame at which we want to compute the twist
    * @return the joint velocities of the robot
    */

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -400,7 +400,7 @@ public:
    * @param joint_positions current joint positions, used to compute the jacobian matrix
    * @param frame_name name of the frame at which we want to compute the twist
    * @param parameters parameters of the inverse velocity kinematics algorithm (default is default values of the
-   * InverseVelocityParameters structure)
+   * QPInverseVelocityParameters structure)
    * @return the joint velocities of the robot
    */
   state_representation::JointVelocities inverse_velocity(const state_representation::CartesianTwist& cartesian_twist,

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -453,8 +453,8 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
   // extract the solution
   JointVelocities result(joint_positions.get_name(), joint_positions.get_names());
   Eigen::VectorXd delta_q = solution.head(nb_joints);
-  double T = solution(nb_joints);
-  result.set_velocities(delta_q / T);
+  //double T = solution(nb_joints);
+  //result.set_velocities(delta_q / T);
   return result;
 }
 

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -318,8 +318,8 @@ Eigen::VectorXd Model::cwln_repulsive_potential_field(const state_representation
 state_representation::JointPositions
 Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
                           const state_representation::JointPositions& joint_positions,
-                          const std::string& frame_name,
-                          const InverseKinematicsParameters& parameters) {
+                          const InverseKinematicsParameters& parameters,
+                          const std::string& frame_name) {
   unsigned int frame_id;
   if (frame_name.empty()) {
     // get last frame if none specified
@@ -370,11 +370,11 @@ Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_p
 
 state_representation::JointPositions
 Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
-                          const std::string& frame_name,
-                          const InverseKinematicsParameters& parameters) {
+                          const InverseKinematicsParameters& parameters,
+                          const std::string& frame_name) {
   Eigen::VectorXd q(pinocchio::neutral(this->robot_model_));
   state_representation::JointPositions positions(this->get_robot_name(), this->get_joint_frames(), q);
-  return this->inverse_kinematics(cartesian_pose, positions, frame_name, parameters);
+  return this->inverse_kinematics(cartesian_pose, positions, parameters, frame_name);
 }
 
 std::vector<state_representation::CartesianTwist>

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -414,7 +414,7 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
     jacobian.block(3 * i, 0, 3 * i + 3, nb_joints) =
         this->compute_jacobian(joint_positions, twist.get_name()).data().block(0, 0, 3, nb_joints);
   }
-  // extract the orientation for the end-effector
+  // extract pose for the end-effector
   CartesianTwist state = cartesian_twists.back();
   delta_r.segment<3>(3 * (cartesian_twists.size() - 1)) = state.get_linear_velocity();
   delta_r.tail(3) = state.get_angular_velocity();
@@ -445,12 +445,10 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
   this->solver_.updateLinearConstraintsMatrix(this->constraint_matrix_);
   // solve the QP problem
   this->solver_.solve();
-  Eigen::VectorXd solution = this->solver_.getSolution();
   // extract the solution
-  JointVelocities result(joint_positions.get_name(), joint_positions.get_names());
-  Eigen::VectorXd delta_q = solution.head(nb_joints);
-  //double T = solution(nb_joints);
-  result.set_velocities(delta_q);
+  JointVelocities result(joint_positions.get_name(),
+                         joint_positions.get_names(),
+                         this->solver_.getSolution().head(nb_joints));
   return result;
 }
 

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -454,7 +454,7 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
   JointVelocities result(joint_positions.get_name(), joint_positions.get_names());
   Eigen::VectorXd delta_q = solution.head(nb_joints);
   //double T = solution(nb_joints);
-  //result.set_velocities(delta_q / T);
+  result.set_velocities(delta_q);
   return result;
 }
 

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -427,7 +427,7 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
     jacobian.block(3 * i, 0, 3 * i + 3, nb_joints) =
         this->compute_jacobian(joint_positions, frame_names.at(i)).data().block(0, 0, 3, nb_joints);
   }
-  // full twist for the end-effector
+  // full twist for the last provided frame
   state_representation::CartesianTwist eef_twist = cartesian_twists.back();
   dX.tail(6) = eef_twist.data();
   jacobian.bottomRows(6) = this->compute_jacobian(joint_positions, frame_names.back()).data();
@@ -470,7 +470,7 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
     jacobian.block(3 * i, 0, 3 * i + 3, nb_joints) =
         this->compute_jacobian(joint_positions, frame_names.at(i)).data().block(0, 0, 3, nb_joints);
   }
-  // extract pose for the end-effector
+  // extract pose for the last provided frame
   CartesianTwist eef_twist = cartesian_twists.back();
   CartesianPose eef_displacement = eef_twist;
   delta_r.segment<3>(3 * (cartesian_twists.size() - 1)) = eef_displacement.get_position();

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -269,7 +269,7 @@ TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
 
   for (auto& config : test_configs) {
     state_representation::CartesianPose reference = franka->forward_kinematics(config, "panda_link8");
-    state_representation::JointPositions q = franka->inverse_kinematics(reference, "panda_link8", param);
+    state_representation::JointPositions q = franka->inverse_kinematics(reference, param, "panda_link8");
     state_representation::CartesianPose X = franka->forward_kinematics(q, "panda_link8");
     EXPECT_TRUE(((reference - X) / dt).data().cwiseAbs().maxCoeff() < tol);
   }
@@ -283,7 +283,7 @@ TEST_F(RobotModelKinematicsTest, TestInverseKinematicsIKDoesNotConverge) {
   param.max_number_of_iterations = 1;
 
   state_representation::CartesianPose reference = franka->forward_kinematics(config, "panda_link8");
-  EXPECT_THROW(franka->inverse_kinematics(reference, "panda_link8", param),
+  EXPECT_THROW(franka->inverse_kinematics(reference, param, "panda_link8"),
                exceptions::InverseKinematicsNotConvergingException);
 }
 


### PR DESCRIPTION
Finally I came up with a solution to fix this inverse velocity. First I need to give you some context on the actual algorithm. The algorithm is based on https://hal.archives-ouvertes.fr/hal-01521582/document where they solve the inverse velocity in a quadratic programming optimization by adding the time of the control loop as a slack variable. This has some interesting benefits as it allows to slows down to respect velocity limits or maximal velocity of the end-effector. Because it is an optimization problem you can also add constraints to respect joint limits. Then I mixed another approach from Salman, previous postdoc in the lab (https://infoscience.epfl.ch/record/228940/files/root.pdf) that instead of having `dX = J * dq` as a constraint, adds it in the gradient of the optimization. This is for the basics.

Now the actual problem was twofold. First, the original algorithm was using displacement and not actual velocity. Initially, I thought I could just use the velocities instead and it was kind of working. Wrong! The constraints were actually not correct doing so. So I came back to considering displacement and not velocities and double checked all the constraints. Then I notice another problem, the original paper had the the position constraints incorrect. So I corrected that as well and now everything is working fine.

Somehow, I still have this test error but it is not related as I got the same thing when using `dq = J^-1 * dX`. So the actual test I used to check the convergence is the `robot_kinematics_control_loop` demo. You can try and it converges nicely. I actually tried different period for the control loop (this is now a parameter of the algorithm), all of them lead to convergence.

Before merging this PR we should find a nice unit test that validates it. Because of the time slack variable, the result might not be exactly the same as an algorithm from Matlab. Obviously it should be in a similar order though.