### PR TITLE
Load urdf from ROS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Release Versions:
 - Add a concrete CartesianTwistController to easily control
 linear and angular velocity with a set of 4 gains (#135)
 - Add a joint velocity control demo in the ROS demo package that 
-showcases the `robot_model` module (#136)
+showcases the `robot_model` module (#136, #139)
 
 ## 2.0.0
 


### PR DESCRIPTION
While trying to make this work for the Stäubli, I realized that this is a good opportunity to showcase the `create_urdf_from_string` function because in a more realistic setting, you would get the urdf from the ROS param server. So this demo can work for any robot now, not just the franka