### PR TITLE
Fix install path of clproto

### DIFF
--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -18,6 +18,8 @@ else()
     find_package(GTest QUIET)
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 set(PROTOBUF_DIR ${PROJECT_SOURCE_DIR}/../protobuf)
 set(PROTOBUF_BINDINGDS_DIR ${PROTOBUF_DIR}/bindings/cpp)
 

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -30,7 +30,7 @@ file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGDS_DIR}/*.pb.cc" "
 add_library(${PROJECT_NAME}_bindings ${GENERATED_PROTO_BINDINGS})
 target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGDS_DIR})
 
-add_library(${PROJECT_NAME} src/clproto.cpp)
+add_library(${PROJECT_NAME} SHARED src/clproto.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)
 

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -30,6 +30,12 @@ file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGDS_DIR}/*.pb.cc" "
 add_library(${PROJECT_NAME}_bindings SHARED ${GENERATED_PROTO_BINDINGS})
 target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGDS_DIR})
 
+install(TARGETS ${PROJECT_NAME}_bindings
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
 add_library(${PROJECT_NAME} SHARED src/clproto.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -57,6 +57,7 @@ if (BUILD_TESTING)
     target_link_libraries(test_${PROJECT_NAME}
         protobuf
         ${PROJECT_NAME}
+        ${PROJECT_NAME}_bindings
         state_representation
         ${GTEST_LIBRARIES}
         pthread

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -27,7 +27,7 @@ add_custom_target(generate_proto_bindings COMMAND make cpp_bindings
 
 file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGDS_DIR}/*.pb.cc" "${PROTOBUF_BINDINGDS_DIR}/*.pb.h")
 
-add_library(${PROJECT_NAME}_bindings ${GENERATED_PROTO_BINDINGS})
+add_library(${PROJECT_NAME}_bindings SHARED ${GENERATED_PROTO_BINDINGS})
 target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGDS_DIR})
 
 add_library(${PROJECT_NAME} SHARED src/clproto.cpp)

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -18,8 +18,6 @@ else()
     find_package(GTest QUIET)
 endif()
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 set(PROTOBUF_DIR ${PROJECT_SOURCE_DIR}/../protobuf)
 set(PROTOBUF_BINDINGDS_DIR ${PROTOBUF_DIR}/bindings/cpp)
 
@@ -31,8 +29,9 @@ file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGDS_DIR}/*.pb.cc" "
 
 add_library(${PROJECT_NAME}_bindings STATIC ${GENERATED_PROTO_BINDINGS})
 target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGDS_DIR})
+set_property(TARGET ${PROJECT_NAME}_bindings PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-add_library(${PROJECT_NAME} STATIC src/clproto.cpp)
+add_library(${PROJECT_NAME} SHARED src/clproto.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/clproto.h)
 target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -27,28 +27,18 @@ add_custom_target(generate_proto_bindings COMMAND make cpp_bindings
 
 file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGDS_DIR}/*.pb.cc" "${PROTOBUF_BINDINGDS_DIR}/*.pb.h")
 
-add_library(${PROJECT_NAME}_bindings SHARED ${GENERATED_PROTO_BINDINGS})
+add_library(${PROJECT_NAME}_bindings STATIC ${GENERATED_PROTO_BINDINGS})
 target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGDS_DIR})
 
-install(TARGETS ${PROJECT_NAME}_bindings
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-)
-
-add_library(${PROJECT_NAME} SHARED src/clproto.cpp)
+add_library(${PROJECT_NAME} STATIC src/clproto.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/clproto.h)
 target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)
 
-
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
-    DESTINATION include
-)
-
 install(TARGETS ${PROJECT_NAME}
+    PUBLIC_HEADER DESTINATION include
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
 )
 
 if (BUILD_TESTING)
@@ -57,7 +47,6 @@ if (BUILD_TESTING)
     target_link_libraries(test_${PROJECT_NAME}
         protobuf
         ${PROJECT_NAME}
-        ${PROJECT_NAME}_bindings
         state_representation
         ${GTEST_LIBRARIES}
         pthread

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)
 
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include
+install(DIRECTORY include
     DESTINATION include
 )
 

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)
 
 
-install(DIRECTORY include
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
     DESTINATION include
 )
 

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -10,11 +10,6 @@ public:
   explicit DecodingException(const std::string& msg);
 };
 
-class NotImplementedException : public std::runtime_error {
-public:
-  explicit NotImplementedException(const std::string& msg);
-};
-
 enum MessageType {
   UNKNOWN_MESSAGE = 0,
   STATE_MESSAGE = 1,
@@ -81,21 +76,5 @@ template<typename T> T decode(const std::string& msg);
  * @return A success status boolean
  */
 template<typename T> bool decode(const std::string& msg, T& obj);
-
-
-template<typename T>
-std::string encode(const T& obj) {
-  throw NotImplementedException("The encoding of the requested type is not implemented");
-}
-
-template<typename T>
-T decode(const std::string& msg) {
-  throw NotImplementedException("The decoding of the requested type is not implemented");
-}
-
-template<typename T>
-bool decode(const std::string& msg, T& obj) {
-  throw NotImplementedException("The decoding of the requested type is not implemented");
-}
 
 }

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -29,7 +29,6 @@ using namespace state_representation;
 namespace clproto {
 
 DecodingException::DecodingException(const std::string& msg) : std::runtime_error(msg) {}
-NotImplementedException::NotImplementedException(const std::string& msg) : std::runtime_error(msg) {}
 
 bool is_valid(const std::string& msg) {
   return check_message_type(msg) != MessageType::UNKNOWN_MESSAGE;

--- a/protocol/clproto_cpp/test/tests/test_messages.cpp
+++ b/protocol/clproto_cpp/test/tests/test_messages.cpp
@@ -34,8 +34,12 @@ TEST(CartesianProtoTest, DecodeInvalidString) {
   EXPECT_THROW(clproto::decode<State>(dummy_msg), clproto::DecodingException);
 }
 
-TEST(CartesianProtoTest, EncodeInvalidObject) {
-  Eigen::Vector3d invalid_object;
+/* If an encode / decode template is invoked that is not implemented in clproto,
+ * there will be a linker error "undefined reference" at compile time.
+ * Of course, it's not really possible to test this at run-time.
+PSEUDO_TEST(CartesianProtoTest, EncodeInvalidObject) {
+  foo::Object invalid_object;
 
-  EXPECT_THROW(clproto::encode(invalid_object), clproto::NotImplementedException);
+  EXPECT_LINKER_ERROR(clproto::encode(invalid_object));
 }
+*/

--- a/protocol/install.sh
+++ b/protocol/install.sh
@@ -14,4 +14,4 @@ cd ${CLPROTO_DIR} && mkdir -p build && cd build || exit 1
 cmake -DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" .. 
 
-make -j && make install
+make -j && sudo make install

--- a/protocol/install.sh
+++ b/protocol/install.sh
@@ -14,4 +14,4 @@ cd ${CLPROTO_DIR} && mkdir -p build && cd build || exit 1
 cmake -DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" .. 
 
-make -j && sudo make install
+make -j && make install


### PR DESCRIPTION
There was a problem in the install path `clproto` with the `clproto.h` file installed in `usr/local/include/include`. Thanks @domire8 for finding the fix, i.e. the missing `/` culprit!