### PR TITLE
CartesianTwistController class and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Release Versions:
 - [2.0.0](#200)
 - [1.0.0](#100)
 
+
+## Upcoming changes (in development)
+
+### Features
+
+- Add a concrete CartesianTwistController to easily control
+linear and angular velocity with a set of 4 gains (#135)
+
+
 ## 2.0.0
 
 Version 2.0.0 introduces usage demos for CMake and ROS/ROS2 projects,

--- a/source/controllers/CMakeLists.txt
+++ b/source/controllers/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(
 )
 
 set(CORE_SOURCES
+  src/impedance/CartesianTwistController.cpp
   src/impedance/Impedance.cpp
   src/impedance/VelocityImpedance.cpp
   src/impedance/Dissipative.cpp

--- a/source/controllers/include/controllers/impedance/CartesianTwistController.hpp
+++ b/source/controllers/include/controllers/impedance/CartesianTwistController.hpp
@@ -46,6 +46,26 @@ public:
   explicit CartesianTwistController(const Eigen::Vector4d& gains);
 
   /**
+   * @brief Copy constructor
+   * @param other the controller to copy
+   */
+  CartesianTwistController(const CartesianTwistController& other);
+
+  /**
+   * @brief Swap the values of the two controllers
+   * @param controller1 controller to be swapped with 2
+   * @param controller2 controller to be swapped with 1
+   */
+  friend void swap(CartesianTwistController& controller1, CartesianTwistController& controller2);
+
+  /**
+   * @param Assignment operator
+   * @param other the controller to copy
+   * @return reference to the controller with values from other
+   */
+  CartesianTwistController& operator=(const CartesianTwistController& other);
+
+  /**
  * @brief Setter of the linear principle damping
  * @param the new principle damping value
  */
@@ -82,6 +102,18 @@ public:
    * @param angular_damping the new angular damping value
    */
   void set_angular_gains(double angular_stiffness, double angular_damping);
+
+  /**
+   * @brief Setter of the controller gains
+   * @param linear_principle_damping damping along principle eigenvector of linear velocity error
+   * @param linear_orthogonal_damping damping along secondary eigenvectors of linear velocity error
+   * @param angular_stiffness stiffness of angular displacement
+   * @param angular_damping damping of angular velocity error
+   */
+  void set_gains(double linear_principle_damping,
+                 double linear_orthogonal_damping,
+                 double angular_stiffness,
+                 double angular_damping);
 
   /**
    * @brief Setter of the controller gains
@@ -125,5 +157,14 @@ public:
                                                    const state_representation::CartesianState& feedback_state,
                                                    const state_representation::Jacobian& jacobian) override;
 };
+
+inline void swap(CartesianTwistController& controller1, CartesianTwistController& controller2) {
+  std::swap(controller1.linear_principle_damping_, controller2.linear_principle_damping_);
+  std::swap(controller1.linear_orthogonal_damping_, controller2.linear_orthogonal_damping_);
+  std::swap(controller1.angular_stiffness_, controller2.angular_stiffness_);
+  std::swap(controller1.angular_damping_, controller2.angular_damping_);
+  swap(controller1.dissipative_ctrl_, controller2.dissipative_ctrl_);
+  swap(controller1.velocity_impedance_ctrl_, controller2.velocity_impedance_ctrl_);
+}
 
 }// namespace controllers

--- a/source/controllers/include/controllers/impedance/CartesianTwistController.hpp
+++ b/source/controllers/include/controllers/impedance/CartesianTwistController.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "controllers/Controller.hpp"
+#include "controllers/impedance/Dissipative.hpp"
+#include "controllers/impedance/VelocityImpedance.hpp"
+#include "state_representation/parameters/Parameter.hpp"
+
+namespace controllers::impedance {
+/**
+ * @class CartesianTwistController
+ * @brief A concrete controller class specifically for controlling
+ * 6 degree of freedom Cartesian twist with a combination of impedance
+ * controllers. The linear velocity is controlled with the Dissipative
+ * controller class, while the angular velocity is controlled
+ * with the VelocityImpedance class.
+ */
+class CartesianTwistController : public Controller<state_representation::CartesianState> {
+private:
+  std::shared_ptr<state_representation::Parameter<double>>
+      linear_principle_damping_; ///< damping along principle eigenvector of linear velocity error
+  std::shared_ptr<state_representation::Parameter<double>>
+      linear_orthogonal_damping_; ///< damping along secondary eigenvectors of linear velocity error
+  std::shared_ptr<state_representation::Parameter<double>> angular_stiffness_; ///< stiffness of angular displacement
+  std::shared_ptr<state_representation::Parameter<double>> angular_damping_; ///< damping of angular velocity error
+
+  Dissipative<state_representation::CartesianState> dissipative_ctrl_;
+  VelocityImpedance<state_representation::CartesianState> velocity_impedance_ctrl_;
+public:
+  /**
+   * @brief Constructor for the CartesianTwistController
+   * @param linear_principle_damping damping along principle eigenvector of linear velocity error
+   * @param linear_orthogonal_damping damping along secondary eigenvectors of linear velocity error
+   * @param angular_stiffness stiffness of angular displacement
+   * @param angular_damping damping of angular velocity error
+   */
+  CartesianTwistController(double linear_principle_damping,
+                           double linear_orthogonal_damping,
+                           double angular_stiffness,
+                           double angular_damping);
+
+  /**
+   * @brief Constructor for the CartesianTwistController with vector form gains
+   * @param gains Eigen 4d vector of gains in the order linear_principle_damping,
+   * linear_orthogonal_damping, angular_stiffness, angular_damping
+   */
+  explicit CartesianTwistController(const Eigen::Vector4d& gains);
+
+  /**
+ * @brief Setter of the linear principle damping
+ * @param the new principle damping value
+ */
+  void set_linear_principle_damping(double linear_principle_damping);
+
+  /**
+ * @brief Setter of the linear orthogonal damping
+ * @param the new orthogonal damping value
+ */
+  void set_linear_orthogonal_damping(double linear_orthogonal_damping);
+
+  /**
+   * @brief Setter of the linear damping values
+   * @param linear_principle_damping the new principle damping value
+   * @param linear_orthogonal_damping the new orthogonal damping value
+   */
+  void set_linear_gains(double linear_principle_damping, double linear_orthogonal_damping);
+
+  /**
+   * @brief Setter of the angular stiffness
+   * @param the new stiffness value
+   */
+  void set_angular_stiffness(double angular_stiffness);
+
+  /**
+   * @brief Setter of the angular damping
+   * @param the new damping value
+   */
+  void set_angular_damping(double angular_damping);
+
+  /**
+   * @brief Setter of the angular damping
+   * @param angular_stiffness the new angular stiffness value
+   * @param angular_damping the new angular damping value
+   */
+  void set_angular_gains(double angular_stiffness, double angular_damping);
+
+  /**
+   * @brief Setter of the controller gains
+   * @param the new gains as a vector of linear principle damping,
+   * linear orthogonal, angular stiffness and angular damping values
+   */
+  void set_gains(const Eigen::Vector4d& gains);
+
+  /**
+   * @brief Getter of the controller gains
+   * @return the new gains as a vector of linear principle damping,
+   * linear orthogonal, angular stiffness and angular damping values
+   */
+  Eigen::Vector4d get_gains() const;
+
+  /**
+   * @brief Return a list of all the parameters of the controller
+   * @return the list of parameters
+   */
+  std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const override;
+
+  /**
+   * @brief Compute the force (task space) or torque (joint space) command based on the input state 
+   * of the system as the error between the desired state and the real state.
+   * @param desired_state the desired state to reach
+   * @param feedback_state the real state of the system as read from feedback loop
+   * @return the output command at the input state
+   */
+  state_representation::CartesianState compute_command(const state_representation::CartesianState& desired_state,
+                                                       const state_representation::CartesianState& feedback_state) override;
+
+  /**
+   * @brief Compute the command based on the desired state and a feedback state in a non const fashion
+   * To be redefined based on the actual controller implementation.
+   * @param desired_state the desired state of the system.
+   * @param feedback_state the real state of the system as read from feedback loop
+   * @param jacobian the Jacobian matrix of the robot to convert from one state to the other
+   * @return the output command at the input state
+   */
+  state_representation::JointState compute_command(const state_representation::CartesianState& desired_state,
+                                                   const state_representation::CartesianState& feedback_state,
+                                                   const state_representation::Jacobian& jacobian) override;
+};
+
+}// namespace controllers

--- a/source/controllers/include/controllers/impedance/CartesianTwistController.hpp
+++ b/source/controllers/include/controllers/impedance/CartesianTwistController.hpp
@@ -66,15 +66,15 @@ public:
   CartesianTwistController& operator=(const CartesianTwistController& other);
 
   /**
- * @brief Setter of the linear principle damping
- * @param the new principle damping value
- */
+   * @brief Setter of the linear principle damping
+   * @param the new principle damping value
+   */
   void set_linear_principle_damping(double linear_principle_damping);
 
   /**
- * @brief Setter of the linear orthogonal damping
- * @param the new orthogonal damping value
- */
+   * @brief Setter of the linear orthogonal damping
+   * @param the new orthogonal damping value
+   */
   void set_linear_orthogonal_damping(double linear_orthogonal_damping);
 
   /**

--- a/source/controllers/src/impedance/CartesianTwistController.cpp
+++ b/source/controllers/src/impedance/CartesianTwistController.cpp
@@ -22,10 +22,34 @@ CartesianTwistController::CartesianTwistController(const Eigen::Vector4d& gains)
 
 }
 
+CartesianTwistController::CartesianTwistController(const CartesianTwistController& other) :
+    linear_principle_damping_(std::make_shared<Parameter<double>>("linear_principle_damping", other.get_gains()(0))),
+    linear_orthogonal_damping_(std::make_shared<Parameter<double>>("linear_orthogonal_damping", other.get_gains()(1))),
+    angular_stiffness_(std::make_shared<Parameter<double>>("angular_stiffness", other.get_gains()(2))),
+    angular_damping_(std::make_shared<Parameter<double>>("angular_damping", other.get_gains()(3))),
+    dissipative_ctrl_(other.dissipative_ctrl_),
+    velocity_impedance_ctrl_(other.velocity_impedance_ctrl_) {
+}
+
+CartesianTwistController& CartesianTwistController::operator=(const CartesianTwistController& other) {
+  CartesianTwistController tmp(other);
+  swap(*this, tmp);
+  return *this;
+}
+
+void CartesianTwistController::set_gains(double linear_principle_damping,
+                                         double linear_orthogonal_damping,
+                                         double angular_stiffness,
+                                         double angular_damping) {
+  set_linear_gains(linear_principle_damping, linear_orthogonal_damping);
+  set_angular_gains(angular_stiffness, angular_damping);
+}
+
 void CartesianTwistController::set_gains(const Eigen::Vector4d& gains) {
   set_linear_gains(gains(0), gains(1));
   set_angular_gains(gains(2), gains(3));
 }
+
 
 Eigen::Vector4d CartesianTwistController::get_gains() const {
   return Eigen::Vector4d(linear_principle_damping_->get_value(),

--- a/source/controllers/src/impedance/CartesianTwistController.cpp
+++ b/source/controllers/src/impedance/CartesianTwistController.cpp
@@ -16,13 +16,12 @@ CartesianTwistController::CartesianTwistController(double linear_principle_dampi
     angular_damping_(std::make_shared<Parameter<double>>("angular_damping", angular_damping)),
     dissipative_ctrl_(ComputationalSpaceType::LINEAR),
     velocity_impedance_ctrl_(Eigen::MatrixXd::Zero(6, 6), Eigen::MatrixXd::Zero(6, 6)) {
+  set_linear_gains(linear_principle_damping, linear_orthogonal_damping);
   set_angular_gains(angular_stiffness, angular_damping);
 }
 
 CartesianTwistController::CartesianTwistController(const Eigen::Vector4d& gains) :
-    CartesianTwistController(gains(0), gains(1), gains(2), gains(3)) {
-
-}
+    CartesianTwistController(gains(0), gains(1), gains(2), gains(3)) {}
 
 CartesianTwistController::CartesianTwistController(const CartesianTwistController& other) :
     linear_principle_damping_(std::make_shared<Parameter<double>>("linear_principle_damping", other.get_gains()(0))),
@@ -30,8 +29,7 @@ CartesianTwistController::CartesianTwistController(const CartesianTwistControlle
     angular_stiffness_(std::make_shared<Parameter<double>>("angular_stiffness", other.get_gains()(2))),
     angular_damping_(std::make_shared<Parameter<double>>("angular_damping", other.get_gains()(3))),
     dissipative_ctrl_(other.dissipative_ctrl_),
-    velocity_impedance_ctrl_(other.velocity_impedance_ctrl_) {
-}
+    velocity_impedance_ctrl_(other.velocity_impedance_ctrl_) {}
 
 CartesianTwistController& CartesianTwistController::operator=(const CartesianTwistController& other) {
   CartesianTwistController tmp(other);
@@ -91,7 +89,8 @@ void CartesianTwistController::set_angular_gains(double angular_stiffness, doubl
   Eigen::MatrixXd k(6, 6), d(6, 6);
   k.diagonal() << 0, 0, 0, angular_stiffness, angular_stiffness, angular_stiffness;
   d.diagonal() << 0, 0, 0, angular_damping, angular_damping, angular_damping;
-  velocity_impedance_ctrl_ = VelocityImpedance<CartesianState>(k, d);
+  velocity_impedance_ctrl_.set_stiffness(k);
+  velocity_impedance_ctrl_.set_damping(d);
 }
 
 std::list<std::shared_ptr<ParameterInterface>> CartesianTwistController::get_parameters() const {

--- a/source/controllers/src/impedance/CartesianTwistController.cpp
+++ b/source/controllers/src/impedance/CartesianTwistController.cpp
@@ -1,0 +1,95 @@
+#include "controllers/impedance/CartesianTwistController.hpp"
+
+namespace controllers::impedance {
+
+using namespace state_representation;
+
+CartesianTwistController::CartesianTwistController(double linear_principle_damping,
+                                                   double linear_orthogonal_damping,
+                                                   double angular_stiffness,
+                                                   double angular_damping) :
+    linear_principle_damping_(std::make_shared<Parameter<double>>("linear_principle_damping", linear_principle_damping)),
+    linear_orthogonal_damping_(std::make_shared<Parameter<double>>("linear_orthogonal_damping", linear_orthogonal_damping)),
+    angular_stiffness_(std::make_shared<Parameter<double>>("angular_stiffness", angular_stiffness)),
+    angular_damping_(std::make_shared<Parameter<double>>("angular_damping", angular_damping)),
+    dissipative_ctrl_(ComputationalSpaceType::LINEAR),
+    velocity_impedance_ctrl_(Eigen::MatrixXd::Zero(6, 6), Eigen::MatrixXd::Zero(6, 6)) {
+  set_angular_gains(angular_stiffness, angular_damping);
+}
+
+CartesianTwistController::CartesianTwistController(const Eigen::Vector4d& gains) :
+  CartesianTwistController(gains(0), gains(1), gains(2), gains(3)) {
+
+}
+
+void CartesianTwistController::set_gains(const Eigen::Vector4d& gains) {
+  set_linear_gains(gains(0), gains(1));
+  set_angular_gains(gains(2), gains(3));
+}
+
+Eigen::Vector4d CartesianTwistController::get_gains() const {
+  return Eigen::Vector4d(linear_principle_damping_->get_value(),
+                         linear_orthogonal_damping_->get_value(),
+                         angular_stiffness_->get_value(),
+                         angular_damping_->get_value());
+}
+
+void CartesianTwistController::set_linear_principle_damping(double linear_principle_damping) {
+  set_linear_gains(linear_principle_damping, linear_orthogonal_damping_->get_value());
+}
+
+void CartesianTwistController::set_linear_orthogonal_damping(double linear_orthogonal_damping) {
+  set_linear_gains(linear_principle_damping_->get_value(), linear_orthogonal_damping);
+}
+
+void CartesianTwistController::set_linear_gains(double linear_principle_damping, double linear_orthogonal_damping) {
+  linear_principle_damping_->set_value(linear_principle_damping);
+  linear_orthogonal_damping_->set_value(linear_orthogonal_damping);
+
+  Eigen::VectorXd damping(6);
+  damping << linear_principle_damping, linear_orthogonal_damping, linear_orthogonal_damping, 0, 0, 0;
+  dissipative_ctrl_.set_damping_eigenvalues(damping);
+}
+
+void CartesianTwistController::set_angular_stiffness(double angular_stiffness) {
+  set_angular_gains(angular_stiffness, angular_damping_->get_value());
+}
+
+void CartesianTwistController::set_angular_damping(double angular_damping) {
+  set_angular_gains(angular_stiffness_->get_value(), angular_damping);
+}
+
+void CartesianTwistController::set_angular_gains(double angular_stiffness, double angular_damping) {
+  angular_stiffness_->set_value(angular_stiffness);
+  angular_damping_->set_value(angular_damping);
+
+  Eigen::MatrixXd k(6, 6), d(6, 6);
+  k.diagonal() << 0, 0, 0, angular_stiffness, angular_stiffness, angular_stiffness;
+  d.diagonal() << 0, 0, 0, angular_damping, angular_damping, angular_damping;
+  velocity_impedance_ctrl_ = VelocityImpedance<CartesianState>(k, d);
+}
+
+std::list<std::shared_ptr<state_representation::ParameterInterface>> CartesianTwistController::get_parameters() const {
+  std::list<std::shared_ptr<state_representation::ParameterInterface>> param_list;
+  param_list.push_back(linear_principle_damping_);
+  param_list.push_back(linear_orthogonal_damping_);
+  param_list.push_back(angular_stiffness_);
+  param_list.push_back(angular_damping_);
+  return param_list;
+}
+
+state_representation::CartesianState CartesianTwistController::compute_command(const state_representation::CartesianState& desired_state,
+                                                                               const state_representation::CartesianState& feedback_state) {
+  CartesianWrench command = dissipative_ctrl_.compute_command(CartesianTwist(desired_state), CartesianTwist(feedback_state));
+  command += velocity_impedance_ctrl_.compute_command(desired_state, feedback_state);
+  return command;
+}
+
+state_representation::JointState CartesianTwistController::compute_command(const state_representation::CartesianState& desired_state,
+                                                                           const state_representation::CartesianState& feedback_state,
+                                                                           const state_representation::Jacobian& jacobian) {
+  CartesianWrench wrench = compute_command(desired_state, feedback_state);
+  return jacobian.transpose() * wrench;
+}
+
+}

--- a/source/controllers/src/impedance/CartesianTwistController.cpp
+++ b/source/controllers/src/impedance/CartesianTwistController.cpp
@@ -8,8 +8,10 @@ CartesianTwistController::CartesianTwistController(double linear_principle_dampi
                                                    double linear_orthogonal_damping,
                                                    double angular_stiffness,
                                                    double angular_damping) :
-    linear_principle_damping_(std::make_shared<Parameter<double>>("linear_principle_damping", linear_principle_damping)),
-    linear_orthogonal_damping_(std::make_shared<Parameter<double>>("linear_orthogonal_damping", linear_orthogonal_damping)),
+    linear_principle_damping_(std::make_shared<Parameter<double>>("linear_principle_damping",
+                                                                  linear_principle_damping)),
+    linear_orthogonal_damping_(std::make_shared<Parameter<double>>("linear_orthogonal_damping",
+                                                                   linear_orthogonal_damping)),
     angular_stiffness_(std::make_shared<Parameter<double>>("angular_stiffness", angular_stiffness)),
     angular_damping_(std::make_shared<Parameter<double>>("angular_damping", angular_damping)),
     dissipative_ctrl_(ComputationalSpaceType::LINEAR),
@@ -18,7 +20,7 @@ CartesianTwistController::CartesianTwistController(double linear_principle_dampi
 }
 
 CartesianTwistController::CartesianTwistController(const Eigen::Vector4d& gains) :
-  CartesianTwistController(gains(0), gains(1), gains(2), gains(3)) {
+    CartesianTwistController(gains(0), gains(1), gains(2), gains(3)) {
 
 }
 
@@ -49,7 +51,6 @@ void CartesianTwistController::set_gains(const Eigen::Vector4d& gains) {
   set_linear_gains(gains(0), gains(1));
   set_angular_gains(gains(2), gains(3));
 }
-
 
 Eigen::Vector4d CartesianTwistController::get_gains() const {
   return Eigen::Vector4d(linear_principle_damping_->get_value(),
@@ -93,8 +94,8 @@ void CartesianTwistController::set_angular_gains(double angular_stiffness, doubl
   velocity_impedance_ctrl_ = VelocityImpedance<CartesianState>(k, d);
 }
 
-std::list<std::shared_ptr<state_representation::ParameterInterface>> CartesianTwistController::get_parameters() const {
-  std::list<std::shared_ptr<state_representation::ParameterInterface>> param_list;
+std::list<std::shared_ptr<ParameterInterface>> CartesianTwistController::get_parameters() const {
+  std::list<std::shared_ptr<ParameterInterface>> param_list;
   param_list.push_back(linear_principle_damping_);
   param_list.push_back(linear_orthogonal_damping_);
   param_list.push_back(angular_stiffness_);
@@ -102,16 +103,16 @@ std::list<std::shared_ptr<state_representation::ParameterInterface>> CartesianTw
   return param_list;
 }
 
-state_representation::CartesianState CartesianTwistController::compute_command(const state_representation::CartesianState& desired_state,
-                                                                               const state_representation::CartesianState& feedback_state) {
+CartesianState
+CartesianTwistController::compute_command(const CartesianState& desired_state, const CartesianState& feedback_state) {
   CartesianWrench command = dissipative_ctrl_.compute_command(CartesianTwist(desired_state), CartesianTwist(feedback_state));
   command += velocity_impedance_ctrl_.compute_command(desired_state, feedback_state);
   return command;
 }
 
-state_representation::JointState CartesianTwistController::compute_command(const state_representation::CartesianState& desired_state,
-                                                                           const state_representation::CartesianState& feedback_state,
-                                                                           const state_representation::Jacobian& jacobian) {
+JointState CartesianTwistController::compute_command(const CartesianState& desired_state,
+                                                     const CartesianState& feedback_state,
+                                                     const Jacobian& jacobian) {
   CartesianWrench wrench = compute_command(desired_state, feedback_state);
   return jacobian.transpose() * wrench;
 }

--- a/source/controllers/test/tests/test_cartesian_twist_controller.cpp
+++ b/source/controllers/test/tests/test_cartesian_twist_controller.cpp
@@ -8,6 +8,28 @@
 using namespace controllers::impedance;
 using namespace state_representation;
 
+TEST(CartesianTwistControllerTest, Constructors) {
+  CartesianTwistController a(1, 2, 3, 4);
+  CartesianTwistController b(Eigen::Vector4d(11, 22, 33, 44));
+
+  EXPECT_NE(a.get_gains().norm(), b.get_gains().norm());
+
+  // copy constructor
+  CartesianTwistController c(a);
+  EXPECT_DOUBLE_EQ(a.get_gains().norm(), c.get_gains().norm());
+
+  // check that the copy was performed deeply and correctly (no shared references)
+  c.set_gains(Eigen::Vector4d(111, 222, 333, 444));
+  EXPECT_NE(a.get_gains().norm(), c.get_gains().norm());
+
+  // check copy by assignment
+  c = b;
+  EXPECT_DOUBLE_EQ(b.get_gains().norm(), c.get_gains().norm());
+
+  // check that the copy was performed deeply and correctly (no shared references)
+  c.set_gains(Eigen::Vector4d(111, 222, 333, 444));
+  EXPECT_NE(b.get_gains().norm(), c.get_gains().norm());
+}
 
 TEST(CartesianTwistControllerTest, CartesianWrench) {
   CartesianTwistController controller(100, 100, 5, 5);

--- a/source/controllers/test/tests/test_cartesian_twist_controller.cpp
+++ b/source/controllers/test/tests/test_cartesian_twist_controller.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include "controllers/impedance/CartesianTwistController.hpp"
+#include "state_representation/space/cartesian/CartesianWrench.hpp"
+#include "state_representation/space/cartesian/CartesianTwist.hpp"
+#include "state_representation/robot/JointTorques.hpp"
+
+using namespace controllers::impedance;
+using namespace state_representation;
+
+
+TEST(CartesianTwistControllerTest, CartesianWrench) {
+  CartesianTwistController controller(100, 100, 5, 5);
+
+  auto desired_twist = CartesianTwist::Identity("test");
+  auto feedback_twist = CartesianTwist::Identity("test");
+
+  // check command when desired state == feedback state
+  CartesianWrench command = controller.compute_command(desired_twist, feedback_twist);
+  EXPECT_NEAR(command.data().norm(), 0.0, 1e-5);
+
+  // check command when there is linear velocity error
+  desired_twist.set_linear_velocity(Eigen::Vector3d::Random());
+  command = controller.compute_command(desired_twist, feedback_twist);
+  EXPECT_GT(command.get_force().norm(), 0.0);
+  EXPECT_NEAR(command.get_torque().norm(), 0.0, 1e-5);
+
+  // check command when there is angular velocity error
+  desired_twist.set_linear_velocity(Eigen::Vector3d::Zero());
+  desired_twist.set_angular_velocity(Eigen::Vector3d::Random());
+  command = controller.compute_command(desired_twist, feedback_twist);
+  // expect some non-null data for force
+  EXPECT_NEAR(command.get_force().norm(), 0.0, 1e-5);
+  EXPECT_GT(command.get_torque().norm(), 0.0);
+}
+
+TEST(CartesianTwistControllerTest, JointTorques) {
+  CartesianTwistController controller(100, 100, 5, 5);
+
+  auto desired_twist = CartesianTwist::Random("test");
+  auto feedback_twist = CartesianTwist::Identity("test");
+  auto jacobian = Jacobian::Random("test_robot", 3, "test");
+
+  JointTorques command = controller.compute_command(desired_twist, feedback_twist, jacobian);
+  // expect some non-null data
+  EXPECT_GT(command.data().norm(), 0.0);
+}
+
+TEST(CartesianTwistControllerTest, ParametersAndSetters) {
+  CartesianTwistController controller(1, 2, 3, 4);
+
+  auto params = controller.get_parameters();
+  EXPECT_EQ(params.size(), 4);
+  for (auto& param_interface : params) {
+    auto param = std::dynamic_pointer_cast<Parameter<double>>(param_interface);
+    if (param->get_name() == "linear_principle_damping") {
+      EXPECT_NEAR(param->get_value(), 1, 1e-5);
+      EXPECT_NEAR(controller.get_gains()(0), 1, 1e-5);
+      param->set_value(11);
+      EXPECT_NEAR(controller.get_gains()(0), 11, 1e-5);
+      controller.set_linear_principle_damping(21);
+      EXPECT_NEAR(param->get_value(), 21, 1e-5);
+    } else if (param->get_name() == "linear_orthogonal_damping") {
+      EXPECT_NEAR(param->get_value(), 2, 1e-5);
+      EXPECT_NEAR(controller.get_gains()(1), 2, 1e-5);
+      param->set_value(12);
+      EXPECT_NEAR(controller.get_gains()(1), 12, 1e-5);
+      controller.set_linear_orthogonal_damping(22);
+      EXPECT_NEAR(param->get_value(), 22, 1e-5);
+    } else if (param->get_name() == "angular_stiffness") {
+      EXPECT_NEAR(param->get_value(), 3, 1e-5);
+      EXPECT_NEAR(controller.get_gains()(2), 3, 1e-5);
+      param->set_value(13);
+      EXPECT_NEAR(controller.get_gains()(2), 13, 1e-5);
+      controller.set_angular_stiffness(23);
+      EXPECT_NEAR(param->get_value(), 23, 1e-5);
+    } else if (param->get_name() == "angular_damping") {
+      EXPECT_NEAR(param->get_value(), 4, 1e-5);
+      EXPECT_NEAR(controller.get_gains()(3), 4, 1e-5);
+      param->set_value(14);
+      EXPECT_NEAR(controller.get_gains()(3), 14, 1e-5);
+      controller.set_angular_damping(24);
+      EXPECT_NEAR(param->get_value(), 24, 1e-5);
+    }
+  }
+}


### PR DESCRIPTION
* Add concrete controller class to wrap Dissipative
controller for linear velocity and VelocityImpedance
controller for angular velocity under one roof,
with a simple set of 4 gains (linear principle
and orthogonal damping, angular stiffness and
damping)

---

Long overdue, I finally got around to making a simple concrete controller class to wrap the dissipative and velocity impedance controller. In short, an easy peasy controller for Cartesian twist (within the impedance namespace). 