### PR TITLE
Fix CartesianPose constructor and revise run script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release Versions:
 
 - Preserve emptiness upon copy construction (#152)
 - Use release configuration in install script (#155)
+- Fix CartesianPose constructor in Python bindings and revise run script (#157)
 
 ## 3.0.0
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest
+ARG BRANCH=develop
 
 # install python dependencies
 RUN apt-get update && apt-get install -y \
@@ -8,13 +9,13 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /source
-RUN git clone https://github.com/epfl-lasa/control_libraries
+RUN git clone --single-branch --branch $BRANCH https://github.com/epfl-lasa/control_libraries
 RUN bash control_libraries/source/install.sh --auto --no-controllers --no-dynamical-systems --no-robot-model
 RUN ldconfig
 
 COPY source control_libraries/python/source
 COPY pyproject.toml setup.py control_libraries/python/
-RUN pip3 install control_libraries/python
+RUN pip3 install numpy control_libraries/python
 
 RUN useradd --create-home --shell /bin/bash dev
 USER dev

--- a/python/README.md
+++ b/python/README.md
@@ -99,4 +99,9 @@ The docker image installs the core control libraries and subsequently installs t
 The [`run.sh`](./run.sh) script will build the docker image and launch an interactive container
 with the test files in the [`tests`](./tests) directory copied to the local path.
 
+The run script tries to the clone the current local git branch when installing the control libraries
+in the Dockerfile. If the local branch does not exist on the remote, or if you want to test the 
+python bindings against a difference control libraries source branch, you can supply a specific
+branch as the first argument to the run script. For example, `./run.sh develop` to use the `develop` branch.
+
 You can run these tests with `python <test_name.py>`, or just enter a python shell with `python`.

--- a/python/run.sh
+++ b/python/run.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
-docker build --tag control-libraries/python/test . || exit 1
+BRANCH=$(git branch --show-current)
+if [ -n "$1" ]; then
+  BRANCH=$1
+fi
+echo "Using control libraries branch ${BRANCH}"
+
+docker build --build-arg BRANCH="${BRANCH}" --tag control-libraries/python/test . || exit 1
 
 docker run -it --rm \
+  --volume "$(pwd)":/source/control_libraries/python \
   --name control-libraries-python-test \
   control-libraries/python/test

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -131,8 +131,14 @@ void cartesian_pose(py::module_& m) {
 
   c.def(py::init<const std::string&, const Eigen::Vector3d&, const std::string&>(), "Constructor of a CartesianPose from a position given as a vector of coordinates", "name"_a, "position"_a, "reference"_a=std::string("world"));
   c.def(py::init<const std::string&, double, double, double, const std::string&>(), "Constructor of a CartesianPose from a position given as three scalar coordinates", "name"_a, "x"_a, "y"_a, "z"_a, "reference"_a=std::string("world"));
-  c.def(py::init<const std::string&, const Eigen::Quaterniond&, const std::string&>(), "Constructor of a CartesianPose from a quaternion", "name"_a, "orientation"_a, "reference"_a=std::string("world"));
-  c.def(py::init<const std::string&, const Eigen::Vector3d&, const Eigen::Quaterniond&, const std::string&>(), "Constructor of a CartesianPose from a position given as a vector of coordinates and a quaternion", "name"_a, "position"_a, "orientation"_a, "reference"_a=std::string("world"));
+  c.def(py::init([](const std::string& name, const Eigen::Vector4d& orientation, const std::string& reference) {
+    Eigen::Quaterniond q(orientation(0), orientation(1), orientation(2), orientation(3));
+    return new CartesianPose(name, q, reference);
+  }), "Constructor of a CartesianPose from a quaternion", "name"_a, "orientation"_a, "reference"_a=std::string("world"));
+  c.def(py::init([](const std::string& name, const Eigen::Vector3d& position, const Eigen::Vector4d& orientation, const std::string& reference) {
+    Eigen::Quaterniond q(orientation(0), orientation(1), orientation(2), orientation(3));
+    return new CartesianPose(name, position, q, reference);
+  }), "Constructor of a CartesianPose from a position given as a vector of coordinates and a quaternion", "name"_a, "position"_a, "orientation"_a, "reference"_a=std::string("world"));
 
   c.def_static("Identity", &CartesianPose::Identity, "Constructor for the identity pose", "name"_a, "reference"_a=std::string("world"));
   c.def_static("Random", &CartesianPose::Random, "Constructor for a random pose", "name"_a, "reference"_a=std::string("world"));

--- a/python/tests/cartesian_pose_test.py
+++ b/python/tests/cartesian_pose_test.py
@@ -1,0 +1,24 @@
+import unittest
+from state_representation import CartesianPose
+import numpy as np
+
+class TestCartesianPose(unittest.TestCase):
+    def assert_np_array_equal(self, a, b):
+        self.assertListEqual(list(a), list(b))
+
+    def test_constructors(self):
+        CartesianPose("A", "B")
+        A = CartesianPose("A", np.array([1, 2, 3]), "B")
+        self.assert_np_array_equal(A.get_position(), [1, 2, 3])
+        self.assert_np_array_equal(A.get_orientation(), [1, 0, 0, 0])
+
+        A = CartesianPose("A", np.array([1, 2, 3, 4]), "B")
+        self.assert_np_array_equal(A.get_orientation(), [0, 0, 0])
+        self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
+
+        A = CartesianPose("A", np.array([1, 2, 3]), np.array([1, 2, 3, 4]), "B")
+        self.assert_np_array_equal(A.get_orientation(), [1, 2, 3])
+        self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/cartesian_pose_test.py
+++ b/python/tests/cartesian_pose_test.py
@@ -13,11 +13,11 @@ class TestCartesianPose(unittest.TestCase):
         self.assert_np_array_equal(A.get_orientation(), [1, 0, 0, 0])
 
         A = CartesianPose("A", np.array([1, 2, 3, 4]), "B")
-        self.assert_np_array_equal(A.get_orientation(), [0, 0, 0])
+        self.assert_np_array_equal(A.get_position(), [0, 0, 0])
         self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
 
         A = CartesianPose("A", np.array([1, 2, 3]), np.array([1, 2, 3, 4]), "B")
-        self.assert_np_array_equal(A.get_orientation(), [1, 2, 3])
+        self.assert_np_array_equal(A.get_position(), [1, 2, 3])
         self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add custom lambda bindings for CartesianPose constructors
involving the orientation. Because Eigen::Quaterniond is not
implicitly convertible by PyBind11, an Eigen::Vector4d is
used as a placeholder instead.

* Add a cartesian_pose_test file to test constructors

* Improve run script for testing bindings by adding a
branch argument to the clone stage of control libraries
in the Dockerfile. The branch is the current local one
by default, else is specified by the first input argument.

* Mount the source volume when running so that it's easier
to test changes and rebuild quickly