### PR TITLE
Revise docker COPY syntax

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -104,7 +104,7 @@ RUN pip3 install numpy setuptools pybind11
 # install google dependencies
 COPY --from=google-dependencies /usr/include/gtest /usr/include/gtest
 COPY --from=google-dependencies /usr/local/include/google /usr/local/include/google
-COPY --from=google-dependencies /usr/local/lib/libgtest* /usr/local/lib
-COPY --from=google-dependencies /usr/local/lib/libproto* /usr/local/lib
+COPY --from=google-dependencies /usr/local/lib/libgtest* /usr/local/lib/
+COPY --from=google-dependencies /usr/local/lib/libproto* /usr/local/lib/
 COPY --from=google-dependencies /usr/local/bin/protoc /usr/local/bin
 RUN ldconfig


### PR DESCRIPTION
* Add slash to destination to resolve the issue:
When using COPY with more than one source file,
the destination must be a directory and end with
a "/"

---

This is a tiny fix to ensure the CI build will succeed on release. Using docker buildkit, multiple files can be copied to a directory with destination syntax `/path/to/dir` or `/path/to/dir/` working equivalently ("many to many" operation). However, when copying multiple files, the CI without docker buildkit will recognise the `/path/to/dir` as a singular destination file, and will fail (it sees it as a "many to one" operation). The simple solution is to add the trailing `/` to explicitly mark the destination as a directory.

The other cases are either copying full directories (gtest, include/google) or a single file (protoc). Both of these are "one to one" operations so don't need the `/`.

See also 
https://github.com/epfl-lasa/modulo/pull/20