### PR TITLE
RSA for SSH dev server authentication and revised launch script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ showcases the `robot_model` module (#136, #139)
 - Remove `set_rows` and `set_cols` from Jacobian class due to inexpedience (#144)
 - Add constructor for the CartesianPose with only a quaternion provided (#145)
 - Add empty constructor for the Jacobian (#146)
-- Fix operators in JointState (#148)
 - Add empty constructors for JointState and CartesianState linear DS and improve unittests (#147)
+- Fix operators in JointState (#148)
+- RSA authentication for development server and better launch script (#149)
 
 ## 2.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,14 +23,16 @@ as long as they adhere to the overall contribution guidelines.
 
 Prerequisites: Install [Docker](https://docs.docker.com/get-docker/) and [CLion IDE](https://www.jetbrains.com/clion/download).
 
-Step 1: Build and run the development container server with `./dev-server.sh`.
+Step 1: Build and run the development container server with `./dev-server.sh`. The script requires access
+to your public RSA key file. You may additionally specify a custom port.
+Run `./dev-server.sh --help` for more details.
 
 Step 2: If not already done, [create a remote toolchain in CLion](https://www.jetbrains.com/help/clion/remote-projects-support.html#remote-toolchain)
 using the following credentials:
- - host `127.0.0.1`
- - port `2222`
- - username `remote`
- - password `password`
+ - Host: `127.0.0.1`
+ - Port: `2222` (or custom specified port)
+ - User name: `remote`
+ - Authentication type: `Key pair`
  
 Step 3: If not already done, [create a CMake profile that uses the remote toolchain](https://www.jetbrains.com/help/clion/remote-projects-support.html#CMakeProfile).
 

--- a/dev-server.sh
+++ b/dev-server.sh
@@ -1,12 +1,54 @@
 #!/usr/bin/env bash
-# Build and run a docker container as an SSH toolchain server for remote development
 
 IMAGE_NAME=control-libraries/remote-development
+STAGE_NAME=remote-development
 CONTAINER_NAME=control-libraries-remote-development-ssh
+CONTAINER_HOSTNAME=control-libraries-remote-development
 
-DOCKER_BUILDKIT=1 docker build -f Dockerfile --target remote-development --tag "${IMAGE_NAME}" .
+SSH_PORT=2222
+SSH_KEY_FILE="$HOME/.ssh/id_rsa.pub"
 
-docker container stop "$CONTAINER_NAME" >/dev/null 2>&1
-docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1
+HELP_MESSAGE="Usage: ./dev-server.sh [--port <port>] [--key-file </path/to/id_rsa.pub>]
 
-docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name "${CONTAINER_NAME}" "${IMAGE_NAME}"
+Build and run a docker container as an SSH toolchain server for remote development.
+
+The server is bound to the specified port on localhost (127.0.0.1)
+and uses passwordless RSA key-pair authentication. The host public key
+is read from the specified key file and copied to the server on startup.
+
+The server will run in the background as ${CONTAINER_NAME}.
+
+You can connect with 'ssh remote@localhost -p <port>'.
+
+Close the server with 'docker container stop ${CONTAINER_NAME}'.
+
+Options:
+  -p, --port [XXXX]        Specify the port to bind for SSH
+                           connection.
+                           (default: ${SSH_PORT})
+
+  -k, --key-file [path]    Specify the path of the RSA
+                           public key file.
+                           (default: ${SSH_KEY_FILE})
+
+  -h, --help               Show this help message."
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p|--port) SSH_PORT=$2; shift 1;;
+    -k|--key-file) SSH_KEY_FILE=$2; shift 1;;
+    -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
+    -*) echo "Unknown option: $1" >&2; echo "${HELP_MESSAGE}"; exit 1;;
+  esac
+done
+
+DOCKER_BUILDKIT=1 docker build -f Dockerfile --target "${STAGE_NAME}" --tag "${IMAGE_NAME}" .
+
+docker container stop "${CONTAINER_NAME}" >/dev/null 2>&1
+docker rm --force "${CONTAINER_NAME}" >/dev/null 2>&1
+
+docker run -d --cap-add sys_ptrace \
+  --publish 127.0.0.1:"${SSH_PORT}":22 \
+  --name "${CONTAINER_NAME}" \
+  --hostname "${CONTAINER_HOSTNAME}" \
+  "${IMAGE_NAME}" "$(cat "${SSH_KEY_FILE}")"


### PR DESCRIPTION
* Remove password for remote user and instead
copy a public key file to the list of
authorized keys in the ssh entrypoint script
before launching the sshd process

* Improve dev server script with options and help

* Update documentation

---

This is something I've been meaning to revise for a while. It was prompted by the work I was doing to get the ROS2 environment working, where things like user groups and passwordless authentication are more important. Before I share those results I thought I would share this as a simple introduction.

The consequence will be that you will have to reconfigure your CLion projects to use the Key pair authentication for the remote host rather than the password, but it's a simple one-time change. 