### PR TITLE
Declare set_data in State.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release Versions:
 ## Upcoming changes (in development)
 
 - Add set_data function (#163)
+- Move set_data declaration to State and add it for Ellipsoid (#166)
 
 ## 3.1.0
 

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -1,12 +1,7 @@
-/**
- * @author Baptiste Busch
- * @date 2019/04/16
- */
-
 #pragma once
 
 #include "state_representation/MathTools.hpp"
-#include <assert.h>
+#include <cassert>
 #include <chrono>
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
@@ -147,6 +142,25 @@ public:
    * @brief Initialize the State to a zero value
    */
   virtual void initialize();
+
+  /**
+   * @brief Set the data of the state from a single Eigen vector
+   * @param the data vector
+   */
+  virtual void set_data(const Eigen::VectorXd& data);
+
+  /**
+   * @brief Set the data of the state from a single std vector
+   * @param the data vector
+   */
+  virtual void set_data(const std::vector<double>& data);
+
+  /**
+   * @brief Set the data of the state from an Eigen matrix
+   * @param the data vector
+   */
+  virtual void set_data(const Eigen::MatrixXd& data);
+
 
   /**
    * @brief Overload the ostream operator for printing

--- a/source/state_representation/include/state_representation/geometry/Ellipsoid.hpp
+++ b/source/state_representation/include/state_representation/geometry/Ellipsoid.hpp
@@ -71,7 +71,7 @@ public:
   double get_rotation_angle() const;
 
   /**
-   * @brief Seetter of the rotation angle
+   * @brief Setter of the rotation angle
    * @param rotation_angle the rotation angle
    */
   void set_rotation_angle(double rotation_angle);
@@ -111,14 +111,26 @@ public:
   const std::vector<double> to_std_vector() const;
 
   /**
-   * @brief Create an ellipsoid from an std vector representaiton of its parameter
+   * @brief Create an ellipsoid from an std vector representation of its parameter
    * @param an std vector with [center_position, rotation_angle, axis_lengths]
    */
-  void from_std_vector(const std::vector<double>& parameters);
+  [[deprecated]] void from_std_vector(const std::vector<double>& parameters);
+
+  /**
+   * @brief Set the ellipsoid data from an Eigen vector
+   * @param the data vector with [center_position, rotation_angle, axis_lengths]
+   */
+  virtual void set_data(const Eigen::VectorXd& data) override;
+
+  /**
+   * @brief Set the ellipsoid data from a std vector
+   * @param the data vector with [center_position, rotation_angle, axis_lengths]
+   */
+  virtual void set_data(const std::vector<double>& data) override;
 
   /**
     * @brief Overload the ostream operator for printing
-    * @param os the ostream to happend the string representing the Ellipsoid to
+    * @param os the ostream to append the string representing the Ellipsoid to
     * @param ellipsoid the Ellipsoid to print
     * @return the appended ostream
      */

--- a/source/state_representation/include/state_representation/robot/Jacobian.hpp
+++ b/source/state_representation/include/state_representation/robot/Jacobian.hpp
@@ -195,7 +195,7 @@ public:
   /**
    * @brief Setter of the data attribute
    */
-  void set_data(const Eigen::MatrixXd& data);
+  void set_data(const Eigen::MatrixXd& data) override;
 
   /**
    * @brief Check if the Jacobian matrix is compatible for operations with the state given as argument

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -308,14 +308,14 @@ public:
    * all the state variables in a single Eigen vector
    * @param the concatenated data vector
    */
-  virtual void set_data(const Eigen::VectorXd& data);
+  virtual void set_data(const Eigen::VectorXd& data) override;
 
   /**
    * @brief Set the data of the state from
    * all the state variables in a single std vector
    * @param the concatenated data vector
    */
-  virtual void set_data(const std::vector<double>& data);
+  virtual void set_data(const std::vector<double>& data) override;
 
   /**
    * @brief Returns the data vector as an Eigen Array

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -376,14 +376,14 @@ public:
    * all the state variables in a single Eigen vector
    * @param the concatenated data vector
    */
-  virtual void set_data(const Eigen::VectorXd& data);
+  virtual void set_data(const Eigen::VectorXd& data) override;
 
   /**
    * @brief Set the data of the state from
    * all the state variables in a single std vector
    * @param the concatenated data vector
    */
-  virtual void set_data(const std::vector<double>& data);
+  virtual void set_data(const std::vector<double>& data) override;
 
   /**
    * @brief Overload the *= operator with another state by deriving the equations of motions

--- a/source/state_representation/src/State.cpp
+++ b/source/state_representation/src/State.cpp
@@ -1,4 +1,5 @@
 #include "state_representation/State.hpp"
+#include "state_representation/exceptions/NotImplementedException.hpp"
 
 namespace state_representation {
 State::State() : type_(StateType::STATE), name_("none"), empty_(true) {}
@@ -10,6 +11,18 @@ State::State(const StateType& type, const std::string& name, const bool& empty)
 
 State::State(const State& state)
     : type_(state.type_), name_(state.name_), empty_(state.empty_), timestamp_(std::chrono::steady_clock::now()) {}
+
+void State::set_data(const Eigen::VectorXd& data) {
+  throw exceptions::NotImplementedException("set_data() is not implemented for the base State class");
+}
+
+void State::set_data(const std::vector<double>& data) {
+  throw exceptions::NotImplementedException("set_data() is not implemented for the base State class");
+}
+
+void State::set_data(const Eigen::MatrixXd& data) {
+  throw exceptions::NotImplementedException("set_data() is not implemented for the base State class");
+}
 
 std::ostream& operator<<(std::ostream& os, const State& state) {
   if (state.is_empty()) {

--- a/source/state_representation/src/geometry/Ellipsoid.cpp
+++ b/source/state_representation/src/geometry/Ellipsoid.cpp
@@ -1,5 +1,6 @@
 #include "state_representation/geometry/Ellipsoid.hpp"
 #include "state_representation/exceptions/NoSolutionToFitException.hpp"
+#include "state_representation/exceptions/IncompatibleSizeException.hpp"
 
 namespace state_representation {
 Ellipsoid::Ellipsoid(const std::string& name, const std::string& reference_frame) :
@@ -163,6 +164,20 @@ const Ellipsoid Ellipsoid::fit(const std::string& name,
     delta = coefficients[1] * coefficients[1] - 4 * coefficients[0] * coefficients[2];
   } while (delta > 0);
   return from_algebraic_equation(name, coefficients, reference_frame);
+}
+
+void Ellipsoid::set_data(const Eigen::VectorXd& data) {
+  if (data.size() != 6) {
+    throw exceptions::IncompatibleSizeException(
+        "Input is of incorrect size: expected 6, given " + std::to_string(data.size()));
+  }
+  this->set_center_position(data.head(3));
+  this->set_rotation_angle(data(3));
+  this->set_axis_lengths({data(4), data(5)});
+}
+
+void Ellipsoid::set_data(const std::vector<double>& data) {
+  this->set_data(Eigen::VectorXd::Map(data.data(), data.size()));
 }
 
 std::ostream& operator<<(std::ostream& os, const Ellipsoid& ellipsoid) {


### PR DESCRIPTION
As requested by #165 and proposed last week by @buschbapti, I moved the `set_data` function declarations to `State.hpp` and implemented it in `Ellipsoid` as well.

I think it could be nice if we would generalize the `data` and `to_std_vector` as well. For example. we could have the `data` function take an argument by reference (either the std or Eigen vector) and modify it. This would be a breaking change though and would be postponed to the next major release. Or you might have other propositions...