### PR TITLE
Add a function to check compatibility with state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release Versions:
 linear and angular velocity with a set of 4 gains (#135)
 - Add a joint velocity control demo in the ROS demo package that 
 showcases the `robot_model` module (#136, #139)
+- Add a function to check compatibility between a state and a dynamical system (#142)
 
 ## 2.0.0
 

--- a/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
@@ -18,7 +18,7 @@ namespace dynamical_systems {
 template<class S>
 class DynamicalSystem {
 private:
-  S base_frame_;
+  S base_frame_; ///< frame in which the dynamical system is expressed
 
 protected:
   /**
@@ -62,8 +62,16 @@ public:
    */
   virtual std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
 
+  /**
+   * @brief Return the base frame of the dynamical system
+   * @return the base frame
+   */
   const S& get_base_frame() const;
 
+  /**
+   * @brief Set the base frame of the dynamical system
+   * @param base_frame the new base frame
+   */
   virtual void set_base_frame(const S& base_frame);
 };
 

--- a/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
@@ -73,6 +73,13 @@ public:
    * @param base_frame the new base frame
    */
   virtual void set_base_frame(const S& base_frame);
+
+  /**
+   * @brief Check compatibility between a state and the dynamical system
+   * @param state the state to check for compatibility
+   * @return true if the state is compatible with the dynamical system
+   */
+  virtual bool is_compatible(const S& state);
 };
 
 template<class S>

--- a/source/dynamical_systems/include/dynamical_systems/Linear.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Linear.hpp
@@ -119,6 +119,7 @@ template<class S>
 inline void Linear<S>::set_attractor(const S& attractor) {
   this->attractor_->set_value(attractor);
 }
+
 template<>
 inline void Linear<state_representation::CartesianState>::set_attractor(const state_representation::CartesianState& attractor) {
   // validate that the reference frame of the attractor is always compatible with the DS reference frame
@@ -135,7 +136,6 @@ inline void Linear<state_representation::CartesianState>::set_attractor(const st
     this->attractor_->set_value(attractor);
   }
 }
-
 
 template<class S>
 inline void Linear<S>::set_base_frame(const S& base_frame) {

--- a/source/dynamical_systems/include/dynamical_systems/exceptions/IncompatibleSizeException.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/exceptions/IncompatibleSizeException.hpp
@@ -3,15 +3,9 @@
 #include <iostream>
 #include <exception>
 
-namespace dynamical_systems
-{
-	namespace exceptions
-	{
-		class IncompatibleSizeException : public std::runtime_error
-		{
-		public:
-			explicit IncompatibleSizeException(const std::string& msg) : runtime_error(msg)
-			{};
-		};
-	}
+namespace dynamical_systems::exceptions {
+class IncompatibleSizeException : public std::runtime_error {
+public:
+  explicit IncompatibleSizeException(const std::string& msg) : runtime_error(msg) {};
+};
 }

--- a/source/dynamical_systems/include/dynamical_systems/exceptions/NotImplementedException.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/exceptions/NotImplementedException.hpp
@@ -3,15 +3,9 @@
 #include <iostream>
 #include <exception>
 
-namespace dynamical_systems
-{
-	namespace exceptions
-	{
-		class NotImplementedException : public std::logic_error
-		{
-		public:
-			explicit NotImplementedException(const std::string& msg) : logic_error(msg)
-			{};
-		};
-	}
+namespace dynamical_systems::exceptions {
+class NotImplementedException : public std::logic_error {
+public:
+  explicit NotImplementedException(const std::string& msg) : logic_error(msg) {};
+};
 }

--- a/source/dynamical_systems/src/DynamicalSystem.cpp
+++ b/source/dynamical_systems/src/DynamicalSystem.cpp
@@ -2,6 +2,7 @@
 #include "state_representation/robot/JointState.hpp"
 #include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
+#include "dynamical_systems/exceptions/NotImplementedException.hpp"
 
 using namespace state_representation;
 
@@ -18,6 +19,17 @@ DynamicalSystem<CartesianState>::DynamicalSystem() : base_frame_(CartesianState:
 template<>
 DynamicalSystem<CartesianState>::DynamicalSystem(const std::string& base_frame) :
     base_frame_(CartesianState::Identity(base_frame, base_frame)) {}
+
+template<class S>
+bool DynamicalSystem<S>::is_compatible(const S&) {
+  throw exceptions::NotImplementedException("is_compatible(state) not implemented for this type of state");
+}
+
+template<>
+bool DynamicalSystem<state_representation::CartesianState>::is_compatible(const state_representation::CartesianState& state) {
+  return !(state.get_reference_frame() != this->get_base_frame().get_name()
+      && state.get_reference_frame() != this->get_base_frame().get_reference_frame());
+}
 
 template<class S>
 S DynamicalSystem<S>::evaluate(const S& state) const {

--- a/source/dynamical_systems/test/tests/test_linear.cpp
+++ b/source/dynamical_systems/test/tests/test_linear.cpp
@@ -33,6 +33,25 @@ protected:
   double angular_tol = 1e-3;
 };
 
+TEST_F(LinearDSTest, IsCompatible) {
+  state_representation::CartesianState state1("C", "A");
+  state_representation::CartesianState state2("C", "B");
+  state_representation::CartesianState state3("C", "D");
+
+  state_representation::CartesianState attractor_frame("CAttractor", "A");
+  dynamical_systems::Linear<state_representation::CartesianState> ds(attractor_frame);
+  EXPECT_TRUE(ds.is_compatible(state1));
+  EXPECT_FALSE(ds.is_compatible(state2));
+  EXPECT_FALSE(ds.is_compatible(state3));
+
+  // change the base frame
+  state_representation::CartesianState base_frame("A", "B");
+  ds.set_base_frame(base_frame);
+  EXPECT_TRUE(ds.is_compatible(state1));
+  EXPECT_TRUE(ds.is_compatible(state2));
+  EXPECT_FALSE(ds.is_compatible(state3));
+}
+
 TEST_F(LinearDSTest, PositionOnly) {
   current_pose.set_orientation(Eigen::Quaterniond::Identity());
   target_pose.set_orientation(Eigen::Quaterniond::Identity());

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -59,7 +59,6 @@ TEST_F(RingDSTest, PointsOnRadius) {
   EXPECT_NEAR(twist.get_linear_velocity().z(), -1, tol);
 }
 
-
 TEST_F(RingDSTest, PointsNearRadius) {
   dynamical_systems::Ring ring(center, radius, width, speed, field_strength);
   state_representation::CartesianTwist twist;
@@ -178,7 +177,6 @@ TEST_F(RingDSTest, OrientationAroundCircle) {
   EXPECT_NEAR(twist.get_angular_velocity().norm(), 0, tol);
 }
 
-
 TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
   dynamical_systems::Ring ring(center, radius, width, 0);
   state_representation::CartesianTwist twist;
@@ -257,7 +255,8 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // should give the same local command, regardless of the center frame
   current_pose = state_representation::CartesianPose("B",
                                                      Eigen::Vector3d(radius, 0, 0),
-                                                     Eigen::Quaterniond(1, 1, 0, 0).normalized()  * ring.get_rotation_offset(),
+                                                     Eigen::Quaterniond(1, 1, 0, 0).normalized()
+                                                         * ring.get_rotation_offset(),
                                                      "A");
   current_pose = center * current_pose;
   twist = ring.evaluate(current_pose);


### PR DESCRIPTION
I needed a function to check the compatibility between a state and the dynamical system. It basically reuse the boolean check when doing `evaluate`. I figured I could reuse it in there but in fact, depending which part of the check fails there is a different outcome.

I also corrected a few indentations and the missing docstring in the base class.