### PR TITLE
Fix clamping of state variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Release Versions:
 ## Upcoming changes (in development)
 
 - Protobuf message protocol and C++ binding library `clproto` for
-serializing and deserializing control library objects (#168)
+serializing and deserializing control library objects (#168, #175, #177, #179)
 - Add set_data function (#163)
 - Move set_data declaration to State and add it for Ellipsoid (#166)
 - Add automatic documentation generation and deployment to GitHub Pages (#170)
@@ -19,6 +19,7 @@ serializing and deserializing control library objects (#168)
   the generated bindings from the repository, while providing installation
   scripts (#174)
 - Add class JointAccelerations (#173)
+- Fix clamp_state_variable function for CartesianState and JointState (#176)
 
 ## 3.1.0
 

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -57,8 +57,9 @@ public:
    * @brief joint_names list of joint names
    * @brief positions the vector of positions
    */
-  explicit JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names,
-                          const Eigen::VectorXd& positions);
+  explicit JointPositions(
+      const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions
+  );
 
   /**
    * @brief Copy constructor

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -230,6 +230,40 @@ public:
   virtual void set_data(const std::vector<double>& data) override;
 
   /**
+   * @brief Clamp inplace the magnitude of the positions to the value in argument
+   * @param max_absolute_value the maximum value of position for all the joints
+   * @param noise_ratio if provided, this value will be used to apply a dead zone relative to the maximum absolute value
+   * under which the position will be set to 0
+   */
+  void clamp(double max_absolute_value, double noise_ratio = 0.);
+
+  /**
+   * @brief Return the position clamped to the value in argument
+   * @param max_absolute_value the maximum value of position for all the joints
+   * @param noise_ratio if provided, this value will be used to apply a dead zone relative to the maximum absolute value
+   * under which the position will be set to 0
+   * @return the clamped JointPositions
+   */
+  JointPositions clamped(double max_absolute_value, double noise_ratio = 0.) const;
+
+  /**
+   * @brief Clamp inplace the magnitude of the positions to the values in argument
+   * @param max_absolute_value_array the maximum value of position for each joint
+   * @param noise_ratio_array those values will be used to apply a dead zone relative to the maximum absolute value
+   * under which the position will be set to 0 for each individual joint
+   */
+  void clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array);
+
+  /**
+   * @brief Return the position clamped to the values in argument
+   * @param max_absolute_value_array the maximum value of position for each joint
+   * @param noise_ratio_array those values will be used to apply a dead zone relative to the maximum absolute value
+   * under which the position will be set to 0 for each individual joint
+   * @return the clamped JointPositions
+   */
+  JointPositions clamped(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) const;
+
+  /**
    * @brief Overload the ostream operator for printing
    * @param os the ostream to append the string representing the state
    * @param positions the state to print

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -286,9 +286,9 @@ public:
    * @param noise_ratio_array those values will be used to apply a dead zone under which
    * the state variable will be set to 0 for each individual joint
    */
-  void clamp_state_variable(const Eigen::VectorXd& max_absolute_value_array,
+  void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
                             const JointStateVariable& state_variable_type,
-                            const Eigen::VectorXd& noise_ratio_array);
+                            const Eigen::ArrayXd& noise_ratio_array);
 
   /**
    * @brief Return a copy of the JointState
@@ -373,7 +373,7 @@ public:
   JointState& operator*=(const Eigen::ArrayXd& lambda);
 
   /**
-   * @brief Overload the *= operator with an array of gains
+   * @brief Overload the * operator with an array of gains
    * @param lambda the gain array to multiply with
    * @return the JointState multiplied by lambda
    */

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -268,27 +268,27 @@ public:
   void set_zero();
 
   /**
-   * @brief Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)
+   * @brief Clamp inplace the magnitude of the a specific state variable (positions, velocities, accelerations or torques)
    * @param max_absolute_value the maximum absolute magnitude of the state variable
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
    * @param noise_ratio if provided, this value will be used to apply a dead zone under which
-   * the velocity will be set to 0
+   * the state variable will be set to 0
    */
   void clamp_state_variable(double max_absolute_value,
                             const JointStateVariable& state_variable_type,
                             double noise_ratio = 0);
 
   /**
-   * @brief Clamp inplace the magnitude of the a specific state variable (velocities, accelerations or forces)
-   * for each individual joints
+   * @brief Clamp inplace the magnitude of the a specific state variable (positions, velocities, accelerations or torques)
+   * for each individual joint
    * @param max_absolute_value_array the maximum absolute magnitude of the state variable for each joints individually
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
-   * @param noise_ratio_array if provided, this value will be used to apply a dead zone under which
-   * the velocity will be set to 0
+   * @param noise_ratio_array those values will be used to apply a dead zone under which
+   * the state variable will be set to 0 for each individual joint
    */
-  void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
+  void clamp_state_variable(const Eigen::VectorXd& max_absolute_value_array,
                             const JointStateVariable& state_variable_type,
-                            const Eigen::ArrayXd& noise_ratio_array);
+                            const Eigen::VectorXd& noise_ratio_array);
 
   /**
    * @brief Return a copy of the JointState

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -14,11 +14,7 @@ class JointState;
  * of the JointState
  */
 enum class JointStateVariable {
-  POSITIONS,
-  VELOCITIES,
-  ACCELERATIONS,
-  TORQUES,
-  ALL
+  POSITIONS, VELOCITIES, ACCELERATIONS, TORQUES, ALL
 };
 
 /**
@@ -29,9 +25,9 @@ enum class JointStateVariable {
  * the distance on (default ALL for full distance across all dimensions)
  * @return the distance between the two states
  */
-double dist(const JointState& s1,
-            const JointState& s2,
-            const JointStateVariable& state_variable_type = JointStateVariable::ALL);
+double dist(
+    const JointState& s1, const JointState& s2, const JointStateVariable& state_variable_type = JointStateVariable::ALL
+);
 
 /**
  * @class JointState
@@ -274,9 +270,9 @@ public:
    * @param noise_ratio if provided, this value will be used to apply a dead zone relative to the maximum absolute value
    * under which the state variable will be set to 0
    */
-  void clamp_state_variable(double max_absolute_value,
-                            const JointStateVariable& state_variable_type,
-                            double noise_ratio = 0);
+  void clamp_state_variable(
+      double max_absolute_value, const JointStateVariable& state_variable_type, double noise_ratio = 0
+  );
 
   /**
    * @brief Clamp inplace the magnitude of the a specific joint state variable
@@ -286,9 +282,10 @@ public:
    * @param noise_ratio_array those values will be used to apply a dead zone relative to the maximum absolute value
    * under which the state variable will be set to 0 for each individual joint
    */
-  void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
-                            const JointStateVariable& state_variable_type,
-                            const Eigen::ArrayXd& noise_ratio_array);
+  void clamp_state_variable(
+      const Eigen::ArrayXd& max_absolute_value_array, const JointStateVariable& state_variable_type,
+      const Eigen::ArrayXd& noise_ratio_array
+  );
 
   /**
    * @brief Return a copy of the JointState
@@ -614,8 +611,9 @@ inline Eigen::VectorXd JointState::get_state_variable(const JointStateVariable& 
   return Eigen::Vector3d::Zero();
 }
 
-inline void JointState::set_state_variable(const Eigen::VectorXd& new_value,
-                                           const JointStateVariable& state_variable_type) {
+inline void JointState::set_state_variable(
+    const Eigen::VectorXd& new_value, const JointStateVariable& state_variable_type
+) {
   switch (state_variable_type) {
     case JointStateVariable::POSITIONS:
       this->set_positions(new_value);

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -269,10 +269,10 @@ public:
 
   /**
    * @brief Clamp inplace the magnitude of the a specific state variable (positions, velocities, accelerations or torques)
-   * @param max_absolute_value the maximum absolute magnitude of the state variable
+   * @param max_absolute_value the maximum absolute value of the state variable
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
-   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
-   * the state variable will be set to 0
+   * @param noise_ratio if provided, this value will be used to apply a dead zone relative to the maximum absolute value
+   * under which the state variable will be set to 0
    */
   void clamp_state_variable(double max_absolute_value,
                             const JointStateVariable& state_variable_type,
@@ -281,10 +281,10 @@ public:
   /**
    * @brief Clamp inplace the magnitude of the a specific state variable (positions, velocities, accelerations or torques)
    * for each individual joint
-   * @param max_absolute_value_array the maximum absolute magnitude of the state variable for each joints individually
+   * @param max_absolute_value_array the maximum absolute value of the state variable for each joints individually
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
-   * @param noise_ratio_array those values will be used to apply a dead zone under which
-   * the state variable will be set to 0 for each individual joint
+   * @param noise_ratio_array those values will be used to apply a dead zone relative to the maximum absolute values
+   * under which the state variable will be set to 0 for each individual joint
    */
   void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
                             const JointStateVariable& state_variable_type,

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -268,7 +268,7 @@ public:
   void set_zero();
 
   /**
-   * @brief Clamp inplace the magnitude of the a specific state variable (positions, velocities, accelerations or torques)
+   * @brief Clamp inplace the magnitude of the a specific joint state variable
    * @param max_absolute_value the maximum absolute value of the state variable
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
    * @param noise_ratio if provided, this value will be used to apply a dead zone relative to the maximum absolute value
@@ -279,11 +279,11 @@ public:
                             double noise_ratio = 0);
 
   /**
-   * @brief Clamp inplace the magnitude of the a specific state variable (positions, velocities, accelerations or torques)
+   * @brief Clamp inplace the magnitude of the a specific joint state variable
    * for each individual joint
    * @param max_absolute_value_array the maximum absolute value of the state variable for each joints individually
    * @param state_variable_type name of the variable from the JointStateVariable structure to clamp
-   * @param noise_ratio_array those values will be used to apply a dead zone relative to the maximum absolute values
+   * @param noise_ratio_array those values will be used to apply a dead zone relative to the maximum absolute value
    * under which the state variable will be set to 0 for each individual joint
    */
   void clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -549,7 +549,8 @@ inline const Eigen::Quaterniond& CartesianState::get_orientation() const {
 inline Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
   return Eigen::Vector4d(
       this->get_orientation().w(), this->get_orientation().x(), this->get_orientation().y(),
-      this->get_orientation().z());
+      this->get_orientation().z()
+      );
 }
 
 inline Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -550,7 +550,7 @@ inline Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
   return Eigen::Vector4d(
       this->get_orientation().w(), this->get_orientation().x(), this->get_orientation().y(),
       this->get_orientation().z()
-      );
+  );
 }
 
 inline Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -35,9 +35,10 @@ enum class CartesianStateVariable {
  * the distance on. Default ALL for full distance across all dimensions
  * @return the distance between the two states
  */
-double dist(const CartesianState& s1,
-            const CartesianState& s2,
-            const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL);
+double dist(
+    const CartesianState& s1, const CartesianState& s2,
+    const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL
+);
 
 /**
  * @class CartesianState
@@ -80,9 +81,10 @@ private:
    * @param angular_state_variable the angular part of the state variable to fill
    * @param new_value the new value of the state variable
    */
-  void set_state_variable(Eigen::Vector3d& linear_state_variable,
-                          Eigen::Vector3d& angular_state_variable,
-                          const Eigen::Matrix<double, 6, 1>& new_value);
+  void set_state_variable(
+      Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable,
+      const Eigen::Matrix<double, 6, 1>& new_value
+  );
 
   /**
    * @brief Set new_value in the provided state_variable (twist, accelerations or wrench)
@@ -90,9 +92,10 @@ private:
    * @param angular_state_variable the angular part of the state variable to fill
    * @param new_value the new value of the state variable
    */
-  void set_state_variable(Eigen::Vector3d& linear_state_variable,
-                          Eigen::Vector3d& angular_state_variable,
-                          const std::vector<double>& new_value);
+  void set_state_variable(
+      Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable,
+      const std::vector<double>& new_value
+  );
 
 protected:
   /**
@@ -342,15 +345,13 @@ public:
   void set_zero();
 
   /**
-   * @brief Clamp inplace the magnitude of the a specific state variable (velocity, acceleration or force)
-   * @param max_value the maximum absolute magnitude of the state variable
+   * @brief Clamp inplace the norm of the a specific state variable
+   * @param max_norm the maximum norm of the state variable
    * @param state_variable_type name of the variable from the CartesianStateVariable structure to clamp
-   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
-   * the velocity will be set to 0
+   * @param noise_ratio if provided, this value will be used to apply a dead zone under which
+   * the norm of the state variable will be set to 0
    */
-  void clamp_state_variable(double max_value,
-                            const CartesianStateVariable& state_variable_type,
-                            double noise_ratio = 0);
+  void clamp_state_variable(double max_norm, const CartesianStateVariable& state_variable_type, double noise_ratio = 0);
 
   /**
    * @brief Return a copy of the CartesianState
@@ -454,15 +455,17 @@ public:
    * the distance on. Default ALL for full distance across all dimensions
    * @return dist the distance value as a double
    */
-  double dist(const CartesianState& state,
-              const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
+  double dist(
+      const CartesianState& state, const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL
+  ) const;
 
   /**
    * @brief Compute the norms of the state variable specified by the input type (default is full state)
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector
    */
-  virtual std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
+  virtual std::vector<double>
+  norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ALL) const;
 
   /**
    * @brief Normalize inplace the state at the state variable given in argument (default is full state)
@@ -500,9 +503,9 @@ public:
    * default all for full distance across all dimensions
    * @return the distance between the two states
    */
-  friend double dist(const CartesianState& s1,
-                     const CartesianState& s2,
-                     const CartesianStateVariable& state_variable_type);
+  friend double dist(
+      const CartesianState& s1, const CartesianState& s2, const CartesianStateVariable& state_variable_type
+  );
 
   /**
    * @brief Return the state as a std vector
@@ -544,10 +547,9 @@ inline const Eigen::Quaterniond& CartesianState::get_orientation() const {
 }
 
 inline Eigen::Vector4d CartesianState::get_orientation_coefficients() const {
-  return Eigen::Vector4d(this->get_orientation().w(),
-                         this->get_orientation().x(),
-                         this->get_orientation().y(),
-                         this->get_orientation().z());
+  return Eigen::Vector4d(
+      this->get_orientation().w(), this->get_orientation().x(), this->get_orientation().y(),
+      this->get_orientation().z());
 }
 
 inline Eigen::Matrix<double, 7, 1> CartesianState::get_pose() const {
@@ -671,16 +673,18 @@ inline void CartesianState::set_state_variable(Eigen::Vector3d& state_variable, 
   this->set_state_variable(state_variable, Eigen::Vector3d::Map(new_value.data(), new_value.size()));
 }
 
-inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable,
-                                               Eigen::Vector3d& angular_state_variable,
-                                               const Eigen::Matrix<double, 6, 1>& new_value) {
+inline void CartesianState::set_state_variable(
+    Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable,
+    const Eigen::Matrix<double, 6, 1>& new_value
+) {
   this->set_state_variable(linear_state_variable, new_value.head(3));
   this->set_state_variable(angular_state_variable, new_value.tail(3));
 }
 
-inline void CartesianState::set_state_variable(Eigen::Vector3d& linear_state_variable,
-                                               Eigen::Vector3d& angular_state_variable,
-                                               const std::vector<double>& new_value) {
+inline void CartesianState::set_state_variable(
+    Eigen::Vector3d& linear_state_variable, Eigen::Vector3d& angular_state_variable,
+    const std::vector<double>& new_value
+) {
   this->set_state_variable(linear_state_variable, std::vector<double>(new_value.begin(), new_value.begin() + 3));
   this->set_state_variable(angular_state_variable, std::vector<double>(new_value.begin() + 3, new_value.end()));
 }
@@ -767,8 +771,9 @@ inline void CartesianState::set_wrench(const Eigen::Matrix<double, 6, 1>& wrench
   this->set_state_variable(this->force_, this->torque_, wrench);
 }
 
-inline void CartesianState::set_state_variable(const Eigen::VectorXd& new_value,
-                                               const CartesianStateVariable& state_variable_type) {
+inline void CartesianState::set_state_variable(
+    const Eigen::VectorXd& new_value, const CartesianStateVariable& state_variable_type
+) {
   switch (state_variable_type) {
     case CartesianStateVariable::POSITION:
       this->set_position(new_value);

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -135,6 +135,27 @@ void JointPositions::set_data(const std::vector<double>& data) {
   this->set_positions(Eigen::VectorXd::Map(data.data(), data.size()));
 }
 
+void JointPositions::clamp(double max_absolute_value, double noise_ratio) {
+  this->clamp_state_variable(max_absolute_value, JointStateVariable::POSITIONS, noise_ratio);
+}
+
+JointPositions JointPositions::clamped(double max_absolute_value, double noise_ratio) const {
+  JointPositions result(*this);
+  result.clamp(max_absolute_value, noise_ratio);
+  return result;
+}
+
+void JointPositions::clamp(const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array) {
+  this->clamp_state_variable(max_absolute_value_array, JointStateVariable::POSITIONS, noise_ratio_array);
+}
+
+JointPositions JointPositions::clamped(const Eigen::ArrayXd& max_absolute_value_array,
+                                       const Eigen::ArrayXd& noise_ratio_array) const {
+  JointPositions result(*this);
+  result.clamp(max_absolute_value_array, noise_ratio_array);
+  return result;
+}
+
 std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {
   if (positions.is_empty()) {
     os << "Empty JointPositions";

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -16,8 +16,9 @@ JointPositions::JointPositions(const std::string& robot_name, const Eigen::Vecto
 JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names) :
     JointState(robot_name, joint_names) {}
 
-JointPositions::JointPositions(const std::string& robot_name, const std::vector<std::string>& joint_names,
-                               const Eigen::VectorXd& positions) : JointState(robot_name, joint_names) {
+JointPositions::JointPositions(
+    const std::string& robot_name, const std::vector<std::string>& joint_names, const Eigen::VectorXd& positions
+) : JointState(robot_name, joint_names) {
   this->set_positions(positions);
 }
 
@@ -28,9 +29,11 @@ JointPositions::JointPositions(const JointState& state) : JointState(state) {
   this->set_empty(state.is_empty());
 }
 
-JointPositions::JointPositions(const JointPositions& positions) : JointPositions(static_cast<const JointState&>(positions)) {}
+JointPositions::JointPositions(const JointPositions& positions) :
+    JointPositions(static_cast<const JointState&>(positions)) {}
 
-JointPositions::JointPositions(const JointVelocities& velocities) : JointPositions(std::chrono::seconds(1) * velocities) {}
+JointPositions::JointPositions(const JointVelocities& velocities) :
+    JointPositions(std::chrono::seconds(1) * velocities) {}
 
 JointPositions JointPositions::Zero(const std::string& robot_name, unsigned int nb_joints) {
   return JointState::Zero(robot_name, nb_joints);
@@ -149,8 +152,9 @@ void JointPositions::clamp(const Eigen::ArrayXd& max_absolute_value_array, const
   this->clamp_state_variable(max_absolute_value_array, JointStateVariable::POSITIONS, noise_ratio_array);
 }
 
-JointPositions JointPositions::clamped(const Eigen::ArrayXd& max_absolute_value_array,
-                                       const Eigen::ArrayXd& noise_ratio_array) const {
+JointPositions JointPositions::clamped(
+    const Eigen::ArrayXd& max_absolute_value_array, const Eigen::ArrayXd& noise_ratio_array
+) const {
   JointPositions result(*this);
   result.clamp(max_absolute_value_array, noise_ratio_array);
   return result;

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -223,7 +223,8 @@ void JointState::clamp_state_variable(
   int expected_size = state_variable.size();
   this->clamp_state_variable(
       max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
-      noise_ratio * Eigen::ArrayXd::Ones(expected_size));
+      noise_ratio * Eigen::ArrayXd::Ones(expected_size)
+      );
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -224,7 +224,7 @@ void JointState::clamp_state_variable(
   this->clamp_state_variable(
       max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
       noise_ratio * Eigen::ArrayXd::Ones(expected_size)
-      );
+  );
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -203,14 +203,12 @@ void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_a
             + std::to_string(noise_ratio_array.size()));
   }
   for (int i = 0; i < expected_size; ++i) {
-    if (state_variable(i) > 0) {
-      state_variable(i) = (state_variable(i) - noise_ratio_array(i) < 0) ? 0 : state_variable(i);
-      state_variable(i) =
-          (state_variable(i) > max_absolute_value_array(i)) ? max_absolute_value_array(i) : state_variable(i);
-    } else {
-      state_variable(i) = (state_variable(i) + noise_ratio_array(i) > 0) ? 0 : state_variable(i);
-      state_variable(i) =
-          (state_variable(i) < -max_absolute_value_array(i)) ? -max_absolute_value_array(i) : state_variable(i);
+    if (noise_ratio_array(i) != 0.0 && abs(state_variable(i)) < noise_ratio_array(i) * max_absolute_value_array(i)) {
+      // apply dead zone
+      state_variable(i) = 0.0;
+    } else if (abs(state_variable(i)) > max_absolute_value_array(i)) {
+      // clamp to max value
+      state_variable(i) *= max_absolute_value_array(i) / state_variable(i);
     }
   }
   this->set_state_variable(state_variable, state_variable_type);

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -186,9 +186,9 @@ Eigen::ArrayXd JointState::array() const {
   return this->data().array();
 }
 
-void JointState::clamp_state_variable(const Eigen::VectorXd& max_absolute_value_array,
+void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
                                       const JointStateVariable& state_variable_type,
-                                      const Eigen::VectorXd& noise_ratio_array) {
+                                      const Eigen::ArrayXd& noise_ratio_array) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
   if (max_absolute_value_array.size() != expected_size) {
@@ -220,8 +220,8 @@ void JointState::clamp_state_variable(double max_absolute_value, const JointStat
                                       double noise_ratio) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  this->clamp_state_variable(max_absolute_value * Eigen::VectorXd::Ones(expected_size), state_variable_type,
-                             noise_ratio * Eigen::VectorXd::Ones(expected_size));
+  this->clamp_state_variable(max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
+                             noise_ratio * Eigen::ArrayXd::Ones(expected_size));
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -208,7 +208,7 @@ void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_a
       state_variable(i) = 0.0;
     } else if (abs(state_variable(i)) > max_absolute_value_array(i)) {
       // clamp to max value
-      state_variable(i) *= max_absolute_value_array(i) / state_variable(i);
+      state_variable(i) *= max_absolute_value_array(i) / abs(state_variable(i));
     }
   }
   this->set_state_variable(state_variable, state_variable_type);

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -186,9 +186,9 @@ Eigen::ArrayXd JointState::array() const {
   return this->data().array();
 }
 
-void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
+void JointState::clamp_state_variable(const Eigen::VectorXd& max_absolute_value_array,
                                       const JointStateVariable& state_variable_type,
-                                      const Eigen::ArrayXd& noise_ratio_array) {
+                                      const Eigen::VectorXd& noise_ratio_array) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
   if (max_absolute_value_array.size() != expected_size) {
@@ -204,13 +204,11 @@ void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_a
   }
   for (int i = 0; i < expected_size; ++i) {
     if (state_variable(i) > 0) {
-      state_variable(i) -= noise_ratio_array(i);
-      state_variable(i) = (state_variable(i) < 0) ? 0 : state_variable(i);
+      state_variable(i) = (state_variable(i) - noise_ratio_array(i) < 0) ? 0 : state_variable(i);
       state_variable(i) =
           (state_variable(i) > max_absolute_value_array(i)) ? max_absolute_value_array(i) : state_variable(i);
     } else {
-      state_variable(i) += noise_ratio_array(i);
-      state_variable(i) = (state_variable(i) > 0) ? 0 : state_variable(i);
+      state_variable(i) = (state_variable(i) + noise_ratio_array(i) > 0) ? 0 : state_variable(i);
       state_variable(i) =
           (state_variable(i) < -max_absolute_value_array(i)) ? -max_absolute_value_array(i) : state_variable(i);
     }
@@ -222,8 +220,8 @@ void JointState::clamp_state_variable(double max_absolute_value, const JointStat
                                       double noise_ratio) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  this->clamp_state_variable(max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
-                             noise_ratio * Eigen::ArrayXd::Ones(expected_size));
+  this->clamp_state_variable(max_absolute_value * Eigen::VectorXd::Ones(expected_size), state_variable_type,
+                             noise_ratio * Eigen::VectorXd::Ones(expected_size));
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -56,23 +56,22 @@ JointState JointState::Zero(const std::string& robot_name, const std::vector<std
 JointState JointState::Random(const std::string& robot_name, unsigned int nb_joints) {
   JointState random = JointState(robot_name, nb_joints);
   // set all the state variables to random
-  random.set_state_variable(Eigen::VectorXd::Random(random.get_size() * 4),
-                            JointStateVariable::ALL);
+  random.set_state_variable(Eigen::VectorXd::Random(random.get_size() * 4), JointStateVariable::ALL);
   return random;
 }
 
 JointState JointState::Random(const std::string& robot_name, const std::vector<std::string>& joint_names) {
   JointState random = JointState(robot_name, joint_names);
   // set all the state variables to random
-  random.set_state_variable(Eigen::VectorXd::Random(random.get_size() * 4),
-                            JointStateVariable::ALL);
+  random.set_state_variable(Eigen::VectorXd::Random(random.get_size() * 4), JointStateVariable::ALL);
   return random;
 }
 
 JointState& JointState::operator+=(const JointState& state) {
   if (!this->is_compatible(state)) {
     throw IncompatibleStatesException(
-        "The two joint states are incompatible, check name, joint names and order or size");
+        "The two joint states are incompatible, check name, joint names and order or size"
+    );
   }
   this->set_all_state_variables(this->get_all_state_variables() + state.get_all_state_variables());
   return (*this);
@@ -87,7 +86,8 @@ JointState JointState::operator+(const JointState& state) const {
 JointState& JointState::operator-=(const JointState& state) {
   if (!this->is_compatible(state)) {
     throw IncompatibleStatesException(
-        "The two joint states are incompatible, check name, joint names and order or size");
+        "The two joint states are incompatible, check name, joint names and order or size"
+    );
   }
   this->set_all_state_variables(this->get_all_state_variables() - state.get_all_state_variables());
   return (*this);
@@ -120,9 +120,10 @@ void JointState::multiply_state_variable(const Eigen::MatrixXd& lambda, const Jo
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
   if (lambda.rows() != expected_size || lambda.cols() != expected_size) {
-    throw IncompatibleSizeException("Gain matrix is of incorrect size: expected " + std::to_string(expected_size) + "x"
-                                        + std::to_string(expected_size) + ", given " + std::to_string(lambda.rows())
-                                        + "x" + std::to_string(lambda.cols()));
+    throw IncompatibleSizeException(
+        "Gain matrix is of incorrect size: expected " + std::to_string(expected_size) + "x"
+            + std::to_string(expected_size) + ", given " + std::to_string(lambda.rows()) + "x"
+            + std::to_string(lambda.cols()));
   }
   this->set_state_variable(lambda * this->get_state_variable(state_variable_type), state_variable_type);
 }
@@ -186,9 +187,10 @@ Eigen::ArrayXd JointState::array() const {
   return this->data().array();
 }
 
-void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_array,
-                                      const JointStateVariable& state_variable_type,
-                                      const Eigen::ArrayXd& noise_ratio_array) {
+void JointState::clamp_state_variable(
+    const Eigen::ArrayXd& max_absolute_value_array, const JointStateVariable& state_variable_type,
+    const Eigen::ArrayXd& noise_ratio_array
+) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
   if (max_absolute_value_array.size() != expected_size) {
@@ -214,12 +216,14 @@ void JointState::clamp_state_variable(const Eigen::ArrayXd& max_absolute_value_a
   this->set_state_variable(state_variable, state_variable_type);
 }
 
-void JointState::clamp_state_variable(double max_absolute_value, const JointStateVariable& state_variable_type,
-                                      double noise_ratio) {
+void JointState::clamp_state_variable(
+    double max_absolute_value, const JointStateVariable& state_variable_type, double noise_ratio
+) {
   Eigen::VectorXd state_variable = this->get_state_variable(state_variable_type);
   int expected_size = state_variable.size();
-  this->clamp_state_variable(max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
-                             noise_ratio * Eigen::ArrayXd::Ones(expected_size));
+  this->clamp_state_variable(
+      max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
+      noise_ratio * Eigen::ArrayXd::Ones(expected_size));
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {
@@ -228,7 +232,8 @@ double JointState::dist(const JointState& state, const JointStateVariable& state
   if (state.is_empty()) { throw EmptyStateException(state.get_name() + " state is empty"); }
   if (!this->is_compatible(state)) {
     throw IncompatibleStatesException(
-        "The two joint states are incompatible, check name, joint names and order or size");
+        "The two joint states are incompatible, check name, joint names and order or size"
+    );
   }
   // calculation
   double result = 0;

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -111,9 +111,8 @@ CartesianState& CartesianState::operator*=(const CartesianState& state) {
   Eigen::Vector3d f_alpha_b = this->get_angular_acceleration();
   // intermediate variables for b_S_c
   Eigen::Vector3d b_P_c = state.get_position();
-  Eigen::Quaterniond b_R_c =
-      (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(
-          -state.get_orientation().coeffs());
+  Eigen::Quaterniond b_R_c = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation()
+                                                                                        : Eigen::Quaterniond(-state.get_orientation().coeffs());
   Eigen::Vector3d b_v_c = state.get_linear_velocity();
   Eigen::Vector3d b_omega_c = state.get_angular_velocity();
   Eigen::Vector3d b_a_c = state.get_linear_acceleration();
@@ -125,9 +124,10 @@ CartesianState& CartesianState::operator*=(const CartesianState& state) {
   this->set_linear_velocity(f_v_b + f_R_b * b_v_c + f_omega_b.cross(f_R_b * b_P_c));
   this->set_angular_velocity(f_omega_b + f_R_b * b_omega_c);
   // acceleration
-  this->set_linear_acceleration(
-      f_a_b + f_R_b * b_a_c + f_alpha_b.cross(f_R_b * b_P_c) + 2 * f_omega_b.cross(f_R_b * b_v_c)
-          + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
+  this->set_linear_acceleration(f_a_b + f_R_b * b_a_c
+                                + f_alpha_b.cross(f_R_b * b_P_c)
+                                + 2 * f_omega_b.cross(f_R_b * b_v_c)
+                                + f_omega_b.cross(f_omega_b.cross(f_R_b * b_P_c)));
   this->set_angular_acceleration(f_alpha_b + f_R_b * b_alpha_c + f_omega_b.cross(f_R_b * b_omega_c));
   // wrench
   //TODO
@@ -154,9 +154,8 @@ CartesianState& CartesianState::operator+=(const CartesianState& state) {
   // operation on pose
   this->set_position(this->get_position() + state.get_position());
   // specific operation on quaternion using Hamilton product
-  Eigen::Quaterniond orientation =
-      (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(
-          -state.get_orientation().coeffs());
+  Eigen::Quaterniond orientation = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation()
+                                                                                              : Eigen::Quaterniond(-state.get_orientation().coeffs());
   this->set_orientation(this->get_orientation() * orientation);
   // operation on twist
   this->set_twist(this->get_twist() + state.get_twist());
@@ -187,9 +186,8 @@ CartesianState& CartesianState::operator-=(const CartesianState& state) {
   // operation on pose
   this->set_position(this->get_position() - state.get_position());
   // specific operation on quaternion using Hamilton product
-  Eigen::Quaterniond orientation =
-      (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation() : Eigen::Quaterniond(
-          -state.get_orientation().coeffs());
+  Eigen::Quaterniond orientation = (this->get_orientation().dot(state.get_orientation()) > 0) ? state.get_orientation()
+                                                                                              : Eigen::Quaterniond(-state.get_orientation().coeffs());
   this->set_orientation(this->get_orientation() * orientation.conjugate());
   // operation on twist
   this->set_twist(this->get_twist() - state.get_twist());

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -241,7 +241,7 @@ void CartesianState::clamp_state_variable(
 ) {
   if (state_variable_type == CartesianStateVariable::ORIENTATION
       || state_variable_type == CartesianStateVariable::POSE) {
-    throw (NotImplementedException("clamp_state_variable is not implemented for this CartesianStateVariable"));
+    throw NotImplementedException("clamp_state_variable is not implemented for this CartesianStateVariable");
   }
   Eigen::VectorXd state_variable_value = this->get_state_variable(state_variable_type);
   if (noise_ratio != 0 && state_variable_value.norm() < noise_ratio * max_norm) {

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -465,11 +465,14 @@ TEST(CartesianStateTest, TestStateClamping) {
   CartesianState state = CartesianState::Identity("test");
   EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::ORIENTATION), exceptions::NotImplementedException);
   EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::POSE), exceptions::NotImplementedException);
-  state.set_linear_velocity(Eigen::Vector3d(-2.0, 1, 5));
-  state.clamp_state_variable(3.0, CartesianStateVariable::LINEAR_VELOCITY);
-  EXPECT_EQ(state.get_linear_velocity().norm(), 3.0);
-  state.clamp_state_variable(10.0, CartesianStateVariable::LINEAR_VELOCITY, 0.5);
-  EXPECT_EQ(state.get_linear_velocity().norm(), 0.0);
+  Eigen::Vector3d position(-2.0, 1, 5);
+  state.set_position(position);
+  state.clamp_state_variable(10.0, CartesianStateVariable::POSITION);
+  EXPECT_EQ(state.get_position(), position);
+  state.clamp_state_variable(3.0, CartesianStateVariable::POSITION);
+  EXPECT_EQ(state.get_position().norm(), 3.0);
+  state.clamp_state_variable(10.0, CartesianStateVariable::POSITION, 0.5);
+  EXPECT_EQ(state.get_position().norm(), 0.0);
 }
 
 TEST(CartesianStateTest, TestVelocityClamping) {

--- a/source/state_representation/test/tests/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/test_cartesian_state.cpp
@@ -4,6 +4,7 @@
 #include "state_representation/space/cartesian/CartesianPose.hpp"
 #include "state_representation/space/cartesian/CartesianTwist.hpp"
 #include "state_representation/space/cartesian/CartesianWrench.hpp"
+#include "state_representation/exceptions/NotImplementedException.hpp"
 
 using namespace state_representation;
 
@@ -458,6 +459,17 @@ TEST(CartesianStateTest, TestImplicitConversion) {
   vel.set_linear_velocity(Eigen::Vector3d(0.1, 0.1, 0.1));
   vel.set_angular_velocity(Eigen::Vector3d(0.1, 0.1, 0));
   tf1 += vel;
+}
+
+TEST(CartesianStateTest, TestStateClamping) {
+  CartesianState state = CartesianState::Identity("test");
+  EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::ORIENTATION), exceptions::NotImplementedException);
+  EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::POSE), exceptions::NotImplementedException);
+  state.set_linear_velocity(Eigen::Vector3d(-2.0, 1, 5));
+  state.clamp_state_variable(3.0, CartesianStateVariable::LINEAR_VELOCITY);
+  EXPECT_EQ(state.get_linear_velocity().norm(), 3.0);
+  state.clamp_state_variable(10.0, CartesianStateVariable::LINEAR_VELOCITY, 0.5);
+  EXPECT_EQ(state.get_linear_velocity().norm(), 0.0);
 }
 
 TEST(CartesianStateTest, TestVelocityClamping) {

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -410,6 +410,8 @@ TEST(JointStateTest, StateClamping) {
   js.clamp_state_variable(9, JointStateVariable::ALL, 0);
   EXPECT_EQ(js.data(), 9 * Eigen::VectorXd::Ones(4 * 4));
 
+  js.clamp_state_variable(10, JointStateVariable::POSITIONS, 0.5);
+  EXPECT_EQ(js.get_positions(), 9 * Eigen::VectorXd::Ones(4));
   js.set_positions(2 * Eigen::VectorXd::Ones(4));
   js.clamp_state_variable(9, JointStateVariable::POSITIONS, 0.5);
   EXPECT_EQ(js.get_positions(), Eigen::VectorXd::Zero(4));
@@ -418,6 +420,9 @@ TEST(JointStateTest, StateClamping) {
   accelerations << -2.0, 1.0, -4.0, 4.0;
   result << -2.0, 0.0, -3.0, 3.0;
   js.set_accelerations(accelerations);
-  js.clamp_state_variable(3 * Eigen::ArrayXd::Ones(4), JointStateVariable::ACCELERATIONS, 0.5 * Eigen::ArrayXd::Ones(4));
+  js.clamp_state_variable(10, JointStateVariable::ACCELERATIONS);
+  EXPECT_EQ(js.get_accelerations(), accelerations);
+  js.clamp_state_variable(
+      3 * Eigen::ArrayXd::Ones(4), JointStateVariable::ACCELERATIONS, 0.5 * Eigen::ArrayXd::Ones(4));
   EXPECT_EQ(js.get_accelerations(), result);
 }

--- a/source/state_representation/test/tests/test_joint_state.cpp
+++ b/source/state_representation/test/tests/test_joint_state.cpp
@@ -403,3 +403,21 @@ TEST(JointStateTest, MultiplyByArray) {
   JointState jscaled = gain * js;
   EXPECT_NEAR(jscaled.data().norm(), (gain * js.data()).norm(), 1e-4);
 }
+
+TEST(JointStateTest, StateClamping) {
+  JointState js = JointState("test_robot", 4);
+  js.set_data(10 * Eigen::VectorXd::Ones(4 * 4));
+  js.clamp_state_variable(9, JointStateVariable::ALL, 0);
+  EXPECT_EQ(js.data(), 9 * Eigen::VectorXd::Ones(4 * 4));
+
+  js.set_positions(2 * Eigen::VectorXd::Ones(4));
+  js.clamp_state_variable(9, JointStateVariable::POSITIONS, 0.5);
+  EXPECT_EQ(js.get_positions(), Eigen::VectorXd::Zero(4));
+
+  Eigen::VectorXd accelerations(4), result(4);
+  accelerations << -2.0, 1.0, -4.0, 4.0;
+  result << -2.0, 0.0, -3.0, 3.0;
+  js.set_accelerations(accelerations);
+  js.clamp_state_variable(3 * Eigen::ArrayXd::Ones(4), JointStateVariable::ACCELERATIONS, 0.5 * Eigen::ArrayXd::Ones(4));
+  EXPECT_EQ(js.get_accelerations(), result);
+}


### PR DESCRIPTION
I think there is a mistake in the clamping method of the `JointState`. The noise ratio is subtracted by default but I think this should only happen in the `if` condition to check if it should be set to zero. This would also match the function description,

For the `CartesianState`, there is the same problem but looking at that too, I wonder if the methods should be renamed because in `JointState`, it clamps each value seperately, whereas in `CartesianState`, it clamps the norm of a `CartesianStateType`. I find that quite different and the same name might be confusing but that's just my opinion. Additionally, I don't know if it makes sense to allow clamping the norm of a quaternion?