### PR TITLE
Add set_data function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release Versions:
 ## Upcoming changes (in development)
 
 - Preserve emptiness upon copy construction (#152)
+- Add set_data function (#153)
 
 ## 3.0.0
 

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -92,6 +92,7 @@ void cartesian_state(py::module_& m) {
   c.def("clamp_state_variable", &CartesianState::clamp_state_variable, "Clamp inplace the magnitude of the a specific state variable (velocity, acceleration or force)", "max_value"_a, "state_variable_type"_a, "noise_ratio"_a=double(0));
   c.def("copy", &CartesianState::copy, "Return a copy of the CartesianState");
   c.def("data", &CartesianState::data, "Returns the data as the concatenation of all the state variables in a single vector");
+  c.def("set_data", &CartesianState::set_data, "Set the data of the state from all the state variables in a single vector");
   c.def("array", &CartesianState::array, "Returns the data vector as an array");
 
   c.def(py::self *= py::self);
@@ -170,6 +171,7 @@ void cartesian_pose(py::module_& m) {
 
   c.def("copy", &CartesianPose::copy, "Return a copy of the CartesianPose");
   c.def("data", &CartesianPose::data, "Returns the pose data as a vector");
+  c.def("set_data", &CartesianPose::set_data, "Set the pose data from an Eigen vector");
   c.def("norms", &CartesianPose::norms, "Compute the norms of the state variable specified by the input type (default is full pose)", "state_variable_type"_a=CartesianStateVariable::POSE);
   c.def("normalized", &CartesianPose::normalized, "Compute the normalized pose at the state variable given in argument (default is full pose)", "state_variable_type"_a=CartesianStateVariable::POSE);
 
@@ -235,6 +237,7 @@ void cartesian_twist(py::module_& m) {
 
   c.def("copy", &CartesianTwist::copy, "Return a copy of the CartesianTwist");
   c.def("data", &CartesianTwist::data, "Returns the twist data as a vector");
+  c.def("set_data", &CartesianTwist::set_data, "Set the twist data from an Eigen vector");
   c.def("norms", &CartesianTwist::norms, "Compute the norms of the state variable specified by the input type (default is full twist)", "state_variable_type"_a=CartesianStateVariable::TWIST);
   c.def("normalized", &CartesianTwist::normalized, "Compute the normalized twist at the state variable given in argument (default is full twist)", "state_variable_type"_a=CartesianStateVariable::TWIST);
 
@@ -294,6 +297,7 @@ void cartesian_wrench(py::module_& m) {
 
   c.def("copy", &CartesianWrench::copy, "Return a copy of the CartesianWrench");
   c.def("data", &CartesianWrench::data, "Returns the wrench data as a vector");
+  c.def("set_data", &CartesianWrench::set_data, "Set the wrench data from an Eigen vector");
   c.def("norms", &CartesianWrench::norms, "Compute the norms of the state variable specified by the input type (default is full wrench)", "state_variable_type"_a=CartesianStateVariable::WRENCH);
   c.def("normalized", &CartesianWrench::normalized, "Compute the normalized twist at the state variable given in argument (default is full wrench)", "state_variable_type"_a=CartesianStateVariable::WRENCH);
 

--- a/python/source/state_representation/bind_joint_space.cpp
+++ b/python/source/state_representation/bind_joint_space.cpp
@@ -53,6 +53,7 @@ void joint_state(py::module_& m) {
   c.def("clamp_state_variable", py::overload_cast<const Eigen::ArrayXd&, const JointStateVariable&, const Eigen::ArrayXd&>(&JointState::clamp_state_variable), "Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)", "max_absolute_value_array"_a, "state_variable_type"_a, "noise_ratio_array"_a);
   c.def("copy", &JointState::copy, "Return a copy of the JointState");
   c.def("data", &JointState::data, "Returns the data as the concatenation of all the state variables in a single vector");
+  c.def("set_data", &JointState::set_data, "Set the data of the state from all the state variables in a single vector");
   c.def("array", &JointState::array, "Returns the data vector as an array");
 
   c.def(py::self += py::self);
@@ -131,6 +132,7 @@ void joint_positions(py::module_& m) {
 
   c.def("copy", &JointPositions::copy, "Return a copy of the JointPositions");
   c.def("data", &JointPositions::data, "Returns the positions data as a vector");
+  c.def("set_data", &JointPositions::set_data, "Set the positions data from an Eigen vector");
 
   c.def("from_list", &JointPositions::from_std_vector, "Set the value from a list");
 
@@ -190,6 +192,7 @@ void joint_velocities(py::module_& m) {
 
   c.def("copy", &JointVelocities::copy, "Return a copy of the JointVelocities");
   c.def("data", &JointVelocities::data, "Returns the velocities data as a vector");
+  c.def("set_data", &JointVelocities::set_data, "Set the velocities data from an Eigen vector");
 
   c.def("clamp", py::overload_cast<double, double>(&JointVelocities::clamp), "Clamp inplace the magnitude of the velocity to the values in argument", "max_absolute_value"_a, "noise_ratio"_a=0.0);
   c.def("clamped", py::overload_cast<double, double>(&JointVelocities::clamp), "Return the velocity clamped to the values in argument", "max_absolute_value"_a, "noise_ratio"_a=0.0);
@@ -248,6 +251,7 @@ void joint_torques(py::module_& m) {
 
   c.def("copy", &JointTorques::copy, "Return a copy of the JointTorques");
   c.def("data", &JointTorques::data, "Returns the torques data as a vector");
+  c.def("set_data", &JointTorques::set_data, "Set the torques data from an Eigen vector");
 
   c.def("clamp", py::overload_cast<double, double>(&JointTorques::clamp), "Clamp inplace the magnitude of the torque to the values in argument", "max_absolute_value"_a, "noise_ratio"_a=0.0);
   c.def("clamped", py::overload_cast<double, double>(&JointTorques::clamp), "Return the torque clamped to the values in argument", "max_absolute_value"_a, "noise_ratio"_a=0.0);

--- a/python/tests/cartesian_state_test.py
+++ b/python/tests/cartesian_state_test.py
@@ -9,6 +9,7 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
     'clamp_state_variable',
     'copy',
     'data',
+    'set_data',
     'dist',
     'from_list',
     'get_accelerations',

--- a/python/tests/joint_state_test.py
+++ b/python/tests/joint_state_test.py
@@ -8,6 +8,7 @@ JOINT_STATE_METHOD_EXPECTS = [
     'clamp_state_variable',
     'copy',
     'data',
+    'set_data',
     'dist',
     'from_list',
     'get_accelerations',

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/09/09
- */
-
 #pragma once
 
 #include "state_representation/exceptions/IncompatibleSizeException.hpp"

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -218,6 +218,12 @@ public:
   Eigen::VectorXd data() const override;
 
   /**
+   * @brief Set the positions data from an Eigen vector
+   * @param the positions data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to append the string representing the state
    * @param positions the state to print

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/09/09
- */
-
 #pragma once
 
 #include "state_representation/robot/JointState.hpp"

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -1,15 +1,9 @@
-/**
- * @author Baptiste Busch
- * @date 2019/04/16
- */
-
 #pragma once
 
 #include "state_representation/exceptions/IncompatibleSizeException.hpp"
 #include "state_representation/State.hpp"
 #include <eigen3/Eigen/Core>
 #include <iostream>
-#include <math.h>
 #include <string>
 #include <vector>
 
@@ -311,6 +305,13 @@ public:
    * @return the concatenated data vector
    */
   virtual Eigen::VectorXd data() const;
+
+  /**
+   * @brief Set the data of the state from
+   * all the state variables in a single vector
+   * @param the concatenated data vector
+   */
+  virtual void set_data(const Eigen::VectorXd& data);
 
   /**
    * @brief Returns the data vector as an Eigen Array

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/09/13
- */
-
 #pragma once
 
 #include "state_representation/robot/JointState.hpp"

--- a/source/state_representation/include/state_representation/robot/JointTorques.hpp
+++ b/source/state_representation/include/state_representation/robot/JointTorques.hpp
@@ -203,6 +203,12 @@ public:
   Eigen::VectorXd data() const override;
 
   /**
+   * @brief Set the torques data from an Eigen vector
+   * @param the torques data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
    * @brief Clamp inplace the magnitude of the torque to the values in argument
    * @param max_absolute_value the maximum magnitude of torque for all the joints
    * @param noise_ratio if provided, this value will be used to apply a dead zone under which

--- a/source/state_representation/include/state_representation/robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/robot/JointVelocities.hpp
@@ -218,6 +218,12 @@ public:
   Eigen::VectorXd data() const override;
 
   /**
+   * @brief Set the velocities data from an Eigen vector
+   * @param the velocities data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
    * @brief Clamp inplace the magnitude of the velocity to the values in argument
    * @param max_absolute_value the maximum magnitude of torque for all the joints
    * @param noise_ratio if provided, this value will be used to apply a dead zone under which

--- a/source/state_representation/include/state_representation/robot/JointVelocities.hpp
+++ b/source/state_representation/include/state_representation/robot/JointVelocities.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/09/09
- */
-
 #pragma once
 
 #include "state_representation/robot/JointPositions.hpp"

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/06/07
- */
-
 #pragma once
 
 #include "state_representation/space/cartesian/CartesianState.hpp"

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -214,6 +214,12 @@ public:
   Eigen::VectorXd data() const override;
 
   /**
+   * @brief Set the pose data from an Eigen vector
+   * @param the pose data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
    * @brief Compute the norms of the state variable specified by the input type (default is full pose)
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -364,6 +364,13 @@ public:
   virtual Eigen::VectorXd data() const;
 
   /**
+   * @brief Set the data of the state from
+   * all the state variables in a single vector
+   * @param the concatenated data vector
+   */
+  virtual void set_data(const Eigen::VectorXd& data);
+
+  /**
    * @brief Return the data vector as an Eigen Array
    * @return the concatenated data array
    */

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/04/16
- */
-
 #pragma once
 
 #include "state_representation/exceptions/IncompatibleSizeException.hpp"

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/06/07
- */
-
 #pragma once
 
 #include "state_representation/space/cartesian/CartesianPose.hpp"

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -221,7 +221,7 @@ public:
    * @brief Returns the twist data as an Eigen vector
    * @return the twist data vector
    */
-  Eigen::VectorXd data() const;
+  Eigen::VectorXd data() const override;
 
   /**
    * @brief Compute the norms of the state variable specified by the input type (default is full twist)

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -224,6 +224,12 @@ public:
   Eigen::VectorXd data() const override;
 
   /**
+   * @brief Set the twist data from an Eigen vector
+   * @param the twist data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
    * @brief Compute the norms of the state variable specified by the input type (default is full twist)
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -202,6 +202,12 @@ public:
   Eigen::VectorXd data() const;
 
   /**
+   * @brief Set the twist data from an Eigen vector
+   * @param the twist data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
    * @brief Compute the norms of the state variable specified by the input type (default is full wrench)
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/09/13
- */
-
 #pragma once
 
 #include "state_representation/space/cartesian/CartesianState.hpp"

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -126,6 +126,10 @@ Eigen::VectorXd JointPositions::data() const {
   return this->get_positions();
 }
 
+void JointPositions::set_data(const Eigen::VectorXd& data) {
+  this->set_positions(data);
+}
+
 std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {
   if (positions.is_empty()) {
     os << "Empty JointPositions";

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -1,6 +1,5 @@
 #include "state_representation/robot/JointPositions.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
-#include "state_representation/exceptions/IncompatibleStatesException.hpp"
 
 using namespace state_representation::exceptions;
 

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -174,6 +174,10 @@ Eigen::VectorXd JointState::data() const {
   return this->get_all_state_variables();
 }
 
+void JointState::set_data(const Eigen::VectorXd& data) {
+  this->set_all_state_variables(data);
+}
+
 Eigen::ArrayXd JointState::array() const {
   return this->data().array();
 }

--- a/source/state_representation/src/robot/JointTorques.cpp
+++ b/source/state_representation/src/robot/JointTorques.cpp
@@ -110,6 +110,10 @@ Eigen::VectorXd JointTorques::data() const {
   return this->get_torques();
 }
 
+void JointTorques::set_data(const Eigen::VectorXd& data) {
+  this->set_torques(data);
+}
+
 void JointTorques::clamp(double max_absolute_value, double noise_ratio) {
   this->clamp_state_variable(max_absolute_value, JointStateVariable::TORQUES, noise_ratio);
 }

--- a/source/state_representation/src/robot/JointTorques.cpp
+++ b/source/state_representation/src/robot/JointTorques.cpp
@@ -1,6 +1,4 @@
 #include "state_representation/robot/JointTorques.hpp"
-#include "state_representation/exceptions/EmptyStateException.hpp"
-#include "state_representation/exceptions/IncompatibleStatesException.hpp"
 
 using namespace state_representation::exceptions;
 

--- a/source/state_representation/src/robot/JointVelocities.cpp
+++ b/source/state_representation/src/robot/JointVelocities.cpp
@@ -126,6 +126,10 @@ Eigen::VectorXd JointVelocities::data() const {
   return this->get_velocities();
 }
 
+void JointVelocities::set_data(const Eigen::VectorXd& data) {
+  this->set_velocities(data);
+}
+
 void JointVelocities::clamp(double max_absolute_value, double noise_ratio) {
   this->clamp_state_variable(max_absolute_value, JointStateVariable::VELOCITIES, noise_ratio);
 }

--- a/source/state_representation/src/robot/JointVelocities.cpp
+++ b/source/state_representation/src/robot/JointVelocities.cpp
@@ -1,6 +1,5 @@
 #include "state_representation/robot/JointVelocities.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
-#include "state_representation/exceptions/IncompatibleStatesException.hpp"
 
 using namespace state_representation::exceptions;
 

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -123,6 +123,10 @@ Eigen::VectorXd CartesianPose::data() const {
   return this->get_pose();
 }
 
+void CartesianPose::set_data(const Eigen::VectorXd& data) {
+  this->set_pose(data);
+}
+
 std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
   if (pose.is_empty()) {
     os << "Empty CartesianPose";

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -79,6 +79,10 @@ Eigen::VectorXd CartesianState::data() const {
   return this->get_state_variable(CartesianStateVariable::ALL);
 }
 
+void CartesianState::set_data(const Eigen::VectorXd& data) {
+  this->set_state_variable(data, CartesianStateVariable::ALL);
+}
+
 Eigen::ArrayXd CartesianState::array() const {
   return this->data().array();
 }

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -149,6 +149,10 @@ Eigen::VectorXd CartesianTwist::data() const {
   return this->get_twist();
 }
 
+void CartesianTwist::set_data(const Eigen::VectorXd& data) {
+  this->set_twist(data);
+}
+
 std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {
   if (twist.is_empty()) {
     os << "Empty CartesianTwist";

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -105,6 +105,10 @@ Eigen::VectorXd CartesianWrench::data() const {
   return this->get_wrench();
 }
 
+void CartesianWrench::set_data(const Eigen::VectorXd& data) {
+  this->set_wrench(data);
+}
+
 std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {
   if (wrench.is_empty()) {
     os << "Empty CartesianWrench";

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -1,5 +1,4 @@
 #include "state_representation/space/cartesian/CartesianWrench.hpp"
-#include "state_representation/exceptions/EmptyStateException.hpp"
 
 using namespace state_representation::exceptions;
 

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -216,7 +216,15 @@ TEST(CartesianStateTest, GetData) {
   CartesianState cs = CartesianState::Random("test");
   Eigen::VectorXd concatenated_state(25);
   concatenated_state << cs.get_pose(), cs.get_twist(), cs.get_accelerations(), cs.get_wrench();
-  EXPECT_NEAR(concatenated_state.norm(), cs.data().norm(), 1e-4);
+  EXPECT_TRUE(concatenated_state.isApprox(cs.data()));
+}
+
+TEST(CartesianStateTest, SetData) {
+  CartesianState cs = CartesianState("test");
+  Eigen::VectorXd concatenated_state(25);
+  concatenated_state << cs.get_pose(), cs.get_twist(), cs.get_accelerations(), cs.get_wrench();
+  cs.set_data(concatenated_state);
+  EXPECT_TRUE(concatenated_state.isApprox(cs.data()));
 }
 
 TEST(CartesianStateTest, CartesianStateToStdVector) {

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -212,7 +212,15 @@ TEST(JointStateTest, GetData) {
   JointState js = JointState::Random("test_robot", 4);
   Eigen::VectorXd concatenated_state(js.get_size() * 4);
   concatenated_state << js.get_positions(), js.get_velocities(), js.get_accelerations(), js.get_torques();
-  EXPECT_NEAR(concatenated_state.norm(), js.data().norm(), 1e-4);
+  EXPECT_TRUE(concatenated_state.isApprox(js.data()));
+}
+
+TEST(JointStateTest, SetData) {
+  JointState js = JointState("test");
+  Eigen::VectorXd concatenated_state(js.get_size() * 4);
+  concatenated_state << js.get_positions(), js.get_velocities(), js.get_accelerations(), js.get_torques();
+  js.set_data(concatenated_state);
+  EXPECT_TRUE(concatenated_state.isApprox(js.data()));
 }
 
 TEST(JointStateTest, JointStateToStdVector) {


### PR DESCRIPTION
I needed the `set_data` function to be able to set all the variables of a `CartesianState` in one go, basically doing `s1.set_data(s2.data())`. I figured I could do it for all the derived classes as well as it is done in the `data` function. I also used my time to clean a bit the extra comments that were still there.
 
Thinking about it, I think it could make sense that `data` and `set_data` functions become part of the `State` base class and are overridden in all the derived classes.