### PR TITLE
Add inverse for CartesianPose and define operators explicitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Release Versions:
 - Add CI workflow for Python bindings (#159)
 - Add emtpy constructors for Circular and Ring DS (#154)
 - Update ROS1 example because simulation is more developed (#160)
+- Define `inverse` and `*` operators for Cartesian types explicitly (#158)
+
+## Important TODOs
+
+- Revise `*=` and `*` operators in Cartesian types before the next release with 
+  breaking changes (some are marked *deprecated*, and some are left as is, but 
+  they should be deleted). See issue #156
+- Add the wrench computation in the `*` operator and `inverse` function (#134)
+- Refactor and improve unittests for state_representation (especially JointState
+  and CartesianState)
 
 ## 3.0.0
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -150,7 +150,7 @@ public:
    * @param pose CartesianPose to multiply with
    * @return the current CartesianPose multiplied by the CartesianPose given in argument
    */
-  [[deprecated]] CartesianPose& operator*=(const CartesianPose& pose);
+  CartesianPose& operator*=(const CartesianPose& pose);
 
   /**
    * @brief Overload the * operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -7,6 +7,7 @@
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/space/cartesian/CartesianTwist.hpp"
+#include "state_representation/space/cartesian/CartesianWrench.hpp"
 
 namespace state_representation {
 class CartesianTwist;
@@ -158,6 +159,27 @@ public:
   CartesianPose operator*(const CartesianPose& pose) const;
 
   /**
+   * @brief Overload the * operator
+   * @param state CartesianState to multiply with
+   * @return the current CartesianPose multiplied by the CartesianState given in argument
+   */
+  CartesianState operator*(const CartesianState& state) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param twist CartesianTwist to multiply with
+   * @return the current CartesianPose multiplied by the CartesianTwist given in argument
+   */
+  CartesianTwist operator*(const CartesianTwist& twist) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param wrench CartesianWrench to multiply with
+   * @return the current CartesianPose multiplied by the CartesianWrench given in argument
+   */
+  CartesianWrench operator*(const CartesianWrench& wrench) const;
+
+  /**
    * @brief Overload the *= operator with a scalar
    * @param lambda the scalar to multiply with
    * @return the CartesianPose multiplied by lambda
@@ -224,6 +246,12 @@ public:
    * @return the norms of the state variables as a vector
    */
   std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::POSE) const override;
+
+  /**
+   * @brief Compute the inverse of the current CartesianPose
+   * @return the inverse corresponding to b_S_f (assuming this is f_S_b)
+   */
+  CartesianPose inverse() const;
 
   /**
    * @brief Compute the normalized pose at the state variable given in argument (default is full pose)

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -11,6 +11,7 @@
 
 namespace state_representation {
 class CartesianTwist;
+class CartesianWrench;
 
 /**
  * @class CartesianPose
@@ -149,7 +150,7 @@ public:
    * @param pose CartesianPose to multiply with
    * @return the current CartesianPose multiplied by the CartesianPose given in argument
    */
-  CartesianPose& operator*=(const CartesianPose& pose);
+  [[deprecated]] CartesianPose& operator*=(const CartesianPose& pose);
 
   /**
    * @brief Overload the * operator
@@ -269,9 +270,16 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const CartesianPose& pose);
 
   /**
+   * @brief Overload the * operator with a CartesianState
+   * @param state the state to multiply with
+   * @return the CartesianPose provided multiplied by the state
+   */
+  friend CartesianPose operator*(const CartesianState& state, const CartesianPose& pose);
+
+  /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
-   * @return the CartesianPose provided multiply by lambda
+   * @return the CartesianPose provided multiplied by lambda
    */
   friend CartesianPose operator*(double lambda, const CartesianPose& pose);
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -379,7 +379,7 @@ public:
    * @param state the state to compose with corresponding to b_S_c
    * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
    */
-  CartesianState& operator*=(const CartesianState& state);
+  [[deprecated]] CartesianState& operator*=(const CartesianState& state);
 
   /**
    * @brief Overload the * operator with another state by deriving the equations of motions

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -379,7 +379,7 @@ public:
    * @param state the state to compose with corresponding to b_S_c
    * @return the CartesianState corresponding f_S_c = f_S_b * b_S_c (assuming this is f_S_b)
    */
-  [[deprecated]] CartesianState& operator*=(const CartesianState& state);
+  CartesianState& operator*=(const CartesianState& state);
 
   /**
    * @brief Overload the * operator with another state by deriving the equations of motions

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -47,9 +47,6 @@ public:
   void set_force(const Eigen::Vector3d& force) = delete;
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
-  CartesianState inverse() const = delete;
-  CartesianState& operator*=(const CartesianState& state) = delete;
-  CartesianState operator*(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor
@@ -122,6 +119,20 @@ public:
    * @return reference to the current twist with new values
    */
   CartesianTwist& operator=(const CartesianTwist& twist) = default;
+
+  /**
+   * @brief Overload the *= operator
+   * @param twist CartesianTwist to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
+   */
+  [[deprecated]] CartesianTwist& operator*=(const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the * operator with a twist
+   * @param twist CartesianTwist to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
+   */
+  [[deprecated]] CartesianTwist operator*(const CartesianTwist& twist) const;
 
   /**
    * @brief Overload the += operator
@@ -216,6 +227,12 @@ public:
    * @return the twist data vector
    */
   Eigen::VectorXd data() const;
+
+  /**
+   * @brief Compute the inverse of the current CartesianTwist
+   * @return the inverse corresponding to b_S_f (assuming this is f_S_b)
+   */
+  CartesianTwist inverse() const;
 
   /**
    * @brief Compute the norms of the state variable specified by the input type (default is full twist)

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -47,6 +47,9 @@ public:
   void set_force(const Eigen::Vector3d& force) = delete;
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
+  CartesianState inverse() const = delete;
+  CartesianState& operator*=(const CartesianState& twist) = delete;
+  CartesianState operator*(const CartesianState& twist) = delete;
 
   /**
    * @brief Empty constructor
@@ -119,20 +122,6 @@ public:
    * @return reference to the current twist with new values
    */
   CartesianTwist& operator=(const CartesianTwist& twist) = default;
-
-  /**
-   * @brief Overload the *= operator
-   * @param twist CartesianTwist to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
-   */
-  CartesianTwist& operator*=(const CartesianTwist& twist);
-
-  /**
-   * @brief Overload the * operator with a twist
-   * @param twist CartesianTwist to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
-   */
-  CartesianTwist operator*(const CartesianTwist& twist) const;
 
   /**
    * @brief Overload the += operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -7,9 +7,11 @@
 
 #include "state_representation/space/cartesian/CartesianPose.hpp"
 #include "state_representation/space/cartesian/CartesianState.hpp"
+#include "state_representation/space/cartesian/CartesianWrench.hpp"
 
 namespace state_representation {
 class CartesianPose;
+class CartesianWrench;
 
 /**
  * @class CartesianTwist
@@ -135,6 +137,27 @@ public:
   [[deprecated]] CartesianTwist operator*(const CartesianTwist& twist) const;
 
   /**
+   * @brief Overload the * operator
+   * @param state CartesianState to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianState given in argument
+   */
+  [[deprecated]] CartesianState operator*(const CartesianState& state) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param state CartesianPose to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianPose given in argument
+   */
+  [[deprecated]] CartesianPose operator*(const CartesianPose& pose) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param state CartesianWrench to multiply with
+   * @return the current CartesianTwist multiplied by the CartesianWrench given in argument
+   */
+  [[deprecated]] CartesianWrench operator*(const CartesianWrench& wrench) const;
+
+  /**
    * @brief Overload the += operator
    * @param twist CartesianTwist to add to
    * @return the current CartesianTwist added the CartesianTwist given in argument
@@ -255,6 +278,13 @@ public:
    * @return the appended ostream
    */
   friend std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist);
+
+  /**
+   * @brief Overload the * operator with a CartesianState
+   * @param state the state to multiply with
+   * @return the CartesianTwist provided multiplied by the state
+   */
+  friend CartesianTwist operator*(const CartesianState& state, const CartesianTwist& twist);
 
   /**
    * @brief Overload the * operator with a scalar

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -48,8 +48,8 @@ public:
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
   CartesianState inverse() const = delete;
-  CartesianState& operator*=(const CartesianState& twist) = delete;
-  CartesianState operator*(const CartesianState& twist) = delete;
+  CartesianState& operator*=(const CartesianState& state) = delete;
+  CartesianState operator*(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -127,7 +127,7 @@ public:
    * @param twist CartesianTwist to multiply with
    * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
    */
-  [[deprecated]] CartesianTwist& operator*=(const CartesianTwist& twist);
+  CartesianTwist& operator*=(const CartesianTwist& twist);
 
   /**
    * @brief Overload the * operator with a twist

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -44,6 +44,9 @@ public:
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
   void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  CartesianState inverse() const = delete;
+  CartesianState& operator*=(const CartesianState& twist) = delete;
+  CartesianState operator*(const CartesianState& twist) = delete;
 
   /**
    * @brief Empty constructor
@@ -111,20 +114,6 @@ public:
    * @return reference to the current wrench with new values
    */
   CartesianWrench& operator=(const CartesianWrench& wrench) = default;
-
-  /**
-   * @brief Overload the *= operator
-   * @param wrench CartesianWrench to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
-   */
-  CartesianWrench& operator*=(const CartesianWrench& wrench);
-
-  /**
-   * @brief Overload the * operator with a wrench
-   * @param wrench CartesianWrench to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
-   */
-  CartesianWrench operator*(const CartesianWrench& wrench) const;
 
   /**
    * @brief Overload the += operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -44,9 +44,6 @@ public:
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
   void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
-  CartesianState inverse() const = delete;
-  CartesianState& operator*=(const CartesianState& state) = delete;
-  CartesianState operator*(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor
@@ -114,6 +111,20 @@ public:
    * @return reference to the current wrench with new values
    */
   CartesianWrench& operator=(const CartesianWrench& wrench) = default;
+
+  /**
+   * @brief Overload the *= operator
+   * @param wrench CartesianWrench to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
+   */
+  [[deprecated]] CartesianWrench& operator*=(const CartesianWrench& wrench);
+
+  /**
+   * @brief Overload the * operator with a wrench
+   * @param wrench CartesianWrench to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
+   */
+  [[deprecated]] CartesianWrench operator*(const CartesianWrench& wrench) const;
 
   /**
    * @brief Overload the += operator
@@ -194,6 +205,12 @@ public:
    * @return the wrench data vector
    */
   Eigen::VectorXd data() const;
+
+  /**
+ * @brief Compute the inverse of the current CartesianWrench
+ * @return the inverse corresponding to b_S_f (assuming this is f_S_b)
+ */
+  CartesianWrench inverse() const;
 
   /**
    * @brief Compute the norms of the state variable specified by the input type (default is full wrench)

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -6,8 +6,12 @@
 #pragma once
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
+#include "state_representation/space/cartesian/CartesianPose.hpp"
+#include "state_representation/space/cartesian/CartesianTwist.hpp"
 
 namespace state_representation {
+class CartesianPose;
+class CartesianTwist;
 /**
  * @class CartesianWrench
  * @brief Class to define wrench in cartesian space as 3D force and torque vectors
@@ -127,6 +131,27 @@ public:
   [[deprecated]] CartesianWrench operator*(const CartesianWrench& wrench) const;
 
   /**
+   * @brief Overload the * operator
+   * @param state CartesianState to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianState given in argument
+   */
+  [[deprecated]] CartesianState operator*(const CartesianState& state) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param state CartesianPose to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianPose given in argument
+   */
+  [[deprecated]] CartesianPose operator*(const CartesianPose& pose) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param state CartesianWrench to multiply with
+   * @return the current CartesianWrench multiplied by the CartesianTwist given in argument
+   */
+  [[deprecated]] CartesianTwist operator*(const CartesianTwist& twist) const;
+
+  /**
    * @brief Overload the += operator
    * @param wrench CartesianWrench to add
    * @return the current CartesianWrench added the CartesianWrench given in argument
@@ -233,6 +258,13 @@ public:
    * @return the appended ostream
    */
   friend std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench);
+
+  /**
+   * @brief Overload the * operator with a CartesianState
+   * @param state the state to multiply with
+   * @return the CartesianWrench provided multiplied by the state
+   */
+  friend CartesianWrench operator*(const CartesianState& state, const CartesianWrench& wrench);
 
   /**
    * @brief Overload the * operator with a scalar

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -121,7 +121,7 @@ public:
    * @param wrench CartesianWrench to multiply with
    * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
    */
-  [[deprecated]] CartesianWrench& operator*=(const CartesianWrench& wrench);
+  CartesianWrench& operator*=(const CartesianWrench& wrench);
 
   /**
    * @brief Overload the * operator with a wrench
@@ -269,7 +269,7 @@ public:
   /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
-   * @return the CartesianWrench provided multiply by lambda
+   * @return the CartesianWrench provided multiplied by lambda
    */
   friend CartesianWrench operator*(double lambda, const CartesianWrench& wrench);
 };

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -45,8 +45,8 @@ public:
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
   void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
   CartesianState inverse() const = delete;
-  CartesianState& operator*=(const CartesianState& twist) = delete;
-  CartesianState operator*(const CartesianState& twist) = delete;
+  CartesianState& operator*=(const CartesianState& state) = delete;
+  CartesianState operator*(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -161,6 +161,10 @@ std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
   return os;
 }
 
+CartesianPose operator*(const CartesianState& state, const CartesianPose& pose) {
+  return CartesianPose(state.operator*(pose));
+}
+
 CartesianPose operator*(double lambda, const CartesianPose& pose) {
   return pose * lambda;
 }

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -66,6 +66,18 @@ CartesianPose CartesianPose::operator*(const CartesianPose& pose) const {
   return this->CartesianState::operator*(pose);
 }
 
+CartesianState CartesianPose::operator*(const CartesianState& state) const {
+  return this->CartesianState::operator*(state);
+}
+
+CartesianTwist CartesianPose::operator*(const CartesianTwist& twist) const {
+  return this->CartesianState::operator*(twist);
+}
+
+CartesianWrench CartesianPose::operator*(const CartesianWrench& wrench) const {
+  return this->CartesianState::operator*(wrench);
+}
+
 CartesianPose& CartesianPose::operator*=(double lambda) {
   this->CartesianState::operator*=(lambda);
   return (*this);
@@ -121,6 +133,25 @@ CartesianPose CartesianPose::copy() const {
 
 Eigen::VectorXd CartesianPose::data() const {
   return this->get_pose();
+}
+
+CartesianPose CartesianPose::inverse() const {
+  CartesianPose result(*this);
+  // inverse name and reference frame
+  std::string ref = result.get_reference_frame();
+  std::string name = result.get_name();
+  result.set_reference_frame(name);
+  result.set_name(ref);
+  // intermediate variables for f_S_b
+  Eigen::Vector3d f_P_b = this->get_position();
+  Eigen::Quaterniond f_R_b = this->get_orientation();
+  // computation for b_S_f
+  Eigen::Quaterniond b_R_f = f_R_b.conjugate();
+  Eigen::Vector3d b_P_f = b_R_f * (-f_P_b);
+  // collect the results
+  result.set_position(b_P_f);
+  result.set_orientation(b_R_f);
+  return result;
 }
 
 std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -136,8 +136,7 @@ Eigen::VectorXd CartesianPose::data() const {
 }
 
 CartesianPose CartesianPose::inverse() const {
-  CartesianPose result = this->CartesianState::inverse();
-  return result;
+  return this->CartesianState::inverse();
 }
 
 std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
@@ -162,7 +161,7 @@ std::ostream& operator<<(std::ostream& os, const CartesianPose& pose) {
 }
 
 CartesianPose operator*(const CartesianState& state, const CartesianPose& pose) {
-  return CartesianPose(state.operator*(pose));
+  return state.operator*(pose);
 }
 
 CartesianPose operator*(double lambda, const CartesianPose& pose) {

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -136,21 +136,7 @@ Eigen::VectorXd CartesianPose::data() const {
 }
 
 CartesianPose CartesianPose::inverse() const {
-  CartesianPose result(*this);
-  // inverse name and reference frame
-  std::string ref = result.get_reference_frame();
-  std::string name = result.get_name();
-  result.set_reference_frame(name);
-  result.set_name(ref);
-  // intermediate variables for f_S_b
-  Eigen::Vector3d f_P_b = this->get_position();
-  Eigen::Quaterniond f_R_b = this->get_orientation();
-  // computation for b_S_f
-  Eigen::Quaterniond b_R_f = f_R_b.conjugate();
-  Eigen::Vector3d b_P_f = b_R_f * (-f_P_b);
-  // collect the results
-  result.set_position(b_P_f);
-  result.set_orientation(b_R_f);
+  CartesianPose result = this->CartesianState::inverse();
   return result;
 }
 

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -201,8 +201,7 @@ CartesianState CartesianState::inverse() const {
   CartesianState result(*this);
   // inverse name and reference frame
   std::string ref = result.get_reference_frame();
-  std::string name = result.get_name();
-  result.set_reference_frame(name);
+  result.set_reference_frame(result.get_name());
   result.set_name(ref);
   // intermediate variables for f_S_b
   Eigen::Vector3d f_P_b = this->get_position();

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -84,12 +84,6 @@ Eigen::ArrayXd CartesianState::array() const {
 }
 
 CartesianState& CartesianState::operator*=(const CartesianState& state) {
-  *this = *this * state;
-  return (*this);
-}
-
-CartesianState CartesianState::operator*(const CartesianState& state) const {
-  CartesianState result(*this);
   // sanity check
   if (this->is_empty()) {
     throw EmptyStateException(this->get_name() + " state is empty");
@@ -100,7 +94,7 @@ CartesianState CartesianState::operator*(const CartesianState& state) const {
   if (this->get_name() != state.get_reference_frame()) {
     throw IncompatibleReferenceFramesException("Expected " + this->get_name() + ", got " + state.get_reference_frame());
   }
-  result.set_name(state.get_name());
+  this->set_name(state.get_name());
   // intermediate variables for f_S_b
   Eigen::Vector3d f_P_b = this->get_position();
   Eigen::Quaterniond f_R_b = this->get_orientation();
@@ -117,24 +111,26 @@ CartesianState CartesianState::operator*(const CartesianState& state) const {
   Eigen::Vector3d b_a_c = state.get_linear_acceleration();
   Eigen::Vector3d b_alpha_c = state.get_angular_acceleration();
   // pose
-  result.set_position(f_P_b + f_R_b * b_P_c);
-  result.set_orientation(f_R_b * b_R_c);
+  this->set_position(f_P_b + f_R_b * b_P_c);
+  this->set_orientation(f_R_b * b_R_c);
   // twist
-  result.set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
-  result.set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
+  this->set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
+  this->set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
   // acceleration
-  result.set_linear_acceleration(f_a_b + f_R_b * b_a_c
-                                    + f_alpha_b.cross(f_R_b * b_P_c)
-                                    + 2 * f_omega_b.cross(f_R_b * b_v_c)
-                                    + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
-  result.set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
+  this->set_linear_acceleration(f_a_b + f_R_b * b_a_c
+                                + f_alpha_b.cross(f_R_b * b_P_c)
+                                + 2 * f_omega_b.cross(f_R_b * b_v_c)
+                                + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
+  this->set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
   // wrench
   //TODO
-  return result;
+  return (*this);
+}
 
-//  CartesianState result(*this);
-//  result *= state;
-//  return result;
+CartesianState CartesianState::operator*(const CartesianState& state) const {
+  CartesianState result(*this);
+  result *= state;
+  return result;
 }
 
 CartesianState& CartesianState::operator+=(const CartesianState& state) {

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -84,6 +84,12 @@ Eigen::ArrayXd CartesianState::array() const {
 }
 
 CartesianState& CartesianState::operator*=(const CartesianState& state) {
+  *this = *this * state;
+  return (*this);
+}
+
+CartesianState CartesianState::operator*(const CartesianState& state) const {
+  CartesianState result(*this);
   // sanity check
   if (this->is_empty()) {
     throw EmptyStateException(this->get_name() + " state is empty");
@@ -94,7 +100,7 @@ CartesianState& CartesianState::operator*=(const CartesianState& state) {
   if (this->get_name() != state.get_reference_frame()) {
     throw IncompatibleReferenceFramesException("Expected " + this->get_name() + ", got " + state.get_reference_frame());
   }
-  this->set_name(state.get_name());
+  result.set_name(state.get_name());
   // intermediate variables for f_S_b
   Eigen::Vector3d f_P_b = this->get_position();
   Eigen::Quaterniond f_R_b = this->get_orientation();
@@ -111,26 +117,24 @@ CartesianState& CartesianState::operator*=(const CartesianState& state) {
   Eigen::Vector3d b_a_c = state.get_linear_acceleration();
   Eigen::Vector3d b_alpha_c = state.get_angular_acceleration();
   // pose
-  this->set_position(f_P_b + f_R_b * b_P_c);
-  this->set_orientation(f_R_b * b_R_c);
+  result.set_position(f_P_b + f_R_b * b_P_c);
+  result.set_orientation(f_R_b * b_R_c);
   // twist
-  this->set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
-  this->set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
+  result.set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
+  result.set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
   // acceleration
-  this->set_linear_acceleration(f_a_b + f_R_b * b_a_c
-                                + f_alpha_b.cross(f_R_b * b_P_c) 
-                                + 2 * f_omega_b.cross(f_R_b * b_v_c)
-                                + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
-  this->set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
+  result.set_linear_acceleration(f_a_b + f_R_b * b_a_c
+                                    + f_alpha_b.cross(f_R_b * b_P_c)
+                                    + 2 * f_omega_b.cross(f_R_b * b_v_c)
+                                    + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
+  result.set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
   // wrench
   //TODO
-  return (*this);
-}
-
-CartesianState CartesianState::operator*(const CartesianState& state) const {
-  CartesianState result(*this);
-  result *= state;
   return result;
+
+//  CartesianState result(*this);
+//  result *= state;
+//  return result;
 }
 
 CartesianState& CartesianState::operator+=(const CartesianState& state) {

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -51,15 +51,6 @@ CartesianTwist CartesianTwist::Random(const std::string& name, const std::string
   return CartesianTwist(name, random, reference);
 }
 
-CartesianTwist& CartesianTwist::operator*=(const CartesianTwist& twist) {
-  this->CartesianState::operator*=(twist);
-  return (*this);
-}
-
-CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
-  return this->CartesianState::operator*(twist);
-}
-
 CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
   this->CartesianState::operator+=(twist);
   return (*this);

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -51,6 +51,15 @@ CartesianTwist CartesianTwist::Random(const std::string& name, const std::string
   return CartesianTwist(name, random, reference);
 }
 
+CartesianTwist& CartesianTwist::operator*=(const CartesianTwist& twist) {
+  this->CartesianState::operator*=(twist);
+  return (*this);
+}
+
+CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
+  return this->CartesianState::operator*(twist);
+}
+
 CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
   this->CartesianState::operator+=(twist);
   return (*this);
@@ -138,6 +147,11 @@ CartesianTwist CartesianTwist::copy() const {
 
 Eigen::VectorXd CartesianTwist::data() const {
   return this->get_twist();
+}
+
+CartesianTwist CartesianTwist::inverse() const {
+  CartesianTwist result = this->CartesianState::inverse();
+  return result;
 }
 
 std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -164,8 +164,7 @@ Eigen::VectorXd CartesianTwist::data() const {
 }
 
 CartesianTwist CartesianTwist::inverse() const {
-  CartesianTwist result = this->CartesianState::inverse();
-  return result;
+  return this->CartesianState::inverse();
 }
 
 std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {
@@ -184,7 +183,7 @@ std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {
 }
 
 CartesianTwist operator*(const CartesianState& state, const CartesianTwist& twist) {
-  return CartesianTwist(state.operator*(twist));
+  return state.operator*(twist);
 }
 
 CartesianTwist operator*(double lambda, const CartesianTwist& twist) {

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -60,6 +60,20 @@ CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
   return this->CartesianState::operator*(twist);
 }
 
+CartesianState CartesianTwist::operator*(const CartesianState& state) const {
+  return this->CartesianState::operator*(state);
+}
+
+
+CartesianPose CartesianTwist::operator*(const CartesianPose& pose) const {
+  return this->CartesianState::operator*(pose);
+}
+
+
+CartesianWrench CartesianTwist::operator*(const CartesianWrench& wrench) const {
+  return this->CartesianState::operator*(wrench);
+}
+
 CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
   this->CartesianState::operator+=(twist);
   return (*this);
@@ -167,6 +181,10 @@ std::ostream& operator<<(std::ostream& os, const CartesianTwist& twist) {
     os << twist.get_angular_velocity()(2) << ")";
   }
   return os;
+}
+
+CartesianTwist operator*(const CartesianState& state, const CartesianTwist& twist) {
+  return CartesianTwist(state.operator*(twist));
 }
 
 CartesianTwist operator*(double lambda, const CartesianTwist& twist) {

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -45,6 +45,15 @@ CartesianWrench CartesianWrench::Random(const std::string& name, const std::stri
   return CartesianWrench(name, random, reference);
 }
 
+CartesianWrench& CartesianWrench::operator*=(const CartesianWrench& wrench) {
+  this->CartesianState::operator*=(wrench);
+  return (*this);
+}
+
+CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const {
+  return this->CartesianState::operator*(wrench);
+}
+
 CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
   this->CartesianState::operator+=(wrench);
   return (*this);
@@ -95,6 +104,10 @@ CartesianWrench CartesianWrench::copy() const {
 
 Eigen::VectorXd CartesianWrench::data() const {
   return this->get_wrench();
+}
+
+CartesianWrench CartesianWrench::inverse() const {
+  return this->CartesianState::inverse();
 }
 
 std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -54,6 +54,20 @@ CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const 
   return this->CartesianState::operator*(wrench);
 }
 
+CartesianState CartesianWrench::operator*(const CartesianState& state) const {
+  return this->CartesianState::operator*(state);
+}
+
+
+CartesianPose CartesianWrench::operator*(const CartesianPose& pose) const {
+  return this->CartesianState::operator*(pose);
+}
+
+
+CartesianTwist CartesianWrench::operator*(const CartesianTwist& twist) const {
+  return this->CartesianState::operator*(twist);
+}
+
 CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
   this->CartesianState::operator+=(wrench);
   return (*this);
@@ -124,6 +138,10 @@ std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {
     os << wrench.get_torque()(2) << ")";
   }
   return os;
+}
+
+CartesianWrench operator*(const CartesianState& state, const CartesianWrench& wrench) {
+  return CartesianWrench(state.operator*(wrench));
 }
 
 CartesianWrench operator*(double lambda, const CartesianWrench& wrench) {

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -45,15 +45,6 @@ CartesianWrench CartesianWrench::Random(const std::string& name, const std::stri
   return CartesianWrench(name, random, reference);
 }
 
-CartesianWrench& CartesianWrench::operator*=(const CartesianWrench& wrench) {
-  this->CartesianState::operator*=(wrench);
-  return (*this);
-}
-
-CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const {
-  return this->CartesianState::operator*(wrench);
-}
-
 CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
   this->CartesianState::operator+=(wrench);
   return (*this);

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -141,7 +141,7 @@ std::ostream& operator<<(std::ostream& os, const CartesianWrench& wrench) {
 }
 
 CartesianWrench operator*(const CartesianState& state, const CartesianWrench& wrench) {
-  return CartesianWrench(state.operator*(wrench));
+  return state.operator*(wrench);
 }
 
 CartesianWrench operator*(double lambda, const CartesianWrench& wrench) {


### PR DESCRIPTION
Sooo issue #156 made us think about the operators a bit more and we came to the conclusion that
1. The resulting type is defined by the right operand (e.g. pose * twist is a twist)
2. twist and wrench do not make sense as left operands

That said, I deleted the `*` operators for twist and wrench, and added explicit `*` operators for the pose.

I expect that this might change again during this PR, which is why I'm waiting with the CHANGELOG and pybindings.