### PR TITLE
Remove redundancy in IK arguments

### DIFF
--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -329,27 +329,23 @@ public:
   /**
    * @brief Compute the inverse geometry, i.e. joint values from the pose of the end-effector in a iteratively manner
    * @param cartesian_pose containing the desired pose of the end-effector
-   * @param frame_name name of the frame at which we want to extract the pose
    * @param parameters parameters of the inverse geometry algorithm (default is default values of the
    * InverseGeometryParameters structure)
    * @return the joint positions of the robot
    */
   state_representation::JointPositions inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
-                                                          const std::string& frame_name = "",
                                                           const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
 
   /**
    * @brief Compute the inverse kinematics, i.e. joint values from the pose of the end-effector
    * @param cartesian_pose containing the desired pose of the end-effector
    * @param joint_positions current state of the robot containing the generalized position
-   * @param frame_name name of the frame at which we want to extract the pose
    * @param parameters parameters of the inverse geometry algorithm (default is default values of the
    * InverseGeometryParameters structure)
    * @return the joint positions of the robot
    */
   state_representation::JointPositions inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
                                                           const state_representation::JointPositions& joint_positions,
-                                                          const std::string& frame_name = "",
                                                           const InverseKinematicsParameters& parameters = InverseKinematicsParameters());
 
   /**

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -326,19 +326,12 @@ Eigen::VectorXd Model::cwln_repulsive_potential_field(const state_representation
 state_representation::JointPositions
 Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
                           const state_representation::JointPositions& joint_positions,
-                          const std::string& frame_name,
                           const InverseKinematicsParameters& parameters) {
-  unsigned int frame_id;
-  if (frame_name.empty()) {
-    // get last frame if none specified
-    frame_id = this->robot_model_.getFrameId(this->robot_model_.frames.back().name);
-  } else {
-    // throw error if specified frame does not exist
-    if (!this->robot_model_.existFrame(frame_name)) {
-      throw (exceptions::FrameNotFoundException(frame_name));
-    }
-    frame_id = this->robot_model_.getFrameId(frame_name);
+  // throw error if specified frame does not exist
+  if (!this->robot_model_.existFrame(cartesian_pose.get_name())) {
+    throw (exceptions::FrameNotFoundException(cartesian_pose.get_name()));
   }
+  unsigned int frame_id = this->robot_model_.getFrameId(cartesian_pose.get_name());
   std::string actual_frame_name = this->robot_model_.frames[frame_id].name;
   // 1 second for the Newton-Raphson method
   const std::chrono::nanoseconds dt(static_cast<int>(1e9));
@@ -378,11 +371,10 @@ Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_p
 
 state_representation::JointPositions
 Model::inverse_kinematics(const state_representation::CartesianPose& cartesian_pose,
-                          const std::string& frame_name,
                           const InverseKinematicsParameters& parameters) {
   Eigen::VectorXd q(pinocchio::neutral(this->robot_model_));
   state_representation::JointPositions positions(this->get_robot_name(), this->get_joint_frames(), q);
-  return this->inverse_kinematics(cartesian_pose, positions, frame_name, parameters);
+  return this->inverse_kinematics(cartesian_pose, positions, parameters);
 }
 
 state_representation::CartesianTwist Model::forward_velocity(const state_representation::JointState& joint_state) {

--- a/source/robot_model/test/tests/test_kinematics.cpp
+++ b/source/robot_model/test/tests/test_kinematics.cpp
@@ -253,7 +253,7 @@ TEST_F(RobotModelKinematicsTest, TestInverseKinematics) {
 
   for (auto& config : test_configs) {
     state_representation::CartesianPose reference = franka->forward_kinematics(config, "panda_link8");
-    state_representation::JointPositions q = franka->inverse_kinematics(reference, "panda_link8", param);
+    state_representation::JointPositions q = franka->inverse_kinematics(reference, param);
     state_representation::CartesianPose X = franka->forward_kinematics(q, "panda_link8");
     EXPECT_TRUE(((reference - X) / dt).data().cwiseAbs().maxCoeff() < tol);
   }
@@ -267,7 +267,7 @@ TEST_F(RobotModelKinematicsTest, TestInverseKinematicsIKDoesNotConverge) {
   param.max_number_of_iterations = 1;
 
   state_representation::CartesianPose reference = franka->forward_kinematics(config, "panda_link8");
-  EXPECT_THROW(franka->inverse_kinematics(reference, "panda_link8", param),
+  EXPECT_THROW(franka->inverse_kinematics(reference, param),
                exceptions::InverseKinematicsNotConvergingException);
 }
 


### PR DESCRIPTION
I have noticed that the argument of the `inverse_kinematics` function are redundant and error prone. Because the pose is already provided in the function, there is no need to pass the frame name as well as it is already included in the name of the pose. Because those need to match, included both is actually error prone.