### PR TITLE
Minor revision on Jacobian and JointState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ linear and angular velocity with a set of 4 gains (#135)
 - Add a joint velocity control demo in the ROS demo package that 
 showcases the `robot_model` module (#136, #139)
 - Add a function to check compatibility between a state and a dynamical system (#142)
+- Remove `set_rows` and `set_cols` from Jacobian class due to inexpedience (#144)
 
 ## 2.0.0
 

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -39,8 +39,6 @@ void bind_jacobian(py::module_& m) {
   c.def("get_reference_frame", &Jacobian::get_reference_frame, "Getter of the reference_frame attribute");
   c.def("data", &Jacobian::data, "Getter of the data attribute");
 
-  c.def("set_rows", py::overload_cast<unsigned int>(&Jacobian::set_rows), "Setter of the number of rows", "rows"_a);
-  c.def("set_cols", py::overload_cast<unsigned int>(&Jacobian::set_cols), "Setter of the number of columns", "cols"_a);
   c.def("set_joint_names", py::overload_cast<unsigned int>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from the number of joints", "nb_joints"_a);
   c.def("set_joint_names", py::overload_cast<const std::vector<std::string>&>(&Jacobian::set_joint_names), "Setter of the joint_names attribute from a vector of joint names", "joint_names"_a);
   c.def("set_reference_frame", py::overload_cast<const CartesianPose&>(&Jacobian::set_reference_frame), "Setter of the reference_frame attribute from a CartesianPose", "reference_frame"_a);

--- a/python/tests/jacobian_test.py
+++ b/python/tests/jacobian_test.py
@@ -12,8 +12,6 @@ JACOBIAN_METHOD_EXPECTS = [
     'get_joint_names',
     'get_frame',
     'get_reference_frame',
-    'set_rows',
-    'set_cols',
     'set_joint_names',
     'set_reference_frame',
     'set_data',

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -42,8 +42,8 @@ public:
    */
   explicit Jacobian(const std::string& robot_name,
                     unsigned int nb_joints,
-                    std::string frame,
-                    std::string reference_frame = "world");
+                    const std::string& frame,
+                    const std::string& reference_frame = "world");
 
   /**
    * @brief Constructor with name, joint names, frame name and reference frame provided
@@ -54,8 +54,8 @@ public:
    */
   explicit Jacobian(const std::string& robot_name,
                     const std::vector<std::string>& joint_names,
-                    std::string frame,
-                    std::string reference_frame = "world");
+                    const std::string& frame,
+                    const std::string& reference_frame = "world");
 
   /**
    * @brief Constructor with name, frame, Jacobian matrix and reference frame provided

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -27,7 +27,7 @@ class Jacobian : public State {
 private:
   std::vector<std::string> joint_names_;///< names of the joints
   std::string frame_;                   ///< name of the frame at which the Jacobian is computed
-  std::string reference_frame_;         /// name of the reference frame in which the Jacobian is expressed
+  std::string reference_frame_;         ///< name of the reference frame in which the Jacobian is expressed
   unsigned int rows_;                   ///< number of rows
   unsigned int cols_;                   ///< number of columns
   Eigen::MatrixXd data_;                ///< internal storage of the Jacobian matrix
@@ -35,31 +35,31 @@ private:
 public:
   /**
    * @brief Constructor with name, number of joints, frame name and reference frame provided
-   * @param robot_name the name of the robot associated to
-   * @param nb_joints the number of joints
+   * @param robot_name the name of the associated robot
+   * @param nb_joints the number of joints of the robot
    * @param frame the name of the frame at which the Jacobian is computed
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
    */
   explicit Jacobian(const std::string& robot_name,
                     unsigned int nb_joints,
-                    const std::string& frame,
-                    const std::string& reference_frame = "world");
+                    std::string frame,
+                    std::string reference_frame = "world");
 
   /**
    * @brief Constructor with name, joint names, frame name and reference frame provided
-   * @param robot_name the name of the robot associated to
-   * @param joint_names the vector of joint names
+   * @param robot_name the name of the associated robot
+   * @param joint_names the vector of joint names of the robot
    * @param frame the name of the frame at which the Jacobian is computed
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
    */
   explicit Jacobian(const std::string& robot_name,
                     const std::vector<std::string>& joint_names,
-                    const std::string& frame,
-                    const std::string& reference_frame = "world");
+                    std::string frame,
+                    std::string reference_frame = "world");
 
   /**
-   * @brief "Constructor with name, frame, Jacobian matrix and reference frame provided"
-   * @param robot_name the name of the robot associated to
+   * @brief Constructor with name, frame, Jacobian matrix and reference frame provided
+   * @param robot_name the name of the associated robot
    * @param frame the name of the frame at which the Jacobian is computed
    * @param data the values of the Jacobian matrix
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
@@ -71,8 +71,8 @@ public:
 
   /**
    * @brief Constructor with name, joint names, frame name, Jacobian matrix and reference frame provided
-   * @param robot_name the name of the robot associated to
-   * @param joint_names the vector of joint names
+   * @param robot_name the name of the associated robot
+   * @param joint_names the vector of joint names of the robot
    * @param frame the name of the frame at which the Jacobian is computed
    * @param data the values of the Jacobian matrix
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
@@ -91,7 +91,7 @@ public:
   /**
    * @brief Constructor for a random Jacobian
    * @param robot_name the name of the associated robot
-   * @param nb_joints the number of joints for initialization
+   * @param nb_joints the number of joints of the robot
    * @param frame the name of the frame at which the Jacobian is computed
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
    * @return Jacobian with random data values
@@ -104,7 +104,7 @@ public:
   /**
    * @brief Constructor for a random Jacobian
    * @param robot_name the name of the associated robot
-   * @param joint_names list of joint names
+   * @param joint_names the vector of joint names of the robot
    * @param frame the name of the frame at which the Jacobian is computed
    * @param reference_frame the name of the reference frame in which the Jacobian is expressed (default "world")
    * @return Jacobian with random data values
@@ -135,14 +135,8 @@ public:
   unsigned int rows() const;
 
   /**
-   * @brief Setter of the number of rows
-   * @param rows the number of rows
-   */
-  void set_rows(unsigned int rows);
-
-  /**
    * @brief Accessor of the row data at given index
-   * @param index the desired index of the row
+   * @param index the index of the desired row
    * @return the row vector at index
    */
   Eigen::VectorXd row(unsigned int index) const;
@@ -154,14 +148,8 @@ public:
   unsigned int cols() const;
 
   /**
-   * @brief Setter of the number of columns
-   * @param cols the number of columns
-   */
-  void set_cols(unsigned int cols);
-
-  /**
    * @brief Accessor of the column data at given index
-   * @param index the desired index of the column
+   * @param index the index of the desired column
    * @return the column vector at index
    */
   Eigen::VectorXd col(unsigned int index) const;
@@ -362,14 +350,6 @@ inline unsigned int Jacobian::cols() const {
   return this->cols_;
 }
 
-inline void Jacobian::set_rows(unsigned int rows) {
-  this->rows_ = rows;
-}
-
-inline void Jacobian::set_cols(unsigned int cols) {
-  this->cols_ = cols;
-}
-
 inline Eigen::VectorXd Jacobian::row(unsigned int index) const {
   return this->data_.row(index);
 }
@@ -427,20 +407,20 @@ inline void Jacobian::set_data(const Eigen::MatrixXd& data) {
 
 inline double& Jacobian::operator()(unsigned int row, unsigned int col) {
   if (row > this->rows_) {
-    throw std::out_of_range("Given row is out of range: number of rows = " + std::to_string(this->rows_));
+    throw std::out_of_range("Given row is out of range: number of rows is " + std::to_string(this->rows_));
   }
   if (col > this->cols_) {
-    throw std::out_of_range("Given column is out of range: number of columns = " + std::to_string(this->cols_));
+    throw std::out_of_range("Given column is out of range: number of columns is " + std::to_string(this->cols_));
   }
   return this->data_(row, col);
 }
 
 inline const double& Jacobian::operator()(unsigned int row, unsigned int col) const {
   if (row > this->rows_) {
-    throw std::out_of_range("Given row is out of range: number of rows = " + std::to_string(this->rows_));
+    throw std::out_of_range("Given row is out of range: number of rows is " + std::to_string(this->rows_));
   }
   if (col > this->cols_) {
-    throw std::out_of_range("Given column is out of range: number of columns = " + std::to_string(this->cols_));
+    throw std::out_of_range("Given column is out of range: number of columns is " + std::to_string(this->cols_));
   }
   return this->data_(row, col);
 }

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -32,11 +32,11 @@ enum class JointStateVariable {
 };
 
 /**
- * @brief compute the distance between two JointState
+ * @brief Compute the distance between two JointState
  * @param s1 the first JointState
  * @param s2 the second JointState
  * @param state_variable_type name of the field from the JointStateVariable structure to apply
- * the distance on. Default ALL for full distance across all dimensions
+ * the distance on (default ALL for full distance across all dimensions)
  * @return the distance between the two states
  */
 double dist(const JointState& s1,
@@ -127,7 +127,7 @@ public:
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
    */
-  explicit JointState(const std::string& robot_name, const std::vector<std::string>& joint_names);
+  explicit JointState(const std::string& robot_name, std::vector<std::string> joint_names);
 
   /**
    * @brief Copy constructor of a JointState
@@ -406,7 +406,7 @@ public:
    * @brief Compute the distance to another state as the sum of distances between each features
    * @param state the second state
    * @param state_variable_type name of the variable from the JointStateVariable structure to apply
-   * the distance on. Default ALL for full distance across all dimensions
+   * the distance on (default ALL for full distance across all dimensions)
    * @return dist the distance value as a double
    */
   double dist(const JointState& state, const JointStateVariable& state_variable_type = JointStateVariable::ALL) const;
@@ -515,16 +515,24 @@ inline const std::vector<std::string>& JointState::get_names() const {
 }
 
 inline void JointState::set_names(unsigned int nb_joints) {
+  if (this->get_size() != nb_joints) {
+    throw exceptions::IncompatibleSizeException(
+        "Input number of joints is of incorrect size, expected " + std::to_string(this->get_size()) + " got "
+            + std::to_string(nb_joints));
+  }
   this->names_.resize(nb_joints);
   for (unsigned int i = 0; i < nb_joints; ++i) {
     this->names_[i] = "joint" + std::to_string(i);
   }
-  this->initialize();
 }
 
 inline void JointState::set_names(const std::vector<std::string>& names) {
+  if (this->get_size() != names.size()) {
+    throw exceptions::IncompatibleSizeException(
+        "Input number of joints is of incorrect size, expected " + std::to_string(this->get_size()) + " got "
+            + std::to_string(names.size()));
+  }
   this->names_ = names;
-  this->initialize();
 }
 
 inline const Eigen::VectorXd& JointState::get_positions() const {

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -127,7 +127,7 @@ public:
    * @param robot_name the name of the associated robot
    * @param joint_names list of joint names
    */
-  explicit JointState(const std::string& robot_name, std::vector<std::string> joint_names);
+  explicit JointState(const std::string& robot_name, const std::vector<std::string>& joint_names);
 
   /**
    * @brief Copy constructor of a JointState

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -6,12 +6,12 @@
 namespace state_representation {
 Jacobian::Jacobian(const std::string& robot_name,
                    unsigned int nb_joints,
-                   std::string frame,
-                   std::string reference_frame) :
+                   const std::string& frame,
+                   const std::string& reference_frame) :
     State(StateType::JACOBIANMATRIX, robot_name),
     joint_names_(nb_joints),
-    frame_(std::move(frame)),
-    reference_frame_(std::move(reference_frame)),
+    frame_(frame),
+    reference_frame_(reference_frame),
     rows_(6),
     cols_(nb_joints) {
   this->set_joint_names(nb_joints);
@@ -20,12 +20,12 @@ Jacobian::Jacobian(const std::string& robot_name,
 
 Jacobian::Jacobian(const std::string& robot_name,
                    const std::vector<std::string>& joint_names,
-                   std::string frame,
-                   std::string reference_frame) :
+                   const std::string& frame,
+                   const std::string& reference_frame) :
     State(StateType::JACOBIANMATRIX, robot_name),
     joint_names_(joint_names),
-    frame_(std::move(frame)),
-    reference_frame_(std::move(reference_frame)),
+    frame_(frame),
+    reference_frame_(reference_frame),
     rows_(6),
     cols_(joint_names.size()) {
   this->initialize();

--- a/source/state_representation/src/robot/Jacobian.cpp
+++ b/source/state_representation/src/robot/Jacobian.cpp
@@ -1,16 +1,17 @@
 #include "state_representation/robot/Jacobian.hpp"
+
 #include "state_representation/exceptions/EmptyStateException.hpp"
 #include "state_representation/exceptions/IncompatibleStatesException.hpp"
 
 namespace state_representation {
 Jacobian::Jacobian(const std::string& robot_name,
                    unsigned int nb_joints,
-                   const std::string& frame,
-                   const std::string& reference_frame) :
+                   std::string frame,
+                   std::string reference_frame) :
     State(StateType::JACOBIANMATRIX, robot_name),
     joint_names_(nb_joints),
-    frame_(frame),
-    reference_frame_(reference_frame),
+    frame_(std::move(frame)),
+    reference_frame_(std::move(reference_frame)),
     rows_(6),
     cols_(nb_joints) {
   this->set_joint_names(nb_joints);
@@ -19,12 +20,12 @@ Jacobian::Jacobian(const std::string& robot_name,
 
 Jacobian::Jacobian(const std::string& robot_name,
                    const std::vector<std::string>& joint_names,
-                   const std::string& frame,
-                   const std::string& reference_frame) :
+                   std::string frame,
+                   std::string reference_frame) :
     State(StateType::JACOBIANMATRIX, robot_name),
     joint_names_(joint_names),
-    frame_(frame),
-    reference_frame_(reference_frame),
+    frame_(std::move(frame)),
+    reference_frame_(std::move(reference_frame)),
     rows_(6),
     cols_(joint_names.size()) {
   this->initialize();

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -1,4 +1,5 @@
 #include "state_representation/robot/JointState.hpp"
+
 #include "state_representation/exceptions/EmptyStateException.hpp"
 #include "state_representation/exceptions/IncompatibleStatesException.hpp"
 #include "state_representation/exceptions/NotImplementedException.hpp"
@@ -11,11 +12,12 @@ JointState::JointState() : State(StateType::JOINTSTATE) {
 JointState::JointState(const std::string& robot_name, unsigned int nb_joints) :
     State(StateType::JOINTSTATE, robot_name), names_(nb_joints) {
   this->set_names(nb_joints);
+  this->initialize();
 }
 
-JointState::JointState(const std::string& robot_name, const std::vector<std::string>& joint_names) :
-    State(StateType::JOINTSTATE, robot_name) {
-  this->set_names(joint_names);
+JointState::JointState(const std::string& robot_name, std::vector<std::string>  joint_names) :
+    State(StateType::JOINTSTATE, robot_name), names_(std::move(joint_names)) {
+  this->initialize();
 }
 
 void JointState::initialize() {

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -15,8 +15,8 @@ JointState::JointState(const std::string& robot_name, unsigned int nb_joints) :
   this->initialize();
 }
 
-JointState::JointState(const std::string& robot_name, std::vector<std::string>  joint_names) :
-    State(StateType::JOINTSTATE, robot_name), names_(std::move(joint_names)) {
+JointState::JointState(const std::string& robot_name, const std::vector<std::string>& joint_names) :
+    State(StateType::JOINTSTATE, robot_name), names_(joint_names) {
   this->initialize();
 }
 

--- a/source/state_representation/test/tests/test_jacobian.cpp
+++ b/source/state_representation/test/tests/test_jacobian.cpp
@@ -16,6 +16,8 @@ TEST(JacobianTest, TestCreate) {
     EXPECT_EQ(jac.get_joint_names().at(i), ("joint" + std::to_string(i)));
     EXPECT_EQ(jac.col(i).norm(), 0);
   }
+  EXPECT_THROW(jac.set_joint_names(5), exceptions::IncompatibleSizeException);
+  EXPECT_THROW(jac.set_joint_names(std::vector<std::string>{"j0"}), exceptions::IncompatibleSizeException);
 }
 
 TEST(JacobianTest, TestCreateWithVectorOfJoints) {

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -1,6 +1,7 @@
 #include "state_representation/robot/JointPositions.hpp"
 #include "state_representation/robot/JointState.hpp"
 #include "state_representation/robot/JointTorques.hpp"
+#include "state_representation/exceptions/IncompatibleSizeException.hpp"
 #include <fstream>
 #include <gtest/gtest.h>
 #include <unistd.h>
@@ -20,6 +21,9 @@ TEST(JointStateTest, ZeroInitialization) {
   EXPECT_FALSE(zero2.is_empty());
   // all data should be zero
   EXPECT_EQ(zero2.data().norm(), 0);
+  // should not be able to change the names attribute with a wrong size
+  EXPECT_THROW(zero.set_names(5), exceptions::IncompatibleSizeException);
+  EXPECT_THROW(zero2.set_names(std::vector<std::string>{"j0", "j1", "j2"}), exceptions::IncompatibleSizeException);
 }
 
 TEST(JointStateTest, RandomStateInitialization) {


### PR DESCRIPTION
As discussed I removed the `set_rows` and `set_cols` methods from the Jacobian class and took the opportunity to work on the docstrings at the same time. CLion advised me to use `std::move` in the constructors, if you don't like that, I can revert it.

For JointState, I added a check in the `set_names` methods because this was much needed and analogously to the Jacobian, moved the `initalize` call to the constructor (I think it makes more sense like that). 

To be honest, I'd even like to rename `set_names` to `set_joint_names` like in the Jacobian because I think it's cleaner but this might be too much of a change. Your call.