### PR TITLE
Jacobian pybindings

### DIFF
--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -6,6 +6,9 @@
 
 void bind_jacobian(py::module_& m) {
   py::class_<Jacobian, State> c(m, "Jacobian");
+
+  c.def_property_readonly_static("__array_priority__", [](py::object) { return 10000; });
+
   c.def(py::init<const std::string&, unsigned int, const std::string&, const std::string&>(),
         "Constructor with name, number of joints, frame name and reference frame provided",
         "robot_name"_a, "nb_joints"_a, "frame"_a, "reference_frame"_a = "world");
@@ -56,11 +59,11 @@ void bind_jacobian(py::module_& m) {
 
   c.def("__getitem__", [](const Jacobian& jacobian, std::tuple<int, int> coefficients) {
     return jacobian(std::get<0>(coefficients), std::get<1>(coefficients));
-  }, "Overload the [] operator to modify the value at given (row, col)");
+  }, "Overload the [] operator to access the value at given (row, col)");
   c.def("__setitem__", [](Jacobian& jacobian, std::tuple<int, int> coefficients, double value) {
     jacobian(std::get<0>(coefficients), std::get<1>(coefficients)) = value;
     return jacobian;
-  }, "Overload the [] operator to access the value at given (row, col)");
+  }, "Overload the [] operator to modify the value at given (row, col)");
 
   c.def(py::self * Eigen::MatrixXd());
   c.def(py::self * py::self);

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -3,7 +3,8 @@
 #include <state_representation/State.hpp>
 #include <state_representation/robot/Jacobian.hpp>
 // TODO import necessary?
