### PR TITLE
Pass the frame name as argument of the forward velocity function

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -355,9 +355,11 @@ public:
   /**
    * @brief Compute the forward velocity kinematics, i.e. the twist of the end-effector from the joint velocities
    * @param joint_state the joint state of the robot with positions to compute the Jacobian and velocities for the twist
-   * @return the twist of the end-effector
+   * @param frame_name name of the frame at which we want to compute the twist
+   * @return the twist of the frame in parameter
    */
-  state_representation::CartesianTwist forward_velocity(const state_representation::JointState& joint_state);
+  state_representation::CartesianTwist forward_velocity(const state_representation::JointState& joint_state,
+                                                        const std::string& frame_name = "");
 
   /**
    * @brief Compute the inverse velocity kinematics, i.e. joint velocities from the velocities of the frames in parameter

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -353,6 +353,15 @@ public:
                                                           const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
 
   /**
+   * @brief Compute the forward velocity kinematics, i.e. the twist of certain frames from the joint values
+   * @param joint_state the joint state of the robot with positions to compute the Jacobian and velocities for the twist
+   * @param frame_names name of the frames at which we want to compute the twist
+   * @return the twists of the frames in parameter
+   */
+  std::vector<state_representation::CartesianTwist> forward_velocity(const state_representation::JointState& joint_state,
+                                                                    const std::vector<std::string>& frame_names);
+
+  /**
    * @brief Compute the forward velocity kinematics, i.e. the twist of the end-effector from the joint velocities
    * @param joint_state the joint state of the robot with positions to compute the Jacobian and velocities for the twist
    * @param frame_name name of the frame at which we want to compute the twist

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -359,7 +359,7 @@ public:
    * @return the twists of the frames in parameter
    */
   std::vector<state_representation::CartesianTwist> forward_velocity(const state_representation::JointState& joint_state,
-                                                                    const std::vector<std::string>& frame_names);
+                                                                     const std::vector<std::string>& frame_names);
 
   /**
    * @brief Compute the forward velocity kinematics, i.e. the twist of the end-effector from the joint velocities

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -385,8 +385,9 @@ Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_p
   return this->inverse_kinematics(cartesian_pose, positions, frame_name, parameters);
 }
 
-state_representation::CartesianTwist Model::forward_velocity(const state_representation::JointState& joint_state) {
-  return this->compute_jacobian(joint_state) * static_cast<state_representation::JointVelocities>(joint_state);
+state_representation::CartesianTwist Model::forward_velocity(const state_representation::JointState& joint_state,
+                                                             const std::string& frame_name) {
+  return this->compute_jacobian(joint_state, frame_name) * static_cast<state_representation::JointVelocities>(joint_state);
 }
 
 state_representation::JointVelocities

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -385,9 +385,20 @@ Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_p
   return this->inverse_kinematics(cartesian_pose, positions, frame_name, parameters);
 }
 
+std::vector<state_representation::CartesianTwist>
+Model::forward_velocity(const state_representation::JointState& joint_state,
+                        const std::vector<std::string>& frame_names) {
+  std::vector<state_representation::CartesianTwist> cartesian_twists(frame_names.size());
+  for (std::size_t i = 0; i < frame_names.size(); ++i) {
+    cartesian_twists.at(i) = this->compute_jacobian(joint_state, frame_names.at(i))
+        * static_cast<state_representation::JointVelocities>(joint_state);
+  }
+  return cartesian_twists;
+}
+
 state_representation::CartesianTwist Model::forward_velocity(const state_representation::JointState& joint_state,
                                                              const std::string& frame_name) {
-  return this->compute_jacobian(joint_state, frame_name) * static_cast<state_representation::JointVelocities>(joint_state);
+  return this->forward_velocity(joint_state, std::vector<std::string>{frame_name}).front();
 }
 
 state_representation::JointVelocities


### PR DESCRIPTION
Checking the tests for the `inverse_velocity`, I realized the `forward_velocity` did not include the frame name as argument. This is a simple fix as it just needs to be forwarded to the computation of the Jacobian, which handle all the errors and correct checking.