### PR TITLE
Add compatibility check for Eigen friend operator

### DIFF
--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -300,6 +300,13 @@ Jacobian operator*(const CartesianPose& pose, const Jacobian& jacobian) {
 }
 
 Eigen::MatrixXd operator*(const Eigen::MatrixXd& matrix, const Jacobian& jacobian) {
+  // check compatibility
+  if (jacobian.is_empty()) {
+    throw EmptyStateException(jacobian.get_name() + " state is empty");
+  }
+  if (matrix.cols() != jacobian.rows()) {
+    throw IncompatibleStatesException("The matrix and the Jacobian have incompatible sizes");
+  }
   return matrix * jacobian.data();
 }
 }// namespace state_representation


### PR DESCRIPTION
Not much to explain here, we need to check that the number of columns of the matrix left of the `*` operator correspond with the number of rows of the jacobian