### PR TITLE
Empty DS constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release Versions:
 - Use release configuration in install script (#155)
 - Fix CartesianPose constructor in Python bindings and revise run script (#157)
 - Add CI workflow for Python bindings (#159)
+- Add emtpy constructors for Circular and Ring DS (#154)
 
 ## 3.0.0
 

--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -62,13 +62,16 @@ The **Linear** DS can be thought of as a point attractor, with a velocity that i
 to the distance of the current state from the attractor.
 It is currently implemented for the `CartesianState` and `JointState` types.
 
-The Linear DS is constructed with a state as an argument; this becomes the attractor.
 ```c++
+// empty construction results in empty base frame and attractor
+dynamical_systems::Linear<S> emptyDS;
+
+// construction with an attractor and default value for the gain
 state_representation::CartesianState cartesianAttractor("A");
-dynamical_systems::Linear<state_representation::CartesianState> linear(cartesianAttractor);
+dynamical_systems::Linear<state_representation::CartesianState> linearDS1(cartesianAttractor);
 
 state_representation::JointState jointAttractor("B");
-dynamical_systems::Linear<state_representation::JointState> linear(jointAttractor);
+dynamical_systems::Linear<state_representation::JointState> linearDS2(jointAttractor);
 ```
 
 ### Configuring the Linear DS
@@ -117,11 +120,11 @@ state_representation::CartesianTwist twist = linear.evaluate(csB);
 
 The returned velocity will always be expressed in the same reference frame as the input state.
 
-### Reference frames
+### Reference frames (this applies to all of them, also a note on empty construction?!)
 
 The following section applies for the `CartesianState` type.
 
-The `evaulate()` function will always return a twist expressed in the same reference frame as the input state,
+The `evaluate()` function will always return a twist expressed in the same reference frame as the input state,
 provided that the input state is compatible with the DS.
 
 The input state must be expressed in one of two supported reference frames:
@@ -177,7 +180,7 @@ are automatically combined with the DS result with respect to the common referen
 
 Setting the base frame of the DS has some benefits. In some cases, the state variable to be
 evaluated is not directly expressed in the frame of the DS.
-Similarly the output twist may need to be expressed in a different reference frame.
+Similarly, the output twist may need to be expressed in a different reference frame.
 
 As a practical example, consider a case where the state of an end-effector is
 reported in the reference frame of a robot, while a linear attractor is expressed
@@ -235,6 +238,10 @@ in the constructor, the limit cycle has a constant radius.
 If an elliptical limit cycle is desired, the DS can be constructed directly from an `Ellipsoid` type.
 
 ```c++
+// empty construction results in empty base frame and limit cycle
+dynamical_systems::Circular emptyDS;
+emptyDS.set_limit_cycle(ellipse); // sets a null base frame according to the reference frame of the limit cycle
+
 // construct the circular DS limit cycle using a CartesianState center
 state_representation::CartesianState center("center");
 
@@ -305,6 +312,10 @@ A clockwise rotation can be achieved by rotating the ring 180 degrees about its 
 It only supports the `CartesianState` type, and always acts in a circular ring. 
 
 ```c++
+// empty construction results in empty base frame and center state
+dynamical_systems::Ring emptyDS;
+
+// construction with center state and default values for parameters
 state_representation::CartesianState center("center");
 dynamical_systems::Ring ringDS(center);
 ```

--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -42,13 +42,17 @@ joint velocity.
 
 ### Base frame
 
-The **DynamicalSystem** base class has a private `base_frame` property, which can be thought of as the DS origin. 
+The *DynamicalSystem* base class has a private `base_frame` property, which can be thought of as the DS origin. 
 The functions `get_base_frame()` and `set_base_frame(const S& state)` can be used to access or modify this base frame.
 
-The DynamicalSystem can be constructed with a `state` to set the base frame, or with string frame name. In 
-the latter case the base frame is set as a null / Identity frame with the specified name.
+The `DynamicalSystem<CartesianState>` can be constructed with a `state` to set the base frame, or with string frame name. In 
+the latter case the base frame is set as a null / identity frame with the specified name.
 For example, `DynamicalSystem<CartesianState>("base")` will create a dynamical system with the null base frame "base",
 expressed in its own frame "base".
+
+The `DynamicalSystem<JointState>` can only be constructed with a `state` to set the base frame. Whilst the term 
+*base frame* makes more sense for a `CartesianState` DS, it rather refers to a specific robot with corresponding name
+and joint names in the case of a `JointState` DS.
 
 In most cases, the constructor for the base DynamicalSystem should not be used directly,
 and rather the derived DS classes should construct the base accordingly.
@@ -70,7 +74,7 @@ The input state must be expressed in one of two supported reference frames:
 The following snippet illustrates the difference in these two options.
 ```c++
 // create a linear DS with attractor B in frame A
-state_representation::CartesianState BinA("B", "A");
+state_representation::CartesianState BinA = state_representation::CartesianState::Identity("B", "A");
 dynamical_systems::Linear<state_representation::CartesianState> linearDS(BinA);
 
 linearDS.get_attractor().get_name();             // "B"
@@ -79,11 +83,11 @@ linearDS.get_base_frame().get_name();            // "A"
 linearDS.get_base_frame().get_reference_frame(); // "A"
 
 // evaluate a point C in frame A
-state_representation::CartesianState CinA("C", "A");
+state_representation::CartesianState CinA = state_representation::CartesianState::Random("C", "A");
 auto twist0 = linearDS.evaluate(CinA); // valid, twist is expressed in frame A
 
 // set the base from of the DS to be A expressed in the world frame
-state_representation::CartesianState AinWorld("A", "world");
+state_representation::CartesianState AinWorld = state_representation::CartesianState::Identity("A", "world");
 linearDS.set_base_frame(AinWorld);
 
 linearDS.get_attractor().get_name();             // "B"
@@ -127,7 +131,7 @@ any pre-transformation of the end-effector state or post-transformation of the t
 
 ```c++
 state_representation::CartesianState EE("end_effector", "robot");
-state_representation::CartesianState attractor("attractor", "task");
+state_representation::CartesianState attractor = state_representation::CartesianState::Random("attractor", "task");
 state_representation::CartesianState taskInRobot("task", "robot");
 
 dynamical_systems::Linear<state_representation::CartesianState> linearDS(attractor);
@@ -165,10 +169,10 @@ It is currently implemented for the `CartesianState` and `JointState` types.
 dynamical_systems::Linear<S> emptyDS;
 
 // construction with an attractor and default value for the gain
-state_representation::CartesianState cartesianAttractor("A");
+state_representation::CartesianState cartesianAttractor = state_representation::CartesianState::Identity("A");
 dynamical_systems::Linear<state_representation::CartesianState> linearDS1(cartesianAttractor);
 
-state_representation::JointState jointAttractor("B");
+state_representation::JointState jointAttractor = state_representation::JointState::Zero(6);
 dynamical_systems::Linear<state_representation::JointState> linearDS2(jointAttractor);
 ```
 
@@ -190,7 +194,7 @@ length, or as a scalar (which sets the value along the diagonal elements of the 
 ```c++
 // set a gain (scalar, vector or matrix during construction)
 double gain = 10;
-state_representation::CartesianState csA("A");
+state_representation::CartesianState csA = state_representation::CartesianState::Identity("A");
 dynamical_systems::Linear<state_representation::CartesianState> linear(csA, gain);
 
 // or set / update the gain for the created object
@@ -198,7 +202,7 @@ std::vector<double> gains = {1, 2, 3, 4, 5, 6};
 linear.set_gain(gains);
 
 // update the attractor
-state_representation::CartesianState csB("B");
+state_representation::CartesianState csB = state_representation::CartesianState::Random("B");
 linear.set_attractor(csB);
 ```
 
@@ -207,9 +211,10 @@ linear.set_attractor(csB);
 To get the velocity from a state, simply call the `evaluate()` function.
 
 ```c++
-state_representation::CartesianState csA("A"), csB("B");
+state_representation::CartesianState csA = state_representation::CartesianState::Identity("A");
 dynamical_systems::Linear<state_representation::CartesianState> linear(csA);
 
+state_representation::CartesianState csB = state_representation::CartesianState::Random("B");
 // note: the return type of evaluate() is a CartesianState, but
 // it can be directly assigned to a CartesianTwist because the =operator
 // has been defined for that purpose
@@ -243,7 +248,7 @@ dynamical_systems::Circular emptyDS;
 emptyDS.set_limit_cycle(ellipse); // sets a null base frame according to the reference frame of the limit cycle
 
 // construct the circular DS limit cycle using a CartesianState center
-state_representation::CartesianState center("center");
+state_representation::CartesianState center = state_representation::CartesianState::Identity("center");
 
 // default constructor (radius = 1)
 dynamical_systems::Circular circularDS1(center);
@@ -316,7 +321,7 @@ It only supports the `CartesianState` type, and always acts in a circular ring.
 dynamical_systems::Ring emptyDS;
 
 // construction with center state and default values for parameters
-state_representation::CartesianState center("center");
+state_representation::CartesianState center = state_representation::CartesianState::Identity("center");
 dynamical_systems::Ring ringDS(center);
 ```
 

--- a/source/dynamical_systems/include/dynamical_systems/Circular.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Circular.hpp
@@ -52,8 +52,8 @@ public:
   /**
    * @brief Default constructor with center and fixed radius
    * @param center the center of the limit cycle
-   * @param radius radius of the limit cycle (default is 1.)
-   * @param gain gain of the dynamical system (default is 1.)
+   * @param radius radius of the limit cycle
+   * @param gain gain of the dynamical system
    * @param circular_velocity circular velocity to move around the limit cycle
    */
   explicit Circular(const state_representation::CartesianState& center,
@@ -64,7 +64,7 @@ public:
   /**
    * @brief Constructor with an elliptic limit cycle
    * @param limit_cycle the limit cycle as an ellipsoid
-   * @param gain gain of the dynamical system (default is 1.)
+   * @param gain gain of the dynamical system
    * @param circular_velocity circular velocity to move around the limit cycle
    */
   explicit Circular(const state_representation::Ellipsoid& limit_cycle,
@@ -117,7 +117,7 @@ public:
   void set_normal_gain(double gain);
 
   /**
-   * @brief Getter of the radius's of the limit cycle
+   * @brief Getter of the rotation angle attribute
    * @return the radius value
    */
 
@@ -130,21 +130,21 @@ public:
   void set_rotation_angle(double angle);
 
   /**
-   * @brief Getter of the rotation angle attribute
+   * @brief Getter of the radiuses of the limit cycle
    * @param The rotation angle value
    */
 
   const std::vector<double>& get_radiuses() const;
 
   /**
-   * @brief Setter of the radius's of the limit cycle
-   * @param radiuses the new radius's values
+   * @brief Setter of the radiuses of the limit cycle
+   * @param radiuses the new radiuses values
    */
   void set_radiuses(const std::vector<double>& radiuses);
 
   /**
    * @brief Setter of the radius of the limit cycle as a single value, i.e. perfect cycle
-   * @param radiuses the new radius's values
+   * @param radiuses the new radiuses values
    */
   void set_radius(double radius);
 

--- a/source/dynamical_systems/include/dynamical_systems/Circular.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Circular.hpp
@@ -120,7 +120,6 @@ public:
    * @brief Getter of the rotation angle attribute
    * @return the radius value
    */
-
   double get_rotation_angle() const;
 
   /**
@@ -133,7 +132,6 @@ public:
    * @brief Getter of the radiuses of the limit cycle
    * @param The rotation angle value
    */
-
   const std::vector<double>& get_radiuses() const;
 
   /**

--- a/source/dynamical_systems/include/dynamical_systems/Linear.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Linear.hpp
@@ -137,8 +137,8 @@ inline void Linear<state_representation::CartesianState>::set_attractor(const st
     throw state_representation::exceptions::EmptyStateException(attractor.get_name() + " state is empty");
   }
   if (this->get_base_frame().is_empty()) {
-    DynamicalSystem<state_representation::CartesianState>::set_base_frame(state_representation::CartesianState::Identity(attractor.get_reference_frame(),
-                                                                             attractor.get_reference_frame()));
+    DynamicalSystem<state_representation::CartesianState>::set_base_frame(
+        state_representation::CartesianState::Identity(attractor.get_reference_frame(), attractor.get_reference_frame()));
   }
   // validate that the reference frame of the attractor is always compatible with the DS reference frame
   if (attractor.get_reference_frame() != this->get_base_frame().get_name()) {
@@ -160,7 +160,8 @@ inline void Linear<state_representation::JointState>::set_attractor(const state_
     throw state_representation::exceptions::EmptyStateException(attractor.get_name() + " state is empty");
   }
   if (this->get_base_frame().is_empty()) {
-    DynamicalSystem<state_representation::JointState>::set_base_frame(state_representation::JointState::Zero(attractor.get_name(), attractor.get_names()));
+    DynamicalSystem<state_representation::JointState>::set_base_frame(
+        state_representation::JointState::Zero(attractor.get_name(), attractor.get_names()));
   }
   // validate that the attractor is compatible with the DS reference name
   if (!this->is_compatible(attractor)) {

--- a/source/dynamical_systems/include/dynamical_systems/Linear.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Linear.hpp
@@ -186,9 +186,9 @@ inline void Linear<state_representation::CartesianState>::set_base_frame(const s
     throw state_representation::exceptions::EmptyStateException(base_frame.get_name() + " state is empty");
   }
   DynamicalSystem<state_representation::CartesianState>::set_base_frame(base_frame);
-  auto attractor = this->get_attractor();
-  if (!attractor.is_empty()) {
+  if (!this->get_attractor().is_empty()) {
     // update reference frame of attractor
+    auto attractor = this->get_attractor();
     attractor.set_reference_frame(base_frame.get_name());
     this->set_attractor(attractor);
   }
@@ -200,9 +200,9 @@ inline void Linear<state_representation::JointState>::set_base_frame(const state
     throw state_representation::exceptions::EmptyStateException(base_frame.get_name() + " state is empty");
   }
   DynamicalSystem<state_representation::JointState>::set_base_frame(base_frame);
-  auto attractor = this->get_attractor();
-  if (!attractor.is_empty()) {
+  if (!this->get_attractor().is_empty()) {
     // update name of attractor
+    auto attractor = this->get_attractor();
     attractor.set_name(base_frame.get_name());
     attractor.set_names(base_frame.get_names());
     this->set_attractor(attractor);

--- a/source/dynamical_systems/include/dynamical_systems/Linear.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Linear.hpp
@@ -185,9 +185,9 @@ inline void Linear<state_representation::CartesianState>::set_base_frame(const s
     throw state_representation::exceptions::EmptyStateException(base_frame.get_name() + " state is empty");
   }
   DynamicalSystem<state_representation::CartesianState>::set_base_frame(base_frame);
-  if (!this->get_attractor().is_empty()) {
+  auto attractor = this->get_attractor();
+  if (!attractor.is_empty()) {
     // update reference frame of attractor
-    auto attractor = this->get_attractor();
     attractor.set_reference_frame(base_frame.get_name());
     this->set_attractor(attractor);
   }
@@ -199,9 +199,9 @@ inline void Linear<state_representation::JointState>::set_base_frame(const state
     throw state_representation::exceptions::EmptyStateException(base_frame.get_name() + " state is empty");
   }
   DynamicalSystem<state_representation::JointState>::set_base_frame(base_frame);
-  if (!this->get_attractor().is_empty()) {
+  auto attractor = this->get_attractor();
+  if (!attractor.is_empty()) {
     // update name of attractor
-    auto attractor = this->get_attractor();
     attractor.set_name(base_frame.get_name());
     attractor.set_names(base_frame.get_names());
     this->set_attractor(attractor);

--- a/source/dynamical_systems/include/dynamical_systems/Ring.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Ring.hpp
@@ -44,6 +44,11 @@ protected:
 
 public:
   /**
+   * @brief Empty constructor
+  */
+  Ring();
+
+  /**
    * @brief Default constructor with center and fixed radius
    * @param center the center of the limit cycle
    * @param radius radius of the limit cycle (default=1.)

--- a/source/dynamical_systems/include/dynamical_systems/Ring.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Ring.hpp
@@ -51,7 +51,7 @@ public:
   /**
    * @brief Default constructor with center and fixed radius
    * @param center the center of the limit cycle
-   * @param radius radius of the limit cycle (default=1.)
+   * @param radius radius of the limit cycle
    */
   explicit Ring(const state_representation::CartesianState& center,
                 double radius = 1.0,

--- a/source/dynamical_systems/src/Circular.cpp
+++ b/source/dynamical_systems/src/Circular.cpp
@@ -79,8 +79,8 @@ void Circular::set_base_frame(const CartesianState& base_frame) {
   }
   DynamicalSystem<CartesianState>::set_base_frame(base_frame);
   // update reference frame of center
-  auto center_state = this->limit_cycle_->get_value().get_center_state();
-  if (!center_state.is_empty()) {
+  if (!this->limit_cycle_->get_value().get_center_state().is_empty()) {
+    auto center_state = this->limit_cycle_->get_value().get_center_state();
     center_state.set_reference_frame(base_frame.get_name());
     this->limit_cycle_->get_value().set_center_state(center_state);
   }

--- a/source/dynamical_systems/src/Circular.cpp
+++ b/source/dynamical_systems/src/Circular.cpp
@@ -1,8 +1,20 @@
 #include "dynamical_systems/Circular.hpp"
 
+#include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
+
 using namespace state_representation;
 
 namespace dynamical_systems {
+
+Circular::Circular() :
+    DynamicalSystem<CartesianState>(),
+    limit_cycle_(std::make_shared<Parameter<Ellipsoid>>("limit_cycle", Ellipsoid("limit_cycle", "limit_cycle"))),
+    planar_gain_(std::make_shared<Parameter<double>>("planar_gain", 1.0)),
+    normal_gain_(std::make_shared<Parameter<double>>("normal_gain", 1.0)),
+    circular_velocity_(std::make_shared<Parameter<double>>("circular_velocity", M_PI / 2)) {
+  this->limit_cycle_->get_value().set_center_state(CartesianState("limit_cycle", "limit_cycle"));
+}
+
 Circular::Circular(const CartesianState& center, double radius, double gain, double circular_velocity) :
     DynamicalSystem(center.get_reference_frame()),
     limit_cycle_(std::make_shared<Parameter<Ellipsoid>>("limit_cycle",
@@ -15,13 +27,16 @@ Circular::Circular(const CartesianState& center, double radius, double gain, dou
 }
 
 Circular::Circular(const Ellipsoid& limit_cycle, double gain, double circular_velocity) :
-    DynamicalSystem(limit_cycle.get_center_pose().get_reference_frame()),
+    DynamicalSystem(limit_cycle.get_center_state().get_reference_frame()),
     limit_cycle_(std::make_shared<Parameter<Ellipsoid>>("limit_cycle", limit_cycle)),
     planar_gain_(std::make_shared<Parameter<double>>("planar_gain", gain)),
     normal_gain_(std::make_shared<Parameter<double>>("normal_gain", gain)),
     circular_velocity_(std::make_shared<Parameter<double>>("circular_velocity", circular_velocity)) {}
 
 CartesianState Circular::compute_dynamics(const CartesianState& state) const {
+  if (this->get_limit_cycle().get_center_state().is_empty()) {
+    throw exceptions::EmptyAttractorException("The limit cycle of the dynamical system is empty.");
+  }
   // put the point in the reference of the center
   auto pose = CartesianPose(state);
   pose = this->get_limit_cycle().get_rotation().inverse() * this->get_center().inverse() * pose;
@@ -35,11 +50,11 @@ CartesianState Circular::compute_dynamics(const CartesianState& state) const {
   double a2ratio = (pose.get_position()[0] * pose.get_position()[0]) / (radiuses[0] * radiuses[0]);
   double b2ratio = (pose.get_position()[1] * pose.get_position()[1]) / (radiuses[1] * radiuses[1]);
   double dradius = -this->get_planar_gain() * radiuses[0] * radiuses[1] * (a2ratio + b2ratio - 1);
-  double tangeant_velocity_x = -radiuses[0] / radiuses[1] * pose.get_position()[1];
-  double tangeant_velocity_y = radiuses[1] / radiuses[0] * pose.get_position()[0];
+  double tangent_velocity_x = -radiuses[0] / radiuses[1] * pose.get_position()[1];
+  double tangent_velocity_y = radiuses[1] / radiuses[0] * pose.get_position()[0];
 
-  linear_velocity(0) = this->get_circular_velocity() * tangeant_velocity_x + dradius * tangeant_velocity_y;
-  linear_velocity(1) = this->get_circular_velocity() * tangeant_velocity_y - dradius * tangeant_velocity_x;
+  linear_velocity(0) = this->get_circular_velocity() * tangent_velocity_x + dradius * tangent_velocity_y;
+  linear_velocity(1) = this->get_circular_velocity() * tangent_velocity_y - dradius * tangent_velocity_x;
 
   velocity.set_linear_velocity(linear_velocity);
   velocity.set_angular_velocity(Eigen::Vector3d::Zero());
@@ -59,10 +74,15 @@ std::list<std::shared_ptr<ParameterInterface>> Circular::get_parameters() const 
 }
 
 void Circular::set_base_frame(const CartesianState& base_frame) {
+  if (base_frame.is_empty()) {
+    throw state_representation::exceptions::EmptyStateException(base_frame.get_name() + " state is empty");
+  }
   DynamicalSystem<CartesianState>::set_base_frame(base_frame);
   // update reference frame of center
   auto center_state = this->limit_cycle_->get_value().get_center_state();
-  center_state.set_reference_frame(base_frame.get_name());
-  this->limit_cycle_->get_value().set_center_state(center_state);
+  if (!center_state.is_empty()) {
+    center_state.set_reference_frame(base_frame.get_name());
+    this->limit_cycle_->get_value().set_center_state(center_state);
+  }
 }
 }// namespace dynamical_systems

--- a/source/dynamical_systems/src/Ring.cpp
+++ b/source/dynamical_systems/src/Ring.cpp
@@ -159,8 +159,8 @@ void Ring::set_base_frame(const state_representation::CartesianState& base_frame
   }
   DynamicalSystem<state_representation::CartesianState>::set_base_frame(base_frame);
   // update reference frame of center
-  auto center = this->get_center();
-  if (!center.is_empty()) {
+  if (!this->get_center().is_empty()) {
+    auto center = this->get_center();
     center.set_reference_frame(base_frame.get_name());
     this->set_center(center);
   }

--- a/source/dynamical_systems/test/tests/test_circular.cpp
+++ b/source/dynamical_systems/test/tests/test_circular.cpp
@@ -1,20 +1,23 @@
-#include "dynamical_systems/Circular.hpp"
 #include <gtest/gtest.h>
-#include <unistd.h>
+
+#include "dynamical_systems/Circular.hpp"
+#include "dynamical_systems/exceptions/EmptyBaseFrameException.hpp"
+#include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
 
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
 
+using namespace state_representation;
 using namespace std::literals::chrono_literals;
 
 class CircularDSTest : public testing::Test {
 protected:
   void SetUp() override {
-    current_pose = state_representation::CartesianPose("A", 10 * Eigen::Vector3d::Random());
-    center = state_representation::CartesianPose::Identity("B");
+    current_pose = CartesianPose("A", 10 * Eigen::Vector3d::Random());
+    center = CartesianPose::Identity("B");
   }
 
-  state_representation::CartesianPose current_pose;
-  state_representation::CartesianPose center;
+  CartesianPose current_pose;
+  CartesianPose center;
   double radius = 10;
   unsigned int nb_steps = 2000;
   std::chrono::milliseconds dt = 10ms;
@@ -26,12 +29,50 @@ TEST_F(CircularDSTest, TestPositionOnRadius) {
   circularDS.set_radius(radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
-    state_representation::CartesianTwist twist = circularDS.evaluate(current_pose);
+    CartesianTwist twist = circularDS.evaluate(current_pose);
     twist.clamp(10, 10, 0.001, 0.001);
     current_pose += dt * twist;
   }
 
-  EXPECT_NEAR((current_pose.get_position() - center.get_position()).norm(), radius, linear_tol);
+  EXPECT_NEAR(current_pose.dist(center, CartesianStateVariable::POSITION), radius, linear_tol);
+}
+
+TEST_F(CircularDSTest, EmptyConstructor) {
+  // construct empty cartesian state DS
+  CartesianPose center = CartesianPose::Identity("CAttractor", "A");
+  dynamical_systems::Circular ds;
+  // base frame and attractor should be empty
+  EXPECT_TRUE(ds.get_center().is_empty());
+  EXPECT_TRUE(ds.get_base_frame().is_empty());
+  ds.set_center(center);
+  EXPECT_FALSE(ds.get_center().is_empty());
+  EXPECT_FALSE(ds.get_base_frame().is_empty());
+  // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
+  EXPECT_EQ(ds.get_base_frame().get_name(), center.get_reference_frame());
+  EXPECT_EQ(ds.get_base_frame().get_reference_frame(), center.get_reference_frame());
+  EXPECT_EQ(ds.get_base_frame().get_transformation_matrix(), Eigen::Matrix4d::Identity());
+
+  ds = dynamical_systems::Circular();
+  CartesianState state1 = CartesianState::Identity("B", "A");
+  CartesianState state2("D", "C");
+  CartesianState state3("C", "A");
+  CartesianState state4("C", "B");
+  // if no base frame is set, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state1), dynamical_systems::exceptions::EmptyBaseFrameException);
+  ds.set_base_frame(state1);
+  // if cartesian state is incompatible, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state2),
+               state_representation::exceptions::IncompatibleReferenceFramesException);
+  // if cartesian state needs to be transformed to other frame first and is empty, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state3), state_representation::exceptions::EmptyStateException);
+  // if no attractor is set, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
+
+  ds.set_center(center);
+  EXPECT_TRUE(ds.is_compatible(state1));
+  EXPECT_FALSE(ds.is_compatible(state2));
+  EXPECT_TRUE(ds.is_compatible(state3));
+  EXPECT_TRUE(ds.is_compatible(state4));
 }
 
 TEST_F(CircularDSTest, TestPositionOnRadiusRandomCenter) {
@@ -46,13 +87,13 @@ TEST_F(CircularDSTest, TestPositionOnRadiusRandomCenter) {
     current_pose += dt * twist;
   }
 
-  EXPECT_NEAR((current_pose.get_position() - center.get_position()).norm(), radius, linear_tol);
+  EXPECT_NEAR(current_pose.dist(center, CartesianStateVariable::POSITION), radius, linear_tol);
 }
 
 TEST_F(CircularDSTest, SetCenterAndBase) {
-  auto BinA = state_representation::CartesianState::Identity("B", "A");
-  auto CinA = state_representation::CartesianState::Identity("C", "A");
-  auto CinB = state_representation::CartesianState::Identity("C", "B");
+  auto BinA = CartesianState::Identity("B", "A");
+  auto CinA = CartesianState::Identity("C", "A");
+  auto CinB = CartesianState::Identity("C", "B");
 
   dynamical_systems::Circular circularDS(BinA);
   EXPECT_STREQ(circularDS.get_center().get_name().c_str(), BinA.get_name().c_str());
@@ -74,6 +115,6 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
 
   // now the base frame is C, setting a center should only work if the reference frame of the center is also C
   EXPECT_THROW(circularDS.set_center(CinA), state_representation::exceptions::IncompatibleReferenceFramesException);
-  EXPECT_THROW(circularDS.set_center(CinB), state_representation::exceptions::IncompatibleReferenceFramesException);
+  EXPECT_NO_THROW(circularDS.set_center(CinB));
   EXPECT_NO_THROW(circularDS.set_center(CinB.inverse()));
 }

--- a/source/dynamical_systems/test/tests/test_circular.cpp
+++ b/source/dynamical_systems/test/tests/test_circular.cpp
@@ -61,8 +61,7 @@ TEST_F(CircularDSTest, EmptyConstructor) {
   EXPECT_THROW(ds.evaluate(state1), dynamical_systems::exceptions::EmptyBaseFrameException);
   ds.set_base_frame(state1);
   // if cartesian state is incompatible, an exception is thrown
-  EXPECT_THROW(ds.evaluate(state2),
-               state_representation::exceptions::IncompatibleReferenceFramesException);
+  EXPECT_THROW(ds.evaluate(state2), state_representation::exceptions::IncompatibleReferenceFramesException);
   // if cartesian state needs to be transformed to other frame first and is empty, an exception is thrown
   EXPECT_THROW(ds.evaluate(state3), state_representation::exceptions::EmptyStateException);
   // if no attractor is set, an exception is thrown

--- a/source/dynamical_systems/test/tests/test_linear.cpp
+++ b/source/dynamical_systems/test/tests/test_linear.cpp
@@ -55,8 +55,7 @@ TEST_F(LinearDSTest, EmptyConstructorCartesianState) {
   EXPECT_THROW(ds.evaluate(state1), dynamical_systems::exceptions::EmptyBaseFrameException);
   ds.set_base_frame(state1);
   // if cartesian state is incompatible, an exception is thrown
-  EXPECT_THROW(ds.evaluate(state2),
-               state_representation::exceptions::IncompatibleReferenceFramesException);
+  EXPECT_THROW(ds.evaluate(state2), state_representation::exceptions::IncompatibleReferenceFramesException);
   // if cartesian state needs to be transformed to other frame first and is empty, an exception is thrown
   EXPECT_THROW(ds.evaluate(state3), state_representation::exceptions::EmptyStateException);
   // if no attractor is set, an exception is thrown

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -1,20 +1,23 @@
 #include <gtest/gtest.h>
-
 #include "dynamical_systems/Ring.hpp"
+#include "dynamical_systems/exceptions/EmptyBaseFrameException.hpp"
+#include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
 
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
 
+using namespace state_representation;
 using namespace std::literals::chrono_literals;
 
 class RingDSTest : public ::testing::Test {
 protected:
   RingDSTest() {
-    center = state_representation::CartesianPose::Identity("A");
-    current_pose = state_representation::CartesianPose("B", radius * Eigen::Vector3d::Random());
+    center = CartesianPose::Identity("A");
+    current_pose = CartesianPose("B", radius * Eigen::Vector3d::Random());
   }
 
-  state_representation::CartesianPose current_pose;
-  state_representation::CartesianPose center;
+  CartesianPose current_pose;
+  CartesianPose center;
   std::vector<double> vlim = {10, 10, 0.001, 0.001};
   double radius = 10;
   double width = 1;
@@ -25,9 +28,47 @@ protected:
   double tol = 1e-3;
 };
 
+TEST_F(RingDSTest, EmptyConstructor) {
+  // construct empty cartesian state DS
+  CartesianPose center = CartesianPose::Identity("CAttractor", "A");
+  dynamical_systems::Ring ds;
+  // base frame and attractor should be empty
+  EXPECT_TRUE(ds.get_center().is_empty());
+  EXPECT_TRUE(ds.get_base_frame().is_empty());
+  ds.set_center(center);
+  EXPECT_FALSE(ds.get_center().is_empty());
+  EXPECT_FALSE(ds.get_base_frame().is_empty());
+  // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
+  EXPECT_EQ(ds.get_base_frame().get_name(), center.get_reference_frame());
+  EXPECT_EQ(ds.get_base_frame().get_reference_frame(), center.get_reference_frame());
+  EXPECT_EQ(ds.get_base_frame().get_transformation_matrix(), Eigen::Matrix4d::Identity());
+
+  ds = dynamical_systems::Ring();
+  CartesianState state1 = CartesianState::Identity("B", "A");
+  CartesianState state2("D", "C");
+  CartesianState state3("C", "A");
+  CartesianState state4("C", "B");
+  // if no base frame is set, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state1), dynamical_systems::exceptions::EmptyBaseFrameException);
+  ds.set_base_frame(state1);
+  // if cartesian state is incompatible, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state2),
+               state_representation::exceptions::IncompatibleReferenceFramesException);
+  // if cartesian state needs to be transformed to other frame first and is empty, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state3), state_representation::exceptions::EmptyStateException);
+  // if no attractor is set, an exception is thrown
+  EXPECT_THROW(ds.evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
+
+  ds.set_center(center);
+  EXPECT_TRUE(ds.is_compatible(state1));
+  EXPECT_FALSE(ds.is_compatible(state2));
+  EXPECT_TRUE(ds.is_compatible(state3));
+  EXPECT_TRUE(ds.is_compatible(state4));
+}
+
 TEST_F(RingDSTest, PointsOnRadius) {
   dynamical_systems::Ring ring(center, radius, width, speed);
-  state_representation::CartesianTwist twist;
+  CartesianTwist twist;
 
   // zero output at center
   current_pose = center;
@@ -61,7 +102,7 @@ TEST_F(RingDSTest, PointsOnRadius) {
 
 TEST_F(RingDSTest, PointsNearRadius) {
   dynamical_systems::Ring ring(center, radius, width, speed, field_strength);
-  state_representation::CartesianTwist twist;
+  CartesianTwist twist;
 
   current_pose.set_position(radius + width, 0, 0);
   twist = ring.evaluate(current_pose);
@@ -95,7 +136,7 @@ TEST_F(RingDSTest, BehaviourNearBoundaryAtHighSpeeds) {
   speed = 10;
   field_strength = 2;
   dynamical_systems::Ring ring(center, radius, width, speed, field_strength);
-  state_representation::CartesianTwist twist;
+  CartesianTwist twist;
 
   current_pose.set_position(0, radius + 1.001 * width, 0);
   twist = ring.evaluate(current_pose);
@@ -112,7 +153,7 @@ TEST_F(RingDSTest, ConvergenceOnRadius) {
   dynamical_systems::Ring ring(center, radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
-    state_representation::CartesianTwist twist = ring.evaluate(current_pose);
+    CartesianTwist twist = ring.evaluate(current_pose);
     twist.clamp(vlim[0], vlim[1], vlim[2], vlim[3]);
     current_pose += dt * twist;
   }
@@ -126,7 +167,7 @@ TEST_F(RingDSTest, ConvergenceOnRadiusRandomCenter) {
   dynamical_systems::Ring ring(center, radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
-    state_representation::CartesianTwist twist = ring.evaluate(current_pose);
+    CartesianTwist twist = ring.evaluate(current_pose);
     twist.clamp(vlim[0], vlim[1], vlim[2], vlim[3]);
     current_pose += dt * twist;
   }
@@ -140,7 +181,7 @@ TEST_F(RingDSTest, ZeroNormalGain) {
 
   double startingHeight = current_pose.get_position().z();
   for (unsigned int i = 0; i < nb_steps; ++i) {
-    state_representation::CartesianTwist twist = ring.evaluate(current_pose);
+    CartesianTwist twist = ring.evaluate(current_pose);
     twist.clamp(vlim[0], vlim[1], vlim[2], vlim[3]);
     current_pose += dt * twist;
   }
@@ -149,7 +190,7 @@ TEST_F(RingDSTest, ZeroNormalGain) {
 
 TEST_F(RingDSTest, OrientationAroundCircle) {
   dynamical_systems::Ring ring(center, radius, width, 0);
-  state_representation::CartesianTwist twist;
+  CartesianTwist twist;
 
   // at the position {radius, 0, 0}, the orientation attractor is by default null,
   // so there should be zero angular velocity if the current pose orientation is also null
@@ -179,7 +220,7 @@ TEST_F(RingDSTest, OrientationAroundCircle) {
 
 TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
   dynamical_systems::Ring ring(center, radius, width, 0);
-  state_representation::CartesianTwist twist;
+  CartesianTwist twist;
 
   // at the position {radius, 0, 0}, the orientation attractor is by default null (angle around circle is 0)
   current_pose.set_position(radius, 0, 0);
@@ -208,7 +249,7 @@ TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
 
 TEST_F(RingDSTest, OrientationRotationOffset) {
   dynamical_systems::Ring ring(center, radius, width, 0);
-  state_representation::CartesianTwist twist;
+  CartesianTwist twist;
 
   current_pose.set_position(radius, 0, 0);
 
@@ -233,7 +274,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // offset that gives a zero command (no rotation offset)
   center.set_orientation(Eigen::Quaterniond::UnitRandom());
   ring.set_center(center);
-  current_pose = state_representation::CartesianPose("B", Eigen::Vector3d(radius, 0, 0), "A");
+  current_pose = CartesianPose("B", Eigen::Vector3d(radius, 0, 0), "A");
   current_pose = center * current_pose;
   ring.set_rotation_offset(Eigen::Quaterniond::Identity());
   twist = ring.evaluate(current_pose);
@@ -243,7 +284,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // still be zero if the current position and orientation matches the rotation offset
   rotation = Eigen::Quaterniond::UnitRandom();
   ring.set_rotation_offset(rotation);
-  current_pose = state_representation::CartesianPose("B",
+  current_pose = CartesianPose("B",
                                                      Eigen::Vector3d(radius, 0, 0),
                                                      ring.get_rotation_offset(),
                                                      "A");
@@ -253,7 +294,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
 
   // any additional orientation in the ring frame on top of the rotation offset
   // should give the same local command, regardless of the center frame
-  current_pose = state_representation::CartesianPose("B",
+  current_pose = CartesianPose("B",
                                                      Eigen::Vector3d(radius, 0, 0),
                                                      Eigen::Quaterniond(1, 1, 0, 0).normalized()
                                                          * ring.get_rotation_offset(),
@@ -262,14 +303,14 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   twist = ring.evaluate(current_pose);
 
   // check the twist in the local frame
-  twist = state_representation::CartesianState(center).inverse() * twist;
+  twist = CartesianState(center).inverse() * twist;
   EXPECT_NEAR(twist.get_angular_velocity().x(), -M_PI_2 * ring.get_angular_gain(), tol);
   EXPECT_NEAR(twist.get_angular_velocity().y(), 0, tol);
   EXPECT_NEAR(twist.get_angular_velocity().z(), 0, tol);
 }
 
 TEST_F(RingDSTest, BaseFrameBehaviours) {
-  auto AinB = state_representation::CartesianState::Random("A", "B");
+  auto AinB = CartesianState::Random("A", "B");
   dynamical_systems::Ring ring(AinB);
 
   // setting the center through the constructor should also set the base frame (as Identity frame)
@@ -280,7 +321,7 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
   EXPECT_NEAR(ring.get_base_frame().get_pose().norm(), 1, tol);
 
   // setting the center should fail if it is incompatible with the base frame
-  auto CinD = state_representation::CartesianState::Random("C", "D");
+  auto CinD = CartesianState::Random("C", "D");
   EXPECT_THROW(ring.set_center(CinD), state_representation::exceptions::IncompatibleReferenceFramesException);
 
   // updating the base frame should "move" the center frame but not change its magnitude
@@ -294,13 +335,13 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
   EXPECT_NEAR(ring.get_center().get_pose().norm(), centerNorm, tol);
 
   // setting the center should succeed if it is expressed relative to the base frame
-  auto BinC = state_representation::CartesianState::Random("B", "C");
+  auto BinC = CartesianState::Random("B", "C");
   EXPECT_NO_THROW(ring.set_center(BinC));
   EXPECT_STREQ(ring.get_center().get_name().c_str(), "B");
   EXPECT_STREQ(ring.get_center().get_reference_frame().c_str(), "C");
 
   // setting the center should also succeed if it shares the same reference frame as the base frame
-  auto BinD = state_representation::CartesianState::Random("B", "D");
+  auto BinD = CartesianState::Random("B", "D");
   EXPECT_NO_THROW(ring.set_center(BinD));
   EXPECT_STREQ(ring.get_center().get_name().c_str(), "B");
   // the reference frame is still C, not D, because the center is internally represented relative to the base frame (C)
@@ -310,7 +351,7 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
 TEST_F(RingDSTest, SettersAndGetters) {
   dynamical_systems::Ring ring(center);
 
-  auto pose = state_representation::CartesianState::Random("C");
+  auto pose = CartesianState::Random("C");
   ring.set_center(pose);
   auto pose2 = ring.get_center();
   EXPECT_STREQ(pose.get_name().c_str(), pose2.get_name().c_str());

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -52,8 +52,7 @@ TEST_F(RingDSTest, EmptyConstructor) {
   EXPECT_THROW(ds.evaluate(state1), dynamical_systems::exceptions::EmptyBaseFrameException);
   ds.set_base_frame(state1);
   // if cartesian state is incompatible, an exception is thrown
-  EXPECT_THROW(ds.evaluate(state2),
-               state_representation::exceptions::IncompatibleReferenceFramesException);
+  EXPECT_THROW(ds.evaluate(state2), state_representation::exceptions::IncompatibleReferenceFramesException);
   // if cartesian state needs to be transformed to other frame first and is empty, an exception is thrown
   EXPECT_THROW(ds.evaluate(state3), state_representation::exceptions::EmptyStateException);
   // if no attractor is set, an exception is thrown
@@ -284,10 +283,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // still be zero if the current position and orientation matches the rotation offset
   rotation = Eigen::Quaterniond::UnitRandom();
   ring.set_rotation_offset(rotation);
-  current_pose = CartesianPose("B",
-                                                     Eigen::Vector3d(radius, 0, 0),
-                                                     ring.get_rotation_offset(),
-                                                     "A");
+  current_pose = CartesianPose("B", Eigen::Vector3d(radius, 0, 0), ring.get_rotation_offset(), "A");
   current_pose = center * current_pose;
   twist = ring.evaluate(current_pose);
   EXPECT_NEAR(twist.get_angular_velocity().norm(), 0, tol);
@@ -295,10 +291,9 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // any additional orientation in the ring frame on top of the rotation offset
   // should give the same local command, regardless of the center frame
   current_pose = CartesianPose("B",
-                                                     Eigen::Vector3d(radius, 0, 0),
-                                                     Eigen::Quaterniond(1, 1, 0, 0).normalized()
-                                                         * ring.get_rotation_offset(),
-                                                     "A");
+                               Eigen::Vector3d(radius, 0, 0),
+                               Eigen::Quaterniond(1, 1, 0, 0).normalized() * ring.get_rotation_offset(),
+                               "A");
   current_pose = center * current_pose;
   twist = ring.evaluate(current_pose);
 


### PR DESCRIPTION
I made the same changes that I already did for the Linear DS for the Circular and Ring DS's. They all have now the same logic in terms of compatibility, being initialized with and empty base frame etc. 

I also tried updating the README a bit but I might require some help there