-#include <state_representation/space/cartesian/CartesianPose.hpp>
+//#include <state_representation/space/cartesian/CartesianPose.hpp>
+//#include <state_representation/space/cartesian/CartesianTwist.hpp>
 
 void bind_jacobian(py::module_& m) {
   py::class_<Jacobian, State> c(m, "Jacobian");
@@ -29,39 +30,43 @@ void bind_jacobian(py::module_& m) {
       "robot_name"_a, "joint_names"_a, "frame"_a, "reference_frame"_a = "world");
 
   c.def("rows", &Jacobian::rows, "Getter of the number of rows attribute");
-  c.def("cols", &Jacobian::cols, "Getter of the number of cols attribute");
   c.def("row", &Jacobian::row, "Accessor of the row data at given index");
+  c.def("cols", &Jacobian::cols, "Getter of the number of cols attribute");
   c.def("col", &Jacobian::col, "Accessor of the column data at given index");
   c.def("get_joint_names", &Jacobian::get_joint_names, "Getter of the joint_names attribute");
   c.def("get_frame", &Jacobian::get_frame, "Getter of the frame attribute");
-  c.def("get_reference_frame", &Jacobian::get_frame, "Getter of the reference_frame attribute");
+  c.def("get_reference_frame", &Jacobian::get_reference_frame, "Getter of the reference_frame attribute");
   c.def("data", &Jacobian::data, "Getter of the data attribute");
 
-  c.def("set_rows", py::overload_cast<unsigned int>(&Jacobian::set_rows), "Setter of the number of rows"); // TODO why not param name
-  c.def("set_cols", py::overload_cast<unsigned int>(&Jacobian::set_cols), "Setter of the number of columns");
-  c.def("set_joint_names", py::overload_cast<unsigned int>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from the number of joints");
-  c.def("set_joint_names", py::overload_cast<const std::vector<std::string>&>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from a vector of joint names");
-  c.def("set_reference_frame", py::overload_cast<const CartesianPose&>(&Jacobian::set_reference_frame), "Setter of the reference_frame attribute from a CartesianPose");
-  c.def("set_data", py::overload_cast<const Eigen::MatrixXd&>(&Jacobian::set_data), "Setter of the data attribute");
+  c.def("set_rows", py::overload_cast<unsigned int>(&Jacobian::set_rows), "Setter of the number of rows", "rows"_a);
+  c.def("set_cols", py::overload_cast<unsigned int>(&Jacobian::set_cols), "Setter of the number of columns", "cols"_a);
+  c.def("set_joint_names", py::overload_cast<unsigned int>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from the number of joints", "nb_joints"_a);
+  c.def("set_joint_names", py::overload_cast<const std::vector<std::string>&>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from a vector of joint names", "joint_names"_a);
+  c.def("set_reference_frame", py::overload_cast<const CartesianPose&>(&Jacobian::set_reference_frame), "Setter of the reference_frame attribute from a CartesianPose", "reference_frame"_a);
+  c.def("set_data", py::overload_cast<const Eigen::MatrixXd&>(&Jacobian::set_data), "Setter of the data attribute", "data"_a);
 
-  // TODO what if its override
-//  c.def("is_compatible", &Jacobian::is_compatible, "Set the JointState to a zero value");
+  // TODO what if its override, apparently its ok
+//  c.def("is_compatible", &Jacobian::is_compatible, "Check if the Jacobian matrix is compatible for operations with the state given as argument", "state"_a);
 //  c.def("initialize", &Jacobian::initialize), "Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)", "value"_a, "state_variable_type"_a, "noise_ratio"_a=double(0));
   c.def("transpose", &Jacobian::transpose, "Return the transpose of the Jacobian matrix");
   c.def("inverse", &Jacobian::inverse, "Return the inverse of the Jacobian matrix");
   c.def("pseudoinverse", &Jacobian::pseudoinverse, "Return the pseudoinverse of the Jacobian matrix");
   c.def("copy", &Jacobian::copy, "Return a copy of the Jacobian");
-  c.def("copy", &Jacobian::copy, "Return a copy of the Jacobian");
-  // TODO ???
-//  c.def("solve", py::overload_cast<const Eigen::MatrixXd&>(&Jacobian::solve), "Solve the system X = inv(J)*M to obtain X which is more efficient than multiplying with the pseudo-inverse", "matrix"_a);
-//  c.def("solve", py::overload_cast<const CartesianTwist&>(&Jacobian::solve), "Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse", "twist"_a);
+  c.def("solve", [](const Jacobian& jacobian, const Eigen::MatrixXd& matrix) {
+    return jacobian.solve(matrix);
+  }, "Solve the system X = inv(J)*M to obtain X which is more efficient than multiplying with the pseudo-inverse");
+  c.def("solve", [](const Jacobian& jacobian, const CartesianTwist& twist) {
+    return jacobian.solve(twist);
+  }, "Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse");
 
-  // TODO no empty constructor
+  // TODO access operators
+  // TODO how does it now what output type is
   c.def(py::self * Eigen::MatrixXd());
-//  c.def(py::self * Jacobian());
+  c.def(py::self * py::self);
   c.def(py::self * JointVelocities());
   c.def(py::self * CartesianTwist());
   c.def(py::self * CartesianWrench());
+  // TODO friend operators
 
   c.def("__repr__", [](const Jacobian& jacobian) {
     std::stringstream buffer;

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -1,5 +1,6 @@
 #include "state_representation_bindings.h"
 
+#include <tuple>
 #include <state_representation/State.hpp>
 #include <state_representation/robot/Jacobian.hpp>
 
@@ -53,7 +54,14 @@ void bind_jacobian(py::module_& m) {
     return jacobian.solve(twist);
   }, "Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse");
 
-  // TODO access operators
+  c.def("__getitem__", [](const Jacobian& jacobian, std::tuple<int, int> coefficients) {
+    return jacobian(std::get<0>(coefficients), std::get<1>(coefficients));
+  }, "Overload the [] operator to modify the value at given (row, col)");
+  c.def("__setitem__", [](Jacobian& jacobian, std::tuple<int, int> coefficients, double value) {
+    jacobian(std::get<0>(coefficients), std::get<1>(coefficients)) = value;
+    return jacobian;
+  }, "Overload the [] operator to access the value at given (row, col)");
+
   c.def(py::self * Eigen::MatrixXd());
   c.def(py::self * py::self);
   c.def(py::self * JointVelocities());

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -2,9 +2,6 @@
 
 #include <state_representation/State.hpp>
 #include <state_representation/robot/Jacobian.hpp>
-// TODO import necessary?
-//#include <state_representation/space/cartesian/CartesianPose.hpp>
-//#include <state_representation/space/cartesian/CartesianTwist.hpp>
 
 void bind_jacobian(py::module_& m) {
   py::class_<Jacobian, State> c(m, "Jacobian");
@@ -45,9 +42,6 @@ void bind_jacobian(py::module_& m) {
   c.def("set_reference_frame", py::overload_cast<const CartesianPose&>(&Jacobian::set_reference_frame), "Setter of the reference_frame attribute from a CartesianPose", "reference_frame"_a);
   c.def("set_data", py::overload_cast<const Eigen::MatrixXd&>(&Jacobian::set_data), "Setter of the data attribute", "data"_a);
 
-  // TODO what if its override, apparently its ok
-//  c.def("is_compatible", &Jacobian::is_compatible, "Check if the Jacobian matrix is compatible for operations with the state given as argument", "state"_a);
-//  c.def("initialize", &Jacobian::initialize), "Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)", "value"_a, "state_variable_type"_a, "noise_ratio"_a=double(0));
   c.def("transpose", &Jacobian::transpose, "Return the transpose of the Jacobian matrix");
   c.def("inverse", &Jacobian::inverse, "Return the inverse of the Jacobian matrix");
   c.def("pseudoinverse", &Jacobian::pseudoinverse, "Return the pseudoinverse of the Jacobian matrix");
@@ -60,13 +54,13 @@ void bind_jacobian(py::module_& m) {
   }, "Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse");
 
   // TODO access operators
-  // TODO how does it now what output type is
   c.def(py::self * Eigen::MatrixXd());
   c.def(py::self * py::self);
   c.def(py::self * JointVelocities());
   c.def(py::self * CartesianTwist());
   c.def(py::self * CartesianWrench());
-  // TODO friend operators
+  c.def(CartesianPose() * py::self);
+  c.def(Eigen::MatrixXd() * py::self);
 
   c.def("__repr__", [](const Jacobian& jacobian) {
     std::stringstream buffer;

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -1,0 +1,72 @@
+#include "state_representation_bindings.h"
+
+#include <state_representation/State.hpp>
+#include <state_representation/robot/Jacobian.hpp>
+// TODO import necessary?
+#include <state_representation/space/cartesian/CartesianPose.hpp>
+
+void bind_jacobian(py::module_& m) {
+  py::class_<Jacobian, State> c(m, "Jacobian");
+  c.def(py::init<const std::string&, unsigned int, const std::string&, const std::string&>(),
+        "Constructor with name, number of joints, frame name and reference frame provided",
+        "robot_name"_a, "nb_joints"_a, "frame"_a, "reference_frame"_a = "world");
+  c.def(py::init<const std::string&, const std::vector<std::string>&, const std::string&, const std::string&>(),
+      "Constructor with name, joint names, frame name and reference frame provided",
+      "robot_name"_a, "joint_names"_a, "frame"_a, "reference_frame"_a = "world");
+  c.def(py::init<const std::string&, const std::string&, const Eigen::MatrixXd&, const std::string&>(),
+        "Constructor with name, frame, Jacobian matrix and reference frame provided",
+        "robot_name"_a, "frame"_a, "data"_a, "reference_frame"_a = "world");
+  c.def(py::init<const std::string&, const std::vector<std::string>&, const std::string&, const Eigen::MatrixXd&, const std::string&>(),
+        "Constructor with name, joint names, frame name, Jacobian matrix and reference frame provided",
+        "robot_name"_a, "joint_names"_a, "frame"_a, "data"_a, "reference_frame"_a = "world");
+  c.def(py::init<const Jacobian&>(), "Copy constructor of a Jacobian", "jacobian"_a);
+
+  c.def_static("Random", py::overload_cast<const std::string&, unsigned int, const std::string&, const std::string&>(&Jacobian::Random),
+      "Constructor for a random Jacobian",
+      "robot_name"_a, "nb_joints"_a, "frame"_a, "reference_frame"_a = "world");
+  c.def_static("Random", py::overload_cast<const std::string&, const std::vector<std::string>&, const std::string&, const std::string&>(&Jacobian::Random),
+      "Constructor for a random Jacobian",
+      "robot_name"_a, "joint_names"_a, "frame"_a, "reference_frame"_a = "world");
+
+  c.def("rows", &Jacobian::rows, "Getter of the number of rows attribute");
+  c.def("cols", &Jacobian::cols, "Getter of the number of cols attribute");
+  c.def("row", &Jacobian::row, "Accessor of the row data at given index");
+  c.def("col", &Jacobian::col, "Accessor of the column data at given index");
+  c.def("get_joint_names", &Jacobian::get_joint_names, "Getter of the joint_names attribute");
+  c.def("get_frame", &Jacobian::get_frame, "Getter of the frame attribute");
+  c.def("get_reference_frame", &Jacobian::get_frame, "Getter of the reference_frame attribute");
+  c.def("data", &Jacobian::data, "Getter of the data attribute");
+
+  c.def("set_rows", py::overload_cast<unsigned int>(&Jacobian::set_rows), "Setter of the number of rows"); // TODO why not param name
+  c.def("set_cols", py::overload_cast<unsigned int>(&Jacobian::set_cols), "Setter of the number of columns");
+  c.def("set_joint_names", py::overload_cast<unsigned int>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from the number of joints");
+  c.def("set_joint_names", py::overload_cast<const std::vector<std::string>&>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from a vector of joint names");
+  c.def("set_reference_frame", py::overload_cast<const CartesianPose&>(&Jacobian::set_reference_frame), "Setter of the reference_frame attribute from a CartesianPose");
+  c.def("set_data", py::overload_cast<const Eigen::MatrixXd&>(&Jacobian::set_data), "Setter of the data attribute");
+
+  // TODO what if its override
+//  c.def("is_compatible", &Jacobian::is_compatible, "Set the JointState to a zero value");
+//  c.def("initialize", &Jacobian::initialize), "Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)", "value"_a, "state_variable_type"_a, "noise_ratio"_a=double(0));
+  c.def("transpose", &Jacobian::transpose, "Return the transpose of the Jacobian matrix");
+  c.def("inverse", &Jacobian::inverse, "Return the inverse of the Jacobian matrix");
+  c.def("pseudoinverse", &Jacobian::pseudoinverse, "Return the pseudoinverse of the Jacobian matrix");
+  c.def("copy", &Jacobian::copy, "Return a copy of the Jacobian");
+  c.def("copy", &Jacobian::copy, "Return a copy of the Jacobian");
+  // TODO ???
+//  c.def("solve", py::overload_cast<const Eigen::MatrixXd&>(&Jacobian::solve), "Solve the system X = inv(J)*M to obtain X which is more efficient than multiplying with the pseudo-inverse", "matrix"_a);
+//  c.def("solve", py::overload_cast<const CartesianTwist&>(&Jacobian::solve), "Solve the system dX = J*dq to obtain dq which is more efficient than multiplying with the pseudo-inverse", "twist"_a);
+
+  // TODO no empty constructor
+  c.def(py::self * Eigen::MatrixXd());
+//  c.def(py::self * Jacobian());
+  c.def(py::self * JointVelocities());
+  c.def(py::self * CartesianTwist());
+  c.def(py::self * CartesianWrench());
+
+  c.def("__repr__", [](const Jacobian& jacobian) {
+    std::stringstream buffer;
+    buffer << jacobian;
+    return buffer.str();
+  });
+}
+

--- a/python/source/state_representation/state_representation_bindings.cpp
+++ b/python/source/state_representation/state_representation_bindings.cpp
@@ -15,4 +15,5 @@ PYBIND11_MODULE(state_representation, m) {
   bind_state(m);
   bind_cartesian_space(m);
   bind_joint_space(m);
+  bind_jacobian(m);
 }

--- a/python/source/state_representation/state_representation_bindings.h
+++ b/python/source/state_representation/state_representation_bindings.h
@@ -22,3 +22,4 @@ using namespace state_representation;
 void bind_state(py::module_& m);
 void bind_cartesian_space(py::module_& m);
 void bind_joint_space(py::module_& m);
+void bind_jacobian(py::module_& m);

--- a/python/tests/cartesian_state_test.py
+++ b/python/tests/cartesian_state_test.py
@@ -59,7 +59,7 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
 
 class TestCartesianState(unittest.TestCase):
     def assert_np_array_equal(self, a, b):
-        self.assertListEqual(list(a), list(b));
+        self.assertListEqual(list(a), list(b))
 
     def test_callable_methods(self):
         methods = [m for m in dir(CartesianState) if callable(getattr(CartesianState, m))]

--- a/python/tests/jacobian_test.py
+++ b/python/tests/jacobian_test.py
@@ -80,7 +80,7 @@ class TestJacobian(unittest.TestCase):
 
         matrix = np.random.rand(3, 6)
         result = jac * matrix
-        # result = matrix * jac TODO
+        result = matrix * jac
 
         joint_velocities = JointVelocities.Random("test", 3)
         twist = jac * joint_velocities

--- a/python/tests/jacobian_test.py
+++ b/python/tests/jacobian_test.py
@@ -75,6 +75,8 @@ class TestJacobian(unittest.TestCase):
 
     def test_operators(self):
         jac = Jacobian.Random("test", 3, "ee", "robot")
+        elem = jac[1, 2]
+        jac[1, 2] = 0.1
 
         matrix = np.random.rand(3, 6)
         result = jac * matrix

--- a/python/tests/jacobian_test.py
+++ b/python/tests/jacobian_test.py
@@ -1,0 +1,114 @@
+import unittest
+from state_representation import Jacobian
+import numpy as np
+
+CARTESIAN_STATE_METHOD_EXPECTS = [
+    'Identity',
+    'Random',
+    'array',
+    'clamp_state_variable',
+    'copy',
+    'data',
+    'dist',
+    'from_list',
+    'get_accelerations',
+    'get_angular_acceleration',
+    'get_angular_velocity',
+    'get_force',
+    'get_linear_acceleration',
+    'get_linear_velocity',
+    'get_name',
+    'get_orientation',
+    'get_pose',
+    'get_position',
+    'get_reference_frame',
+    'get_timestamp',
+    'get_torque',
+    'get_transformation_matrix',
+    'get_twist',
+    'get_type',
+    'get_wrench',
+    'initialize',
+    'inverse',
+    'is_compatible',
+    'is_deprecated',
+    'is_empty',
+    'normalize',
+    'normalized',
+    'norms',
+    'reset_timestamp',
+    'set_accelerations',
+    'set_angular_acceleration',
+    'set_angular_velocity',
+    'set_empty',
+    'set_filled',
+    'set_force',
+    'set_linear_acceleration',
+    'set_linear_velocity',
+    'set_name',
+    'set_orientation',
+    'set_pose',
+    'set_position',
+    'set_reference_frame',
+    'set_torque',
+    'set_twist',
+    'set_wrench',
+    'set_zero',
+    'to_list'
+]
+
+class TestJacobian(unittest.TestCase):
+    # def assert_np_array_equal(self, a, b):
+    #     self.assertListEqual(list(a), list(b));
+
+    # def test_callable_methods(self):
+    #     methods = [m for m in dir(CartesianState) if callable(getattr(CartesianState, m))]
+    #     for expected in CARTESIAN_STATE_METHOD_EXPECTS:
+    #         self.assertIn(expected, methods)
+
+    def test_constructors(self):
+        Jacobian("robot", 7, "ee")
+        A = Jacobian("robot", 7, "ee")
+        Jacobian(A)
+        Jacobian("robot", ["joint_0", "joint_1"], "ee", "robot")
+        A = Jacobian.Random("robot", ["joint_0", "joint_1"], "ee", "robot")
+        B = Jacobian.Random("robot", 7, "ee")
+
+    # def test_setters(self):
+    #     A = CartesianState.Identity("A")
+    #
+    #     A.set_position(1, 2, 3)
+    #     self.assert_np_array_equal(A.get_position(), [1, 2, 3])
+    #     A.set_position([1, 2, 3])
+    #     self.assert_np_array_equal(A.get_position(), [1, 2, 3])
+    #     A.set_position(np.array([1, 2, 3]))
+    #     self.assert_np_array_equal(A.get_position(), [1, 2, 3])
+    #
+    #     A.set_orientation([1, 2, 3, 4])
+    #     self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
+    #
+    #     A.set_twist([1, 2, 3, 4, 5, 6])
+    #     self.assert_np_array_equal(A.get_twist(), [1, 2, 3, 4, 5, 6])
+    #     A.set_accelerations([1, 2, 3, 4, 5, 6])
+    #     self.assert_np_array_equal(A.get_accelerations(), [1, 2, 3, 4, 5, 6])
+    #     A.set_wrench([1, 2, 3, 4, 5, 6])
+    #     self.assert_np_array_equal(A.get_wrench(), [1, 2, 3, 4, 5, 6])
+    #
+    # def test_operators(self):
+    #     A = CartesianState.Random("A")
+    #     B = CartesianState.Random("B")
+    #     CinA = CartesianState.Random("C", "A")
+    #
+    #     C = A * CinA
+    #     A = A * 2
+    #     A = 2 * A
+    #     A *= 2
+    #
+    #     A = A + B
+    #     A += B
+    #
+    #     A = A - B
+    #     A -= B
+
+if __name__ == '__main__':
+    unittest.main()

--- a/source/robot_model/src/Model.cpp
+++ b/source/robot_model/src/Model.cpp
@@ -449,7 +449,7 @@ Model::inverse_velocity(const std::vector<state_representation::CartesianTwist>&
         this->compute_jacobian(joint_positions, frame_names.at(i)).data().block(0, 0, 3, nb_joints);
   }
   // extract pose for the last provided frame
-  CartesianPose full_displacement = cartesian_twists.back();;
+  CartesianPose full_displacement = cartesian_twists.back();
   delta_r.segment<3>(3 * (cartesian_twists.size() - 1)) = full_displacement.get_position();
   delta_r.tail(3) = full_displacement.get_orientation().vec();
   jacobian.bottomRows(6) = this->compute_jacobian(joint_positions, frame_names.back()).data();

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -259,8 +259,6 @@ public:
    * @brief Overload the * operator with a JointVelocities
    * @param dq the joint velocity to multiply with
    * @return this result into the CartesianTwist of the end effector
-   * the name of the output CartesianTwist will be "robot"_end_effector and
-   * the reference frame will be "robot"_base 
    */
   CartesianTwist operator*(const JointVelocities& dq) const;
 

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -34,7 +34,7 @@ private:
 
 public:
   /**
-   * @brief Constructor with names and number of joints provided
+   * @brief Constructor with name, number of joints, frame name and reference frame provided
    * @param robot_name the name of the robot associated to
    * @param nb_joints the number of joints
    * @param frame the name of the frame at which the Jacobian is computed
@@ -46,9 +46,9 @@ public:
                     const std::string& reference_frame = "world");
 
   /**
-   * @brief Constructor with names and list of joint names provided
-   * @param joint_names the vector of joint names
+   * @brief Constructor with name, joint names, frame name and reference frame provided
    * @param robot_name the name of the robot associated to
+   * @param joint_names the vector of joint names
    * @param frame the name of the frame at which the Jacobian is computed
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
    */
@@ -58,7 +58,8 @@ public:
                     const std::string& reference_frame = "world");
 
   /**
-   * @brief Constructor with names and Jacobian matrix as eigen matrix
+   * @brief "Constructor with name, frame, Jacobian matrix and reference frame provided"
+   * @param robot_name the name of the robot associated to
    * @param frame the name of the frame at which the Jacobian is computed
    * @param data the values of the Jacobian matrix
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
@@ -69,7 +70,8 @@ public:
                     const std::string& reference_frame = "world");
 
   /**
-   * @brief Constructor with names, vector of joint names, and Jacobian matrix as eigen matrix
+   * @brief Constructor with name, joint names, frame name, Jacobian matrix and reference frame provided
+   * @param robot_name the name of the robot associated to
    * @param joint_names the vector of joint names
    * @param frame the name of the frame at which the Jacobian is computed
    * @param data the values of the Jacobian matrix
@@ -180,12 +182,12 @@ public:
   void set_joint_names(const std::vector<std::string>& joint_names);
 
   /**
-   * @brief Getter of the frame_name attribute
+   * @brief Getter of the frame attribute
    */
   const std::string& get_frame() const;
 
   /**
-   * @brief Getter of the frame_name attribute
+   * @brief Getter of the reference_frame attribute
    */
   const std::string& get_reference_frame() const;
 


### PR DESCRIPTION
This PR is almost done except for two things (marked with TODO):
- Add the `double& operator()` operators
- Somehow the `matrix * Jacobian` operation doesn't work in the `jacobian_test.py` even though the `friend` operator for that is defined in the `bind_jacobian.cpp`

As with the other bindings, the tests are not extensive but cover most parts.