### PR TITLE
Preserve emptiness upon copy construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Release Versions:
 - [2.0.0](#200)
 - [1.0.0](#100)
 
+## Upcoming changes (in development)
+
+- Preserve emptiness upon copy construction (#152)
+
 ## 3.0.0
 
 Version 3.0.0 introduces Python bindings for the most commonly used

--- a/python/source/state_representation/bind_state.cpp
+++ b/python/source/state_representation/bind_state.cpp
@@ -40,7 +40,7 @@ void state(py::module_& m) {
 
   c.def("get_type", &State::get_type, "Getter of the type attribute");
   c.def("is_empty", &State::is_empty, "Getter of the empty attribute");
-  c.def("set_empty", &State::set_empty, "Setter of the empty attribute to true");
+  c.def("set_empty", &State::set_empty, "Setter of the empty attribute", "empty"_a=true);
   c.def("set_filled", &State::set_filled, "Setter of the empty attribute to false and also reset the timestamp");
   c.def("get_timestamp", &State::get_timestamp, "Getter of the timestamp attribute");
   c.def("reset_timestamp", &State::reset_timestamp, "Reset the timestamp attribute to now");

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -100,9 +100,10 @@ public:
   bool is_empty() const;
 
   /**
-   * @brief Setter of the empty attribute to true
+   * @brief Setter of the empty attribute
+   * @param empty bool if the state should be empty or not
    */
-  void set_empty();
+  void set_empty(bool empty = true);
 
   /**
    * @brief Setter of the empty attribute to false and also reset the timestamp
@@ -177,8 +178,8 @@ inline bool State::is_empty() const {
   return this->empty_;
 }
 
-inline void State::set_empty() {
-  this->empty_ = true;
+inline void State::set_empty(bool empty) {
+  this->empty_ = empty;
 }
 
 inline void State::set_filled() {

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -101,7 +101,7 @@ public:
 
   /**
    * @brief Setter of the empty attribute
-   * @param empty bool if the state should be empty or not
+   * @param empty bool if the state should be empty or not (default is true)
    */
   void set_empty(bool empty = true);
 

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -25,9 +25,7 @@ JointPositions::JointPositions(const JointState& state) : JointState(state) {
   // set all the state variables to 0 except positions
   this->set_zero();
   this->set_positions(state.get_positions());
-  if (state.is_empty()) {
-    this->set_empty();
-  }
+  this->set_empty(state.is_empty());
 }
 
 JointPositions::JointPositions(const JointPositions& positions) : JointPositions(static_cast<const JointState&>(positions)) {}

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -25,6 +25,9 @@ JointPositions::JointPositions(const JointState& state) : JointState(state) {
   // set all the state variables to 0 except positions
   this->set_zero();
   this->set_positions(state.get_positions());
+  if (state.is_empty()) {
+    this->set_empty();
+  }
 }
 
 JointPositions::JointPositions(const JointPositions& positions) : JointPositions(static_cast<const JointState&>(positions)) {}

--- a/source/state_representation/src/robot/JointTorques.cpp
+++ b/source/state_representation/src/robot/JointTorques.cpp
@@ -24,9 +24,7 @@ JointTorques::JointTorques(const JointState& state) : JointState(state) {
   // set all the state variables to 0 except torques
   this->set_zero();
   this->set_torques(state.get_torques());
-  if (state.is_empty()) {
-    this->set_empty();
-  }
+  this->set_empty(state.is_empty());
 }
 
 JointTorques::JointTorques(const JointTorques& torques) : JointTorques(static_cast<const JointState&>(torques)) {}

--- a/source/state_representation/src/robot/JointTorques.cpp
+++ b/source/state_representation/src/robot/JointTorques.cpp
@@ -24,6 +24,9 @@ JointTorques::JointTorques(const JointState& state) : JointState(state) {
   // set all the state variables to 0 except torques
   this->set_zero();
   this->set_torques(state.get_torques());
+  if (state.is_empty()) {
+    this->set_empty();
+  }
 }
 
 JointTorques::JointTorques(const JointTorques& torques) : JointTorques(static_cast<const JointState&>(torques)) {}

--- a/source/state_representation/src/robot/JointVelocities.cpp
+++ b/source/state_representation/src/robot/JointVelocities.cpp
@@ -25,6 +25,9 @@ JointVelocities::JointVelocities(const JointState& state) : JointState(state) {
   // set all the state variables to 0 except velocities
   this->set_zero();
   this->set_velocities(state.get_velocities());
+  if (state.is_empty()) {
+    this->set_empty();
+  }
 }
 
 JointVelocities::JointVelocities(const JointVelocities& velocities) : JointVelocities(static_cast<const JointState&>(velocities)) {}

--- a/source/state_representation/src/robot/JointVelocities.cpp
+++ b/source/state_representation/src/robot/JointVelocities.cpp
@@ -25,9 +25,7 @@ JointVelocities::JointVelocities(const JointState& state) : JointState(state) {
   // set all the state variables to 0 except velocities
   this->set_zero();
   this->set_velocities(state.get_velocities());
-  if (state.is_empty()) {
-    this->set_empty();
-  }
+  this->set_empty(state.is_empty());
 }
 
 JointVelocities::JointVelocities(const JointVelocities& velocities) : JointVelocities(static_cast<const JointState&>(velocities)) {}

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -38,9 +38,7 @@ CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state
   // set all the state variables to 0 except position and orientation
   this->set_zero();
   this->set_pose(state.get_pose());
-  if (state.is_empty()) {
-    this->set_empty();
-  }
+  this->set_empty(state.is_empty());
 }
 
 CartesianPose::CartesianPose(const CartesianPose& pose) : CartesianPose(static_cast<const CartesianState&>(pose)) {}

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -38,6 +38,9 @@ CartesianPose::CartesianPose(const CartesianState& state) : CartesianState(state
   // set all the state variables to 0 except position and orientation
   this->set_zero();
   this->set_pose(state.get_pose());
+  if (state.is_empty()) {
+    this->set_empty();
+  }
 }
 
 CartesianPose::CartesianPose(const CartesianPose& pose) : CartesianPose(static_cast<const CartesianState&>(pose)) {}

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -34,9 +34,7 @@ CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(sta
   // set all the state variables to 0 except linear and angular velocities
   this->set_zero();
   this->set_twist(state.get_twist());
-  if (state.is_empty()) {
-    this->set_empty();
-  }
+  this->set_empty(state.is_empty());
 }
 
 CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianTwist(static_cast<const CartesianState&>(twist)) {}

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -34,6 +34,9 @@ CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(sta
   // set all the state variables to 0 except linear and angular velocities
   this->set_zero();
   this->set_twist(state.get_twist());
+  if (state.is_empty()) {
+    this->set_empty();
+  }
 }
 
 CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianTwist(static_cast<const CartesianState&>(twist)) {}

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -30,9 +30,7 @@ CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(s
   // set all the state variables to 0 except force and torque
   this->set_zero();
   this->set_wrench(state.get_wrench());
-  if (state.is_empty()) {
-    this->set_empty();
-  }
+  this->set_empty(state.is_empty());
 }
 
 CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianWrench(static_cast<const CartesianState&>(wrench)) {}

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -30,6 +30,9 @@ CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(s
   // set all the state variables to 0 except force and torque
   this->set_zero();
   this->set_wrench(state.get_wrench());
+  if (state.is_empty()) {
+    this->set_empty();
+  }
 }
 
 CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianWrench(static_cast<const CartesianState&>(wrench)) {}

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -78,6 +78,11 @@ TEST(CartesianStateTest, CopyState) {
   EXPECT_EQ(state1.get_name(), state3.get_name());
   EXPECT_EQ(state1.get_reference_frame(), state3.get_reference_frame());
   EXPECT_TRUE(state1.data().isApprox(state3.data()));
+
+  CartesianState state4;
+  EXPECT_TRUE(state4.is_empty());
+  CartesianState state5 = state4;
+  EXPECT_TRUE(state5.is_empty());
 }
 
 TEST(CartesianStateTest, CopyPose) {
@@ -110,6 +115,11 @@ TEST(CartesianStateTest, CopyPose) {
   EXPECT_EQ(static_cast<CartesianState&>(pose5).get_twist().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(pose5).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(pose5).get_wrench().norm(), 0);
+
+  CartesianPose pose6;
+  EXPECT_TRUE(pose6.is_empty());
+  CartesianPose pose7 = pose6;
+  EXPECT_TRUE(pose7.is_empty());
 }
 
 TEST(CartesianStateTest, CopyTwist) {
@@ -150,6 +160,11 @@ TEST(CartesianStateTest, CopyTwist) {
   EXPECT_EQ(static_cast<CartesianState&>(twist5).get_orientation().w(), 1);
   EXPECT_EQ(static_cast<CartesianState&>(twist5).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(twist5).get_wrench().norm(), 0);
+
+  CartesianTwist twist6;
+  EXPECT_TRUE(twist6.is_empty());
+  CartesianTwist twist7 = twist6;
+  EXPECT_TRUE(twist7.is_empty());
 }
 
 TEST(CartesianStateTest, CopyWrench) {
@@ -190,6 +205,11 @@ TEST(CartesianStateTest, CopyWrench) {
   EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_orientation().w(), 1);
   EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_twist().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(wrench5).get_accelerations().norm(), 0);
+
+  CartesianWrench wrench6;
+  EXPECT_TRUE(wrench6.is_empty());
+  CartesianWrench wrench7 = wrench6;
+  EXPECT_TRUE(wrench7.is_empty());
 }
 
 TEST(CartesianStateTest, GetData) {

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -14,8 +14,7 @@ TEST(JointStateTest, ZeroInitialization) {
   // all data should be zero
   EXPECT_EQ(zero.data().norm(), 0);
   // same for the second initializer
-  JointState zero2 = JointState::Zero("test",
-                                      std::vector<std::string>{"j0", "j1"});
+  JointState zero2 = JointState::Zero("test", std::vector<std::string>{"j0", "j1"});
   // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(zero2.is_empty());
   // all data should be zero
@@ -33,9 +32,7 @@ TEST(JointStateTest, RandomStateInitialization) {
   EXPECT_GT(random.get_accelerations().norm(), 0);
   EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
-  JointState random2 =
-      JointState::Random("test",
-                         std::vector<std::string>{"j0", "j1"});
+  JointState random2 = JointState::Random("test", std::vector<std::string>{"j0", "j1"});
   // all data should be random (non 0)
   EXPECT_GT(random2.get_positions().norm(), 0);
   EXPECT_GT(random2.get_velocities().norm(), 0);
@@ -51,9 +48,7 @@ TEST(JointStateTest, RandomPositionsInitialization) {
   EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
   // same for the second initializer
-  JointPositions random2 =
-      JointPositions::Random("test",
-                             std::vector<std::string>{"j0", "j1"});
+  JointPositions random2 = JointPositions::Random("test", std::vector<std::string>{"j0", "j1"});
   // only position should be random
   EXPECT_GT(random2.get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
@@ -69,9 +64,7 @@ TEST(JointStateTest, RandomVelocitiesInitialization) {
   EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
   // same for the second initializer
-  JointVelocities random2 =
-      JointVelocities::Random("test",
-                              std::vector<std::string>{"j0", "j1"});
+  JointVelocities random2 = JointVelocities::Random("test", std::vector<std::string>{"j0", "j1"});
   // only velocities should be random
   EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_GT(random2.get_velocities().norm(), 0);
@@ -87,9 +80,7 @@ TEST(JointStateTest, RandomTorquesInitialization) {
   EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
   EXPECT_GT(random.get_torques().norm(), 0);
   // same for the second initializer
-  JointTorques random2 =
-      JointTorques::Random("test",
-                           std::vector<std::string>{"j0", "j1"});
+  JointTorques random2 = JointTorques::Random("test", std::vector<std::string>{"j0", "j1"});
   // only torques should be random
   EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -1,10 +1,9 @@
+#include <fstream>
+#include <gtest/gtest.h>
 #include "state_representation/robot/JointPositions.hpp"
 #include "state_representation/robot/JointState.hpp"
 #include "state_representation/robot/JointTorques.hpp"
 #include "state_representation/exceptions/IncompatibleSizeException.hpp"
-#include <fstream>
-#include <gtest/gtest.h>
-#include <unistd.h>
 
 using namespace state_representation;
 
@@ -106,6 +105,11 @@ TEST(JointStateTest, CopyState) {
   JointState state3 = state1;
   EXPECT_EQ(state1.get_name(), state3.get_name());
   EXPECT_TRUE(state1.data().isApprox(state3.data()));
+
+  JointState state4;
+  EXPECT_TRUE(state4.is_empty());
+  JointState state5 = state4;
+  EXPECT_TRUE(state5.is_empty());
 }
 
 TEST(JointStateTest, CopyPosisitions) {
@@ -136,6 +140,11 @@ TEST(JointStateTest, CopyPosisitions) {
   EXPECT_EQ(static_cast<JointState&>(positions5).get_velocities().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(positions5).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(positions5).get_torques().norm(), 0);
+
+  JointPositions positions6;
+  EXPECT_TRUE(positions6.is_empty());
+  JointPositions positions7 = positions6;
+  EXPECT_TRUE(positions7.is_empty());
 }
 
 TEST(JointStateTest, CopyVelocities) {
@@ -166,6 +175,11 @@ TEST(JointStateTest, CopyVelocities) {
   EXPECT_EQ(static_cast<JointState&>(velocities5).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(velocities5).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(velocities5).get_torques().norm(), 0);
+
+  JointVelocities velocities6;
+  EXPECT_TRUE(velocities6.is_empty());
+  JointVelocities velocities7 = velocities6;
+  EXPECT_TRUE(velocities7.is_empty());
 }
 
 TEST(JointStateTest, CopyTorques) {
@@ -196,6 +210,11 @@ TEST(JointStateTest, CopyTorques) {
   EXPECT_EQ(static_cast<JointState&>(torques5).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(torques5).get_velocities().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(torques5).get_accelerations().norm(), 0);
+
+  JointTorques torques6;
+  EXPECT_TRUE(torques6.is_empty());
+  JointTorques torques7 = torques6;
+  EXPECT_TRUE(torques7.is_empty());
 }
 
 TEST(JointStateTest, GetData) {


### PR DESCRIPTION
Apparently, due to optimization of the complier, instead of calling default constructor and assignment operator in 
```
CartesianState state;
auto state1 = state;
```
it just calls the copy constructor. In the copy constructors, the emptiness of states hasn't been preserved so far and I believe that we should do that. I added it to the most common types (Joint* and Cartesian*) and updated the unittests.

Let me know if you disagree with that in general, or if I need to do it for other classes too. CHANGELOG will be updated as well