### PR TITLE
Add state_representation::Parameters to clproto

### DIFF
--- a/.github/actions/build-test-protocol/entrypoint.sh
+++ b/.github/actions/build-test-protocol/entrypoint.sh
@@ -8,8 +8,9 @@ echo ">>> Building proto bindings..."
 cd /github/workspace/protocol/protobuf && make all || exit 2
 
 echo ">>> Configuring clproto_cpp cmake..."
-cd /github/workspace/protocol/clproto_cpp && mkdir build && cd build && cmake -DBUILD_TESTING=ON .. || \
-  (echo ">>> [ERROR] Configuration stage failed!" && exit 3) || exit $?
+cd /github/workspace/protocol/clproto_cpp && mkdir build && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=ON .. \
+  || (echo ">>> [ERROR] Configuration stage failed!" && exit 3) || exit $?
 
 echo ">>> Building clproto_cpp..."
 make all || (echo ">>> [ERROR] Build stage failed!" && exit 4) || exit $?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Release Versions:
 ## Upcoming changes (in development)
 
 - Protobuf message protocol and C++ binding library `clproto` for
-serializing and deserializing control library objects (#168, #175, #177, #179)
+serializing and deserializing control library objects (#168, #175, #177, #179, #180)
 - Add set_data function (#163)
 - Move set_data declaration to State and add it for Ellipsoid (#166)
 - Add automatic documentation generation and deployment to GitHub Pages (#170)
@@ -20,6 +20,16 @@ serializing and deserializing control library objects (#168, #175, #177, #179)
   scripts (#174)
 - Add class JointAccelerations (#173)
 - Fix clamp_state_variable function for CartesianState and JointState (#176)
+
+### Pending TODOs for the next release
+
+- Revise `*=` and `*` operators in Cartesian types before the next release with
+  breaking changes (some are marked *deprecated*, and some are left as is, but
+  they should be deleted) (#156)
+- Add the wrench computation in the `*` operator and `inverse` function (#134)
+- Refactor and improve unittests for state_representation (especially JointState
+  and CartesianState)
+- Rename repository
 
 ## 3.1.0
 
@@ -44,16 +54,6 @@ of the libraries.
 
 **general**
 - Use release configuration in install script (#155)
-
-### Pending TODOs for the next release
-
-- Revise `*=` and `*` operators in Cartesian types before the next release with 
-  breaking changes (some are marked *deprecated*, and some are left as is, but 
-  they should be deleted) (#156)
-- Add the wrench computation in the `*` operator and `inverse` function (#134)
-- Refactor and improve unittests for state_representation (especially JointState
-  and CartesianState)
-- Rename repository
 
 ## 3.0.0
 

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -19,16 +19,16 @@ else()
 endif()
 
 set(PROTOBUF_DIR ${PROJECT_SOURCE_DIR}/../protobuf)
-set(PROTOBUF_BINDINGDS_DIR ${PROTOBUF_DIR}/bindings/cpp)
+set(PROTOBUF_BINDINGS_DIR ${PROTOBUF_DIR}/bindings/cpp)
 
 add_custom_target(generate_proto_bindings COMMAND make cpp_bindings
     WORKING_DIRECTORY ${PROTOBUF_DIR}
 )
 
-file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGDS_DIR}/*.pb.cc" "${PROTOBUF_BINDINGDS_DIR}/*.pb.h")
+file(GLOB_RECURSE GENERATED_PROTO_BINDINGS "${PROTOBUF_BINDINGS_DIR}/*.pb.cc" "${PROTOBUF_BINDINGS_DIR}/*.pb.h")
 
 add_library(${PROJECT_NAME}_bindings STATIC ${GENERATED_PROTO_BINDINGS})
-target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGDS_DIR})
+target_include_directories(${PROJECT_NAME}_bindings PUBLIC ${PROTOBUF_BINDINGS_DIR})
 set_property(TARGET ${PROJECT_NAME}_bindings PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(${PROJECT_NAME} SHARED

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -5,11 +5,24 @@
 
 namespace clproto {
 
+/**
+ * @class DecodingException
+ * @brief A DedocdingException is raised whenever a
+ * decoding operation fails due to invalid encoding.
+ */
 class DecodingException : public std::runtime_error {
 public:
   explicit DecodingException(const std::string& msg);
 };
 
+/**
+ * @brief The MessageType enumeration contains the possible
+ * message types in the clproto.
+ * @details The values and order of this enumeration
+ * are synchronized with the fields of the protobuf
+ * StateMessage type, allowing a one-to-one mapping
+ * to the StateMessage type case.
+ */
 enum MessageType {
   UNKNOWN_MESSAGE = 0,
   STATE_MESSAGE = 1,
@@ -27,6 +40,7 @@ enum MessageType {
   JOINT_TORQUES_MESSAGE = 13,
   SHAPE_MESSAGE = 14,
   ELLIPSOID_MESSAGE = 15,
+  PARAMETER_MESSAGE = 16
 };
 
 /**

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -45,6 +45,27 @@ enum MessageType {
 };
 
 /**
+ * @enum ParameterMessageType
+ * @brief The ParameterMessageType enumeration contains the
+ * possible value types contained in a parameter message.
+ * @details The values and order of this enumeration
+ * are synchronized with the fields of the protobuf
+ * ParameterValue type, allowing a one-to-one mapping
+ * to the ParameterValue type case.
+ */
+enum ParameterMessageType {
+  UNKNOWN_PARAMETER = 0,
+  DOUBLE = 1,
+  DOUBLE_ARRAY = 2,
+  BOOL = 3,
+  BOOL_ARRAY = 4,
+  STRING = 5,
+  STRING_ARRAY = 6,
+  MATRIX = 7,
+  VECTOR = 8
+};
+
+/**
  * @brief Check if a serialized binary string can be
  * decoded into a support control libraries message type.
  * @param msg The serialized binary string to check
@@ -59,6 +80,14 @@ bool is_valid(const std::string& msg);
  * @return The MessageType of the contained type or UNKNOWN
  */
 MessageType check_message_type(const std::string& msg);
+
+/**
+ * @brief Check which control libraries parameter type a
+ * serialized binary string can be decoded as, if at all.
+ * @param msg The serialized binary string to check
+ * @return The ParameterMessageType of the contained type or UNKNOWN
+ */
+ParameterMessageType check_parameter_message_type(const std::string& msg);
 
 /**
  * @brief Encode a control libraries object into

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -16,6 +16,7 @@ public:
 };
 
 /**
+ * @enum MessageType
  * @brief The MessageType enumeration contains the possible
  * message types in the clproto.
  * @details The values and order of this enumeration
@@ -66,7 +67,8 @@ MessageType check_message_type(const std::string& msg);
  * @param obj The control libraries object to encode
  * @return The serialized binary string encoding
  */
-template<typename T> std::string encode(const T& obj);
+template<typename T>
+std::string encode(const T& obj);
 
 /**
  * @brief Decode a serialized binary string from
@@ -77,7 +79,8 @@ template<typename T> std::string encode(const T& obj);
  * @param msg The serialized binary string to decode
  * @return A new instance of the control libraries object
  */
-template<typename T> T decode(const std::string& msg);
+template<typename T>
+T decode(const std::string& msg);
 
 /**
  * @brief Exception safe decoding of a serialized binary string
@@ -89,6 +92,7 @@ template<typename T> T decode(const std::string& msg);
  * @param obj A reference to a control libraries object
  * @return A success status boolean
  */
-template<typename T> bool decode(const std::string& msg, T& obj);
+template<typename T>
+bool decode(const std::string& msg, T& obj);
 
 }

--- a/protocol/clproto_cpp/include/clproto/decoders.h
+++ b/protocol/clproto_cpp/include/clproto/decoders.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <google/protobuf/repeated_field.h>
+#include <state_representation/parameters/Parameter.hpp>
+#include <state_representation/parameters/parameter.pb.h>
+
 #include "clproto.h"
 
 namespace clproto {
@@ -10,7 +14,7 @@ public:
 };
 
 /**
- * @brief Decoding helper method
+ * @brief Decoding helper method.
  * @tparam ObjT The control libraries output type
  * @tparam MsgT The protocol message input type
  * @param message The protocol message object
@@ -19,9 +23,47 @@ public:
 template<typename ObjT, typename MsgT>
 ObjT decoder(const MsgT& message);
 
+/**
+ * @brief Decoding helper method for a RepeatedField message
+ * into vector data.
+ * @tparam FieldT The datatype within the repeated field
+ * @param message A RepeatedField message
+ * @return The decoded vector of data
+ */
+template<typename FieldT>
+std::vector<FieldT> decoder(const google::protobuf::RepeatedField<FieldT>& message);
+
+/**
+ * @brief Decoding helper method for a RepeatedPtrField message
+ * into vector data.
+ * @tparam FieldT The datatype within the repeated field
+ * @param message A RepeatedPtrField message
+ * @return The decoded vector of data
+ */
+template<typename FieldT>
+std::vector<FieldT> decoder(const google::protobuf::RepeatedPtrField<FieldT>& message);
+
+/**
+ * @brief Decoding helper method for the Parameter type.
+ * @tparam ParamT The type contained within the Parameter object
+ * @param message The protocol Parameter message object
+ * @return The decoded control libraries Parameter object
+ */
+template<typename ParamT>
+state_representation::Parameter<ParamT> decoder(const state_representation::proto::Parameter& message);
+
 template<typename ObjT, typename MsgT>
 ObjT decoder(const MsgT&) {
   throw DecoderNotImplementedException("Templated decoder function not implemented!");
 }
 
+template<typename FieldT>
+std::vector<FieldT> decoder(const google::protobuf::RepeatedField<FieldT>& message) {
+  return {message.begin(), message.end()};
+}
+
+template<typename FieldT>
+std::vector<FieldT> decoder(const google::protobuf::RepeatedPtrField<FieldT>& message) {
+  return {message.begin(), message.end()};
+}
 }

--- a/protocol/clproto_cpp/include/clproto/decoders.h
+++ b/protocol/clproto_cpp/include/clproto/decoders.h
@@ -1,27 +1,13 @@
 #pragma once
 
 #include <google/protobuf/repeated_field.h>
-#include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/parameters/parameter.pb.h>
 
-#include "clproto.h"
+#include <state_representation/State.hpp>
+#include <state_representation/parameters/Parameter.hpp>
+
+#include "state_representation/state_message.pb.h"
 
 namespace clproto {
-
-class DecoderNotImplementedException : public DecodingException {
-public:
-  explicit DecoderNotImplementedException(const std::string& msg);
-};
-
-/**
- * @brief Decoding helper method.
- * @tparam ObjT The control libraries output type
- * @tparam MsgT The protocol message input type
- * @param message The protocol message object
- * @return The equivalent decoded control libraries object
- */
-template<typename ObjT, typename MsgT>
-ObjT decoder(const MsgT& message);
 
 /**
  * @brief Decoding helper method for a RepeatedField message
@@ -52,11 +38,17 @@ std::vector<FieldT> decoder(const google::protobuf::RepeatedPtrField<FieldT>& me
 template<typename ParamT>
 state_representation::Parameter<ParamT> decoder(const state_representation::proto::Parameter& message);
 
-template<typename ObjT, typename MsgT>
-ObjT decoder(const MsgT&) {
-  throw DecoderNotImplementedException("Templated decoder function not implemented!");
-}
+/*
+ * Declarations for decoding helpers
+ */
+std::vector<bool> decoder(const google::protobuf::RepeatedField<bool>& message);
+state_representation::StateType decoder(const state_representation::proto::StateType& message);
+Eigen::Vector3d decoder(const state_representation::proto::Vector3d& message);
+Eigen::Quaterniond decoder(const state_representation::proto::Quaterniond& message);
 
+/*
+ * Definitions for templated RepeatedField methods
+ */
 template<typename FieldT>
 std::vector<FieldT> decoder(const google::protobuf::RepeatedField<FieldT>& message) {
   return {message.begin(), message.end()};
@@ -66,4 +58,5 @@ template<typename FieldT>
 std::vector<FieldT> decoder(const google::protobuf::RepeatedPtrField<FieldT>& message) {
   return {message.begin(), message.end()};
 }
+
 }

--- a/protocol/clproto_cpp/include/clproto/encoders.h
+++ b/protocol/clproto_cpp/include/clproto/encoders.h
@@ -1,25 +1,17 @@
 #pragma once
 
 #include <google/protobuf/repeated_field.h>
+
+#include <state_representation/State.hpp>
+#include <state_representation/space/SpatialState.hpp>
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/robot/Jacobian.hpp>
+#include <state_representation/robot/JointState.hpp>
 #include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/parameters/parameter.pb.h>
+
+#include "state_representation/state_message.pb.h"
 
 namespace clproto {
-
-class EncoderNotImplementedException : public std::runtime_error {
-public:
-  explicit EncoderNotImplementedException(const std::string& msg);
-};
-
-/**
- * @brief Encoding helper method.
- * @tparam MsgT The protocol message output type
- * @tparam ObjT The control libraries input type
- * @param object The control libraries object
- * @return The equivalent encoded protocol message object
- */
-template<typename MsgT, typename ObjT>
-MsgT encoder(const ObjT& object);
 
 /**
  * @brief Encoding helper method for the Parameter type.
@@ -46,16 +38,25 @@ google::protobuf::RepeatedField<FieldT> encoder(const std::vector<FieldT>& data)
  * @param matrix An Eigen matrix of data
  * @return The encoded RepeatedField protocol message object
  */
-google::protobuf::RepeatedField<double> encoder(const Eigen::MatrixXd& matrix);
+google::protobuf::RepeatedField<double> matrix_encoder(const Eigen::MatrixXd& matrix);
 
-template<typename MsgT, typename ObjT>
-MsgT encoder(const ObjT&) {
-  throw EncoderNotImplementedException("Templated encoder function not implemented!");
-}
+/*
+ * Declarations for encoding helpers
+ */
+state_representation::proto::StateType encoder(const state_representation::StateType& type);
+state_representation::proto::State encoder(const state_representation::State& state);
+state_representation::proto::SpatialState encoder(const state_representation::SpatialState& spatial_state);
+state_representation::proto::Vector3d encoder(const Eigen::Vector3d& vector);
+state_representation::proto::Quaterniond encoder(const Eigen::Quaterniond& quaternion);
+state_representation::proto::CartesianState encoder(const state_representation::CartesianState& cartesian_state);
+state_representation::proto::Jacobian encoder(const state_representation::Jacobian& jacobian);
+state_representation::proto::JointState encoder(const state_representation::JointState& joint_state);
 
+/*
+ * Definitions for templated RepeatedField methods
+ */
 template<typename FieldT>
 google::protobuf::RepeatedField<FieldT> encoder(const std::vector<FieldT>& data) {
   return google::protobuf::RepeatedField<FieldT>({data.begin(), data.end()});
 }
-
 }

--- a/protocol/clproto_cpp/include/clproto/encoders.h
+++ b/protocol/clproto_cpp/include/clproto/encoders.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <google/protobuf/repeated_field.h>
+#include <state_representation/parameters/Parameter.hpp>
+#include <state_representation/parameters/parameter.pb.h>
 
 namespace clproto {
 
@@ -10,7 +12,7 @@ public:
 };
 
 /**
- * @brief Encoding helper method
+ * @brief Encoding helper method.
  * @tparam MsgT The protocol message output type
  * @tparam ObjT The control libraries input type
  * @param object The control libraries object
@@ -20,15 +22,31 @@ template<typename MsgT, typename ObjT>
 MsgT encoder(const ObjT& object);
 
 /**
- * @brief Encoding helper method for C-style arrays into
- * a RepeatedField message type
+ * @brief Encoding helper method for the Parameter type.
+ * @tparam ParamT The type contained within the Parameter object
+ * @param parameter The control libraries Parameter object
+ * @return The encoded protocol Parameter message object
+ */
+template<typename ParamT>
+state_representation::proto::Parameter encoder(const state_representation::Parameter<ParamT>& parameter);
+
+/**
+ * @brief Encoding helper method for vector data into
+ * a RepeatedField message type.
  * @tparam FieldT The datatype within the repeated field
- * @param data A C-style array of data
- * @param size The length of the data array
+ * @param data A vector of data
  * @return The encoded RepeatedField protocol message object
  */
 template<typename FieldT>
-google::protobuf::RepeatedField<FieldT> encoder(const FieldT* data, std::size_t size);
+google::protobuf::RepeatedField<FieldT> encoder(const std::vector<FieldT>& data);
+
+/**
+ * @brief Encoding helper method for Eigen data into
+ * a RepeatedField message type.
+ * @param matrix An Eigen matrix of data
+ * @return The encoded RepeatedField protocol message object
+ */
+google::protobuf::RepeatedField<double> encoder(const Eigen::MatrixXd& matrix);
 
 template<typename MsgT, typename ObjT>
 MsgT encoder(const ObjT&) {
@@ -36,8 +54,8 @@ MsgT encoder(const ObjT&) {
 }
 
 template<typename FieldT>
-google::protobuf::RepeatedField<FieldT> encoder(const FieldT*, std::size_t) {
-  throw EncoderNotImplementedException("Templated encoder function not implemented!");
+google::protobuf::RepeatedField<FieldT> encoder(const std::vector<FieldT>& data) {
+  return google::protobuf::RepeatedField<FieldT>({data.begin(), data.end()});
 }
 
 }

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -19,13 +19,6 @@
 #include <state_representation/geometry/Ellipsoid.hpp>
 
 #include "state_representation/state_message.pb.h"
-#include "state_representation/state.pb.h"
-#include "state_representation/space/spatial_state.pb.h"
-#include "state_representation/space/cartesian/cartesian_state.pb.h"
-#include "state_representation/space/joint/jacobian.pb.h"
-#include "state_representation/space/joint/joint_state.pb.h"
-#include "state_representation/geometry/shape.pb.h"
-#include "state_representation/geometry/ellipsoid.pb.h"
 
 using namespace state_representation;
 
@@ -60,6 +53,9 @@ MessageType check_message_type(const std::string& msg) {
   return MessageType::UNKNOWN_MESSAGE;
 }
 
+/* ----------------------
+ *         State
+ * ---------------------- */
 template<>
 std::string encode<State>(const State& obj);
 template<>
@@ -84,7 +80,8 @@ template<>
 bool decode(const std::string& msg, State& obj) {
   try {
     proto::StateMessage message;
-    if (!(message.ParseFromString(msg) && message.message_type_case() == proto::StateMessage::MessageTypeCase::kState)) {
+    if (!(message.ParseFromString(msg)
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kState)) {
       if (!message.mutable_state()->ParseFromString(msg)) {
         return false;
       }
@@ -102,6 +99,9 @@ bool decode(const std::string& msg, State& obj) {
   }
 }
 
+/* ----------------------
+ *      SpatialState
+ * ---------------------- */
 template<>
 std::string encode<SpatialState>(const SpatialState& obj);
 template<>
@@ -127,17 +127,16 @@ bool decode(const std::string& msg, SpatialState& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kSpatialState)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kSpatialState)) {
       if (!message.mutable_spatial_state()->ParseFromString(msg)) {
         return false;
       }
     }
 
     auto spatial_state = message.spatial_state();
-    obj = SpatialState(decoder<StateType>(spatial_state.state().type()),
-                       spatial_state.state().name(),
-                       spatial_state.reference_frame(),
-                       spatial_state.state().empty());
+    obj = SpatialState(
+        decoder<StateType>(spatial_state.state().type()), spatial_state.state().name(), spatial_state.reference_frame(),
+        spatial_state.state().empty());
 
     return true;
   } catch (...) {
@@ -145,6 +144,9 @@ bool decode(const std::string& msg, SpatialState& obj) {
   }
 }
 
+/* ----------------------
+ *     CartesianState
+ * ---------------------- */
 template<>
 std::string encode<CartesianState>(const CartesianState& obj);
 template<>
@@ -194,6 +196,9 @@ bool decode(const std::string& msg, CartesianState& obj) {
   }
 }
 
+/* ----------------------
+ *     CartesianPose
+ * ---------------------- */
 template<>
 std::string encode<CartesianPose>(const CartesianPose& obj);
 template<>
@@ -203,7 +208,7 @@ bool decode(const std::string& msg, CartesianPose& obj);
 template<>
 std::string encode<CartesianPose>(const CartesianPose& obj) {
   proto::StateMessage message;
-  proto::CartesianState cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_pose()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_pose()->mutable_position() = cartesian_state.position();
   *message.mutable_cartesian_pose()->mutable_orientation() = cartesian_state.orientation();
@@ -222,7 +227,7 @@ bool decode(const std::string& msg, CartesianPose& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kCartesianPose)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kCartesianPose)) {
       if (!message.mutable_cartesian_pose()->ParseFromString(msg)) {
         return false;
       }
@@ -239,6 +244,9 @@ bool decode(const std::string& msg, CartesianPose& obj) {
   }
 }
 
+/* ----------------------
+ *     CartesianTwist
+ * ---------------------- */
 template<>
 std::string encode<CartesianTwist>(const CartesianTwist& obj);
 template<>
@@ -248,7 +256,7 @@ bool decode(const std::string& msg, CartesianTwist& obj);
 template<>
 std::string encode<CartesianTwist>(const CartesianTwist& obj) {
   proto::StateMessage message;
-  proto::CartesianState cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_twist()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_twist()->mutable_linear_velocity() = cartesian_state.linear_velocity();
   *message.mutable_cartesian_twist()->mutable_angular_velocity() = cartesian_state.angular_velocity();
@@ -267,7 +275,7 @@ bool decode(const std::string& msg, CartesianTwist& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kCartesianTwist)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kCartesianTwist)) {
       if (!message.mutable_cartesian_twist()->ParseFromString(msg)) {
         return false;
       }
@@ -284,6 +292,9 @@ bool decode(const std::string& msg, CartesianTwist& obj) {
   }
 }
 
+/* ----------------------
+ *    CartesianWrench
+ * ---------------------- */
 template<>
 std::string encode<CartesianWrench>(const CartesianWrench& obj);
 template<>
@@ -293,7 +304,7 @@ bool decode(const std::string& msg, CartesianWrench& obj);
 template<>
 std::string encode<CartesianWrench>(const CartesianWrench& obj) {
   proto::StateMessage message;
-  proto::CartesianState cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_wrench()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_wrench()->mutable_force() = cartesian_state.force();
   *message.mutable_cartesian_wrench()->mutable_torque() = cartesian_state.torque();
@@ -312,7 +323,7 @@ bool decode(const std::string& msg, CartesianWrench& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kCartesianWrench)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kCartesianWrench)) {
       if (!message.mutable_cartesian_wrench()->ParseFromString(msg)) {
         return false;
       }
@@ -329,6 +340,9 @@ bool decode(const std::string& msg, CartesianWrench& obj) {
   }
 }
 
+/* ----------------------
+ *        Jacobian
+ * ---------------------- */
 template<>
 std::string encode<Jacobian>(const Jacobian& obj);
 template<>
@@ -354,7 +368,7 @@ bool decode(const std::string& msg, Jacobian& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJacobian)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJacobian)) {
       if (!message.mutable_jacobian()->ParseFromString(msg)) {
         return false;
       }
@@ -363,17 +377,18 @@ bool decode(const std::string& msg, Jacobian& obj) {
     auto jacobian = message.jacobian();
     auto raw_data = const_cast<double*>(jacobian.data().data());
     auto data = Eigen::Map<Eigen::MatrixXd>(raw_data, jacobian.rows(), jacobian.cols());
-    obj = Jacobian(jacobian.state().name(),
-                   {jacobian.joint_names().begin(), jacobian.joint_names().end()},
-                   jacobian.frame(),
-                   data,
-                   jacobian.reference_frame());
+    obj = Jacobian(
+        jacobian.state().name(), {jacobian.joint_names().begin(), jacobian.joint_names().end()}, jacobian.frame(), data,
+        jacobian.reference_frame());
     return true;
   } catch (...) {
     return false;
   }
 }
 
+/* ----------------------
+ *       JointState
+ * ---------------------- */
 template<>
 std::string encode<JointState>(const JointState& obj);
 template<>
@@ -399,7 +414,7 @@ bool decode(const std::string& msg, JointState& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointState)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointState)) {
       if (!message.mutable_joint_state()->ParseFromString(msg)) {
         return false;
       }
@@ -418,6 +433,9 @@ bool decode(const std::string& msg, JointState& obj) {
   }
 }
 
+/* ----------------------
+ *     JointPositions
+ * ---------------------- */
 template<>
 std::string encode<JointPositions>(const JointPositions& obj);
 template<>
@@ -427,7 +445,7 @@ bool decode(const std::string& msg, JointPositions& obj);
 template<>
 std::string encode<JointPositions>(const JointPositions& obj) {
   proto::StateMessage message;
-  proto::JointState joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
   *message.mutable_joint_positions()->mutable_state() = joint_state.state();
   *message.mutable_joint_positions()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_positions()->mutable_positions() = joint_state.positions();
@@ -446,7 +464,7 @@ bool decode(const std::string& msg, JointPositions& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointPositions)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointPositions)) {
       if (!message.mutable_joint_positions()->ParseFromString(msg)) {
         return false;
       }
@@ -462,6 +480,9 @@ bool decode(const std::string& msg, JointPositions& obj) {
   }
 }
 
+/* ----------------------
+ *    JointVelocities
+ * ---------------------- */
 template<>
 std::string encode<JointVelocities>(const JointVelocities& obj);
 template<>
@@ -471,7 +492,7 @@ bool decode(const std::string& msg, JointVelocities& obj);
 template<>
 std::string encode<JointVelocities>(const JointVelocities& obj) {
   proto::StateMessage message;
-  proto::JointState joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
   *message.mutable_joint_velocities()->mutable_state() = joint_state.state();
   *message.mutable_joint_velocities()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_velocities()->mutable_velocities() = joint_state.velocities();
@@ -490,7 +511,7 @@ bool decode(const std::string& msg, JointVelocities& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointVelocities)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointVelocities)) {
       if (!message.mutable_joint_velocities()->ParseFromString(msg)) {
         return false;
       }
@@ -506,6 +527,9 @@ bool decode(const std::string& msg, JointVelocities& obj) {
   }
 }
 
+/* ----------------------
+ *   JointAccelerations
+ * ---------------------- */
 template<>
 std::string encode<JointAccelerations>(const JointAccelerations& obj);
 template<>
@@ -515,7 +539,7 @@ bool decode(const std::string& msg, JointAccelerations& obj);
 template<>
 std::string encode<JointAccelerations>(const JointAccelerations& obj) {
   proto::StateMessage message;
-  proto::JointState joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
   *message.mutable_joint_accelerations()->mutable_state() = joint_state.state();
   *message.mutable_joint_accelerations()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_accelerations()->mutable_accelerations() = joint_state.accelerations();
@@ -534,7 +558,7 @@ bool decode(const std::string& msg, JointAccelerations& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointAccelerations)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointAccelerations)) {
       if (!message.mutable_joint_accelerations()->ParseFromString(msg)) {
         return false;
       }
@@ -550,6 +574,9 @@ bool decode(const std::string& msg, JointAccelerations& obj) {
   }
 }
 
+/* ----------------------
+ *      JointTorques
+ * ---------------------- */
 template<>
 std::string encode<JointTorques>(const JointTorques& obj);
 template<>
@@ -559,7 +586,7 @@ bool decode(const std::string& msg, JointTorques& obj);
 template<>
 std::string encode<JointTorques>(const JointTorques& obj) {
   proto::StateMessage message;
-  proto::JointState joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
   *message.mutable_joint_torques()->mutable_state() = joint_state.state();
   *message.mutable_joint_torques()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_torques()->mutable_torques() = joint_state.torques();
@@ -578,7 +605,7 @@ bool decode(const std::string& msg, JointTorques& obj) {
   try {
     proto::StateMessage message;
     if (!(message.ParseFromString(msg)
-    && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointTorques)) {
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kJointTorques)) {
       if (!message.mutable_joint_torques()->ParseFromString(msg)) {
         return false;
       }

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -385,7 +385,7 @@ bool decode(const std::string& msg, Jacobian& obj) {
     auto raw_data = const_cast<double*>(jacobian.data().data());
     auto data = Eigen::Map<Eigen::MatrixXd>(raw_data, jacobian.rows(), jacobian.cols());
     obj = Jacobian(
-        jacobian.state().name(), {jacobian.joint_names().begin(), jacobian.joint_names().end()}, jacobian.frame(), data,
+        jacobian.state().name(), decoder<std::string>(jacobian.joint_names()), jacobian.frame(), data,
         jacobian.reference_frame());
     return true;
   } catch (...) {
@@ -406,7 +406,6 @@ template<>
 std::string encode<JointState>(const JointState& obj) {
   proto::StateMessage message;
   *message.mutable_joint_state() = encoder<proto::JointState>(obj);
-  message.PrintDebugString();
   return message.SerializeAsString();
 }
 template<>

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -72,7 +72,7 @@ bool decode(const std::string& msg, State& obj);
 template<>
 std::string encode<State>(const State& obj) {
   proto::StateMessage message;
-  *message.mutable_state() = encoder<proto::State>(obj);
+  *message.mutable_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -95,7 +95,7 @@ bool decode(const std::string& msg, State& obj) {
     }
 
     auto state = message.state();
-    obj = State(decoder<StateType>(state.type()), state.name(), state.empty());
+    obj = State(decoder(state.type()), state.name(), state.empty());
 
     //TODO: (maybe) add set_timestamp method to State and add decoder for int to chrono
     //obj.set_timestamp(state.timestamp());
@@ -118,7 +118,7 @@ bool decode(const std::string& msg, SpatialState& obj);
 template<>
 std::string encode<SpatialState>(const SpatialState& obj) {
   proto::StateMessage message;
-  *message.mutable_spatial_state() = encoder<proto::SpatialState>(obj);
+  *message.mutable_spatial_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -142,7 +142,7 @@ bool decode(const std::string& msg, SpatialState& obj) {
 
     auto spatial_state = message.spatial_state();
     obj = SpatialState(
-        decoder<StateType>(spatial_state.state().type()), spatial_state.state().name(), spatial_state.reference_frame(),
+        decoder(spatial_state.state().type()), spatial_state.state().name(), spatial_state.reference_frame(),
         spatial_state.state().empty());
 
     return true;
@@ -163,7 +163,7 @@ bool decode(const std::string& msg, CartesianState& obj);
 template<>
 std::string encode<CartesianState>(const CartesianState& obj) {
   proto::StateMessage message;
-  *message.mutable_cartesian_state() = encoder<proto::CartesianState>(obj);
+  *message.mutable_cartesian_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -188,14 +188,14 @@ bool decode(const std::string& msg, CartesianState& obj) {
     auto state = message.cartesian_state();
     obj.set_name(state.spatial_state().state().name());
     obj.set_reference_frame(state.spatial_state().reference_frame());
-    obj.set_position(decoder<Eigen::Vector3d>(state.position()));
-    obj.set_orientation(decoder<Eigen::Quaterniond, proto::Quaterniond>(state.orientation()));
-    obj.set_linear_velocity(decoder<Eigen::Vector3d>(state.linear_velocity()));
-    obj.set_angular_velocity(decoder<Eigen::Vector3d>(state.angular_velocity()));
-    obj.set_linear_acceleration(decoder<Eigen::Vector3d>(state.linear_acceleration()));
-    obj.set_angular_acceleration(decoder<Eigen::Vector3d>(state.angular_acceleration()));
-    obj.set_force(decoder<Eigen::Vector3d>(state.force()));
-    obj.set_torque(decoder<Eigen::Vector3d>(state.torque()));
+    obj.set_position(decoder(state.position()));
+    obj.set_orientation(decoder(state.orientation()));
+    obj.set_linear_velocity(decoder(state.linear_velocity()));
+    obj.set_angular_velocity(decoder(state.angular_velocity()));
+    obj.set_linear_acceleration(decoder(state.linear_acceleration()));
+    obj.set_angular_acceleration(decoder(state.angular_acceleration()));
+    obj.set_force(decoder(state.force()));
+    obj.set_torque(decoder(state.torque()));
     obj.set_empty(state.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -215,7 +215,7 @@ bool decode(const std::string& msg, CartesianPose& obj);
 template<>
 std::string encode<CartesianPose>(const CartesianPose& obj) {
   proto::StateMessage message;
-  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_pose()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_pose()->mutable_position() = cartesian_state.position();
   *message.mutable_cartesian_pose()->mutable_orientation() = cartesian_state.orientation();
@@ -242,8 +242,8 @@ bool decode(const std::string& msg, CartesianPose& obj) {
     auto pose = message.cartesian_pose();
     obj.set_name(pose.spatial_state().state().name());
     obj.set_reference_frame(pose.spatial_state().reference_frame());
-    obj.set_position(decoder<Eigen::Vector3d>(pose.position()));
-    obj.set_orientation(decoder<Eigen::Quaterniond, proto::Quaterniond>(pose.orientation()));
+    obj.set_position(decoder(pose.position()));
+    obj.set_orientation(decoder(pose.orientation()));
     obj.set_empty(pose.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -263,7 +263,7 @@ bool decode(const std::string& msg, CartesianTwist& obj);
 template<>
 std::string encode<CartesianTwist>(const CartesianTwist& obj) {
   proto::StateMessage message;
-  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_twist()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_twist()->mutable_linear_velocity() = cartesian_state.linear_velocity();
   *message.mutable_cartesian_twist()->mutable_angular_velocity() = cartesian_state.angular_velocity();
@@ -290,8 +290,8 @@ bool decode(const std::string& msg, CartesianTwist& obj) {
     auto twist = message.cartesian_twist();
     obj.set_name(twist.spatial_state().state().name());
     obj.set_reference_frame(twist.spatial_state().reference_frame());
-    obj.set_linear_velocity(decoder<Eigen::Vector3d>(twist.linear_velocity()));
-    obj.set_angular_velocity(decoder<Eigen::Vector3d>(twist.angular_velocity()));
+    obj.set_linear_velocity(decoder(twist.linear_velocity()));
+    obj.set_angular_velocity(decoder(twist.angular_velocity()));
     obj.set_empty(twist.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -311,7 +311,7 @@ bool decode(const std::string& msg, CartesianWrench& obj);
 template<>
 std::string encode<CartesianWrench>(const CartesianWrench& obj) {
   proto::StateMessage message;
-  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_wrench()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_wrench()->mutable_force() = cartesian_state.force();
   *message.mutable_cartesian_wrench()->mutable_torque() = cartesian_state.torque();
@@ -338,8 +338,8 @@ bool decode(const std::string& msg, CartesianWrench& obj) {
     auto wrench = message.cartesian_wrench();
     obj.set_name(wrench.spatial_state().state().name());
     obj.set_reference_frame(wrench.spatial_state().reference_frame());
-    obj.set_force(decoder<Eigen::Vector3d>(wrench.force()));
-    obj.set_torque(decoder<Eigen::Vector3d>(wrench.torque()));
+    obj.set_force(decoder(wrench.force()));
+    obj.set_torque(decoder(wrench.torque()));
     obj.set_empty(wrench.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -359,7 +359,7 @@ bool decode(const std::string& msg, Jacobian& obj);
 template<>
 std::string encode<Jacobian>(const Jacobian& obj) {
   proto::StateMessage message;
-  *message.mutable_jacobian() = encoder<proto::Jacobian>(obj);
+  *message.mutable_jacobian() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -385,8 +385,7 @@ bool decode(const std::string& msg, Jacobian& obj) {
     auto raw_data = const_cast<double*>(jacobian.data().data());
     auto data = Eigen::Map<Eigen::MatrixXd>(raw_data, jacobian.rows(), jacobian.cols());
     obj = Jacobian(
-        jacobian.state().name(), decoder<std::string>(jacobian.joint_names()), jacobian.frame(), data,
-        jacobian.reference_frame());
+        jacobian.state().name(), decoder(jacobian.joint_names()), jacobian.frame(), data, jacobian.reference_frame());
     return true;
   } catch (...) {
     return false;
@@ -405,7 +404,7 @@ bool decode(const std::string& msg, JointState& obj);
 template<>
 std::string encode<JointState>(const JointState& obj) {
   proto::StateMessage message;
-  *message.mutable_joint_state() = encoder<proto::JointState>(obj);
+  *message.mutable_joint_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -428,7 +427,7 @@ bool decode(const std::string& msg, JointState& obj) {
     }
 
     auto state = message.joint_state();
-    obj = JointState(state.state().name(), decoder<std::string>(state.joint_names()));
+    obj = JointState(state.state().name(), decoder(state.joint_names()));
     obj.set_positions(decoder(state.positions()));
     obj.set_velocities(decoder(state.velocities()));
     obj.set_accelerations(decoder(state.accelerations()));
@@ -452,7 +451,7 @@ bool decode(const std::string& msg, JointPositions& obj);
 template<>
 std::string encode<JointPositions>(const JointPositions& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_positions()->mutable_state() = joint_state.state();
   *message.mutable_joint_positions()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_positions()->mutable_positions() = joint_state.positions();
@@ -499,7 +498,7 @@ bool decode(const std::string& msg, JointVelocities& obj);
 template<>
 std::string encode<JointVelocities>(const JointVelocities& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_velocities()->mutable_state() = joint_state.state();
   *message.mutable_joint_velocities()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_velocities()->mutable_velocities() = joint_state.velocities();
@@ -546,7 +545,7 @@ bool decode(const std::string& msg, JointAccelerations& obj);
 template<>
 std::string encode<JointAccelerations>(const JointAccelerations& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_accelerations()->mutable_state() = joint_state.state();
   *message.mutable_joint_accelerations()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_accelerations()->mutable_accelerations() = joint_state.accelerations();
@@ -593,7 +592,7 @@ bool decode(const std::string& msg, JointTorques& obj);
 template<>
 std::string encode<JointTorques>(const JointTorques& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_torques()->mutable_state() = joint_state.state();
   *message.mutable_joint_torques()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_torques()->mutable_torques() = joint_state.torques();

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -628,7 +628,227 @@ bool decode(const std::string& msg, JointTorques& obj) {
   }
 }
 
-/* Generic template code for future types:
+/* ----------------------
+ *      Parameter<T>
+ * ---------------------- */
+template<typename T>
+static std::string encode_parameter(const Parameter<T>& obj);
+template<typename T>
+static Parameter<T> decode_parameter(const std::string& msg);
+template<typename T>
+static bool decode_parameter(const std::string& msg, Parameter<T>& obj);
+
+template<typename T>
+static std::string encode_parameter(const Parameter<T>& obj) {
+  proto::StateMessage message;
+  *message.mutable_parameter() = encoder<T>(obj);
+  return message.SerializeAsString();
+}
+template<typename T>
+static Parameter<T> decode_parameter(const std::string& msg) {
+  Parameter<T> obj("");
+  if (!decode(msg, obj)) {
+    throw DecodingException("Could not decode the message into a Parameter");
+  }
+  return obj;
+}
+template<typename T>
+static bool decode_parameter(const std::string& msg, Parameter<T>& obj) {
+  try {
+    proto::StateMessage message;
+    if (!(message.ParseFromString(msg)
+        && message.message_type_case() == proto::StateMessage::MessageTypeCase::kParameter)) {
+      if (!message.mutable_parameter()->ParseFromString(msg)) {
+        return false;
+      }
+    }
+    obj = decoder<T>(message.parameter());
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+/* ----------------------
+ *        DOUBLE
+ * ---------------------- */
+template<>
+std::string encode<Parameter<double>>(const Parameter<double>& obj);
+template<>
+Parameter<double> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<double>& obj);
+template<>
+std::string encode<Parameter<double>>(const Parameter<double>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<double> decode(const std::string& msg) {
+  return decode_parameter<double>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<double>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *      DOUBLE_ARRAY
+ * ---------------------- */
+template<>
+std::string encode<Parameter<std::vector<double>>>(const Parameter<std::vector<double>>& obj);
+template<>
+Parameter<std::vector<double>> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<std::vector<double>>& obj);
+template<>
+std::string encode<Parameter<std::vector<double>>>(const Parameter<std::vector<double>>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<std::vector<double>> decode(const std::string& msg) {
+  return decode_parameter<std::vector<double>>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<std::vector<double>>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *          BOOL
+ * ---------------------- */
+template<>
+std::string encode<Parameter<bool>>(const Parameter<bool>& obj);
+template<>
+Parameter<bool> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<bool>& obj);
+template<>
+std::string encode<Parameter<bool>>(const Parameter<bool>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<bool> decode(const std::string& msg) {
+  return decode_parameter<bool>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<bool>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *       BOOL_ARRAY
+ * ---------------------- */
+template<>
+std::string encode<Parameter<std::vector<bool>>>(const Parameter<std::vector<bool>>& obj);
+template<>
+Parameter<std::vector<bool>> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<std::vector<bool>>& obj);
+template<>
+std::string encode<Parameter<std::vector<bool>>>(const Parameter<std::vector<bool>>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<std::vector<bool>> decode(const std::string& msg) {
+  return decode_parameter<std::vector<bool>>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<std::vector<bool>>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *         STRING
+ * ---------------------- */
+template<>
+std::string encode<Parameter<std::string>>(const Parameter<std::string>& obj);
+template<>
+Parameter<std::string> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<std::string>& obj);
+template<>
+std::string encode<Parameter<std::string>>(const Parameter<std::string>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<std::string> decode(const std::string& msg) {
+  return decode_parameter<std::string>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<std::string>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *      STRING_ARRAY
+ * ---------------------- */
+template<>
+std::string encode<Parameter<std::vector<std::string>>>(const Parameter<std::vector<std::string>>& obj);
+template<>
+Parameter<std::vector<std::string>> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<std::vector<std::string>>& obj);
+template<>
+std::string encode<Parameter<std::vector<std::string>>>(const Parameter<std::vector<std::string>>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<std::vector<std::string>> decode(const std::string& msg) {
+  return decode_parameter<std::vector<std::string>>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<std::vector<std::string>>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *         VECTOR
+ * ---------------------- */
+template<>
+std::string encode<Parameter<Eigen::VectorXd>>(const Parameter<Eigen::VectorXd>& obj);
+template<>
+Parameter<Eigen::VectorXd> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<Eigen::VectorXd>& obj);
+template<>
+std::string encode<Parameter<Eigen::VectorXd>>(const Parameter<Eigen::VectorXd>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<Eigen::VectorXd> decode(const std::string& msg) {
+  return decode_parameter<Eigen::VectorXd>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<Eigen::VectorXd>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+/* ----------------------
+ *         MATRIX
+ * ---------------------- */
+template<>
+std::string encode<Parameter<Eigen::MatrixXd>>(const Parameter<Eigen::MatrixXd>& obj);
+template<>
+Parameter<Eigen::MatrixXd> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<Eigen::MatrixXd>& obj);
+template<>
+std::string encode<Parameter<Eigen::MatrixXd>>(const Parameter<Eigen::MatrixXd>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<Eigen::MatrixXd> decode(const std::string& msg) {
+  return decode_parameter<Eigen::MatrixXd>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<Eigen::MatrixXd>& obj) {
+  return decode_parameter(msg, obj);
+}
+
+// Generic template code for future types:
+/* ----------------------
+ *        __TYPE__
+ * ---------------------- */ /*
 template<> std::string encode<__TYPE__>(const __TYPE__& obj);
 template<> __TYPE__ decode(const std::string& msg);
 template<> bool decode(const std::string& msg, __TYPE__& obj);
@@ -657,6 +877,29 @@ template<> bool decode(const std::string& msg, __TYPE__& obj) {
   } catch (...) {
     return false;
   }
+}
+*/
+
+/* ----------------------
+ *   Parameter<ParamT>
+ * ---------------------- */ /*
+template<>
+std::string encode<Parameter<ParamT>>(const Parameter<ParamT>& obj);
+template<>
+Parameter<ParamT> decode(const std::string& msg);
+template<>
+bool decode(const std::string& msg, Parameter<ParamT>& obj);
+template<>
+std::string encode<Parameter<ParamT>>(const Parameter<ParamT>& obj) {
+  return encode_parameter(obj);
+}
+template<>
+Parameter<ParamT> decode(const std::string& msg) {
+  return decode_parameter<ParamT>(msg);
+}
+template<>
+bool decode(const std::string& msg, Parameter<ParamT>& obj) {
+  return decode_parameter(msg, obj);
 }
 */
 

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -189,7 +189,7 @@ bool decode(const std::string& msg, CartesianState& obj) {
     obj.set_name(state.spatial_state().state().name());
     obj.set_reference_frame(state.spatial_state().reference_frame());
     obj.set_position(decoder<Eigen::Vector3d>(state.position()));
-    obj.set_orientation(decoder<Eigen::Quaterniond>(state.orientation()));
+    obj.set_orientation(decoder<Eigen::Quaterniond, proto::Quaterniond>(state.orientation()));
     obj.set_linear_velocity(decoder<Eigen::Vector3d>(state.linear_velocity()));
     obj.set_angular_velocity(decoder<Eigen::Vector3d>(state.angular_velocity()));
     obj.set_linear_acceleration(decoder<Eigen::Vector3d>(state.linear_acceleration()));
@@ -243,7 +243,7 @@ bool decode(const std::string& msg, CartesianPose& obj) {
     obj.set_name(pose.spatial_state().state().name());
     obj.set_reference_frame(pose.spatial_state().reference_frame());
     obj.set_position(decoder<Eigen::Vector3d>(pose.position()));
-    obj.set_orientation(decoder<Eigen::Quaterniond>(pose.orientation()));
+    obj.set_orientation(decoder<Eigen::Quaterniond, proto::Quaterniond>(pose.orientation()));
     obj.set_empty(pose.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -406,6 +406,7 @@ template<>
 std::string encode<JointState>(const JointState& obj) {
   proto::StateMessage message;
   *message.mutable_joint_state() = encoder<proto::JointState>(obj);
+  message.PrintDebugString();
   return message.SerializeAsString();
 }
 template<>
@@ -428,11 +429,11 @@ bool decode(const std::string& msg, JointState& obj) {
     }
 
     auto state = message.joint_state();
-    obj = JointState(state.state().name(), {state.joint_names().begin(), state.joint_names().end()});
-    obj.set_positions(decoder<std::vector<double>>(state.positions()));
-    obj.set_velocities(decoder<std::vector<double>>(state.velocities()));
-    obj.set_accelerations(decoder<std::vector<double>>(state.accelerations()));
-    obj.set_torques(decoder<std::vector<double>>(state.torques()));
+    obj = JointState(state.state().name(), decoder<std::string>(state.joint_names()));
+    obj.set_positions(decoder(state.positions()));
+    obj.set_velocities(decoder(state.velocities()));
+    obj.set_accelerations(decoder(state.accelerations()));
+    obj.set_torques(decoder(state.torques()));
     obj.set_empty(state.state().empty());
     return true;
   } catch (...) {
@@ -478,8 +479,8 @@ bool decode(const std::string& msg, JointPositions& obj) {
     }
 
     auto state = message.joint_positions();
-    obj = JointState(state.state().name(), {state.joint_names().begin(), state.joint_names().end()});
-    obj.set_positions(decoder<std::vector<double>>(state.positions()));
+    obj = JointState(state.state().name(), decoder(state.joint_names()));
+    obj.set_positions(decoder(state.positions()));
     obj.set_empty(state.state().empty());
     return true;
   } catch (...) {
@@ -525,8 +526,8 @@ bool decode(const std::string& msg, JointVelocities& obj) {
     }
 
     auto state = message.joint_velocities();
-    obj = JointState(state.state().name(), {state.joint_names().begin(), state.joint_names().end()});
-    obj.set_velocities(decoder<std::vector<double>>(state.velocities()));
+    obj = JointState(state.state().name(), decoder(state.joint_names()));
+    obj.set_velocities(decoder(state.velocities()));
     obj.set_empty(state.state().empty());
     return true;
   } catch (...) {
@@ -572,8 +573,8 @@ bool decode(const std::string& msg, JointAccelerations& obj) {
     }
 
     auto state = message.joint_accelerations();
-    obj = JointState(state.state().name(), {state.joint_names().begin(), state.joint_names().end()});
-    obj.set_accelerations(decoder<std::vector<double>>(state.accelerations()));
+    obj = JointState(state.state().name(), decoder(state.joint_names()));
+    obj.set_accelerations(decoder(state.accelerations()));
     obj.set_empty(state.state().empty());
     return true;
   } catch (...) {
@@ -619,8 +620,8 @@ bool decode(const std::string& msg, JointTorques& obj) {
     }
 
     auto state = message.joint_torques();
-    obj = JointState(state.state().name(), {state.joint_names().begin(), state.joint_names().end()});
-    obj.set_torques(decoder<std::vector<double>>(state.torques()));
+    obj = JointState(state.state().name(), decoder(state.joint_names()));
+    obj.set_torques(decoder(state.torques()));
     obj.set_empty(state.state().empty());
     return true;
   } catch (...) {

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -53,6 +53,13 @@ MessageType check_message_type(const std::string& msg) {
   return MessageType::UNKNOWN_MESSAGE;
 }
 
+ParameterMessageType check_parameter_message_type(const std::string& msg) {
+  if (proto::StateMessage message; message.ParseFromString(msg) && message.has_parameter()) {
+    return static_cast<ParameterMessageType>(message.parameter().parameter_value().value_type_case());
+  }
+  return ParameterMessageType::UNKNOWN_PARAMETER;
+}
+
 /* ----------------------
  *         State
  * ---------------------- */

--- a/protocol/clproto_cpp/src/decoders.cpp
+++ b/protocol/clproto_cpp/src/decoders.cpp
@@ -1,31 +1,23 @@
 #include "clproto/decoders.h"
 
-#include "state_representation/state_message.pb.h"
-
 using namespace state_representation;
 
 namespace clproto {
 
-DecoderNotImplementedException::DecoderNotImplementedException(const std::string& msg) : DecodingException(msg) {}
-
-template<>
 std::vector<bool> decoder(const google::protobuf::RepeatedField<bool>& message) {
   // explicit construction is needed for the bool vector due to stl optimisations
   std::vector<bool> vec(message.begin(), message.end());
   return vec;
 }
 
-template<>
 StateType decoder(const proto::StateType& message) {
   return static_cast<StateType>(message);
 }
 
-template<>
 Eigen::Vector3d decoder(const proto::Vector3d& message) {
   return {message.x(), message.y(), message.z()};
 }
 
-template<>
 Eigen::Quaterniond decoder(const proto::Quaterniond& message) {
   return {message.w(), message.vec().x(), message.vec().y(), message.vec().z()};
 }

--- a/protocol/clproto_cpp/src/decoders.cpp
+++ b/protocol/clproto_cpp/src/decoders.cpp
@@ -1,10 +1,6 @@
 #include "clproto/decoders.h"
 
-#include <state_representation/State.hpp>
-
-#include "state_representation/state.pb.h"
-#include "state_representation/space/cartesian/cartesian_state.pb.h"
-#include "state_representation/space/cartesian/cartesian_state.pb.h"
+#include "state_representation/state_message.pb.h"
 
 using namespace state_representation;
 

--- a/protocol/clproto_cpp/src/decoders.cpp
+++ b/protocol/clproto_cpp/src/decoders.cpp
@@ -9,23 +9,66 @@ namespace clproto {
 DecoderNotImplementedException::DecoderNotImplementedException(const std::string& msg) : DecodingException(msg) {}
 
 template<>
+std::vector<bool> decoder(const google::protobuf::RepeatedField<bool>& message) {
+  // explicit construction is needed for the bool vector due to stl optimisations
+  std::vector<bool> vec(message.begin(), message.end());
+  return vec;
+}
+
+template<>
 StateType decoder(const proto::StateType& message) {
   return static_cast<StateType>(message);
 }
 
 template<>
 Eigen::Vector3d decoder(const proto::Vector3d& message) {
-  return Eigen::Vector3d(message.x(), message.y(), message.z());
+  return {message.x(), message.y(), message.z()};
 }
 
 template<>
 Eigen::Quaterniond decoder(const proto::Quaterniond& message) {
-  return Eigen::Quaterniond(message.w(), message.vec().x(), message.vec().y(), message.vec().z());
+  return {message.w(), message.vec().x(), message.vec().y(), message.vec().z()};
 }
 
 template<>
-std::vector<double> decoder(const google::protobuf::RepeatedField<double>& message) {
-  return std::vector<double>(message.begin(), message.end());
+Parameter<double> decoder(const state_representation::proto::Parameter& message) {
+  return Parameter<double>(message.state().name(), message.parameter_value().double_().value());
 }
-
+template<>
+Parameter<std::vector<double>> decoder(const state_representation::proto::Parameter& message) {
+  return Parameter<std::vector<double>>(
+      message.state().name(), decoder(message.parameter_value().double_array().value()));
+}
+template<>
+Parameter<bool> decoder(const state_representation::proto::Parameter& message) {
+  return Parameter<bool>(message.state().name(), message.parameter_value().bool_().value());
+}
+template<>
+Parameter<std::vector<bool>> decoder(const state_representation::proto::Parameter& message) {
+  auto val = decoder(message.parameter_value().bool_array().value());
+  return Parameter<std::vector<bool>>(message.state().name(), val);
+}
+template<>
+Parameter<std::string> decoder(const state_representation::proto::Parameter& message) {
+  return Parameter<std::string>(message.state().name(), message.parameter_value().string().value());
+}
+template<>
+Parameter<std::vector<std::string>> decoder(const state_representation::proto::Parameter& message) {
+  return Parameter<std::vector<std::string>>(
+      message.state().name(), decoder(message.parameter_value().string_array().value()));
+}
+template<>
+Parameter<Eigen::VectorXd> decoder(const state_representation::proto::Parameter& message) {
+  std::vector<double> elements = decoder(message.parameter_value().vector().value());
+  return Parameter<Eigen::VectorXd>(
+      message.state().name(), Eigen::Map<Eigen::VectorXd>(
+          elements.data(), static_cast<Eigen::Index>(elements.size())));
+}
+template<>
+Parameter<Eigen::MatrixXd> decoder(const state_representation::proto::Parameter& message) {
+  std::vector<double> elements = decoder(message.parameter_value().matrix().value());
+  return Parameter<Eigen::MatrixXd>(
+      message.state().name(), Eigen::Map<Eigen::MatrixXd>(
+          elements.data(), message.parameter_value().matrix().rows(), message.parameter_value().matrix().cols()));
+}
 }

--- a/protocol/clproto_cpp/src/encoders.cpp
+++ b/protocol/clproto_cpp/src/encoders.cpp
@@ -6,11 +6,7 @@
 #include <state_representation/robot/Jacobian.hpp>
 #include <state_representation/robot/JointState.hpp>
 
-#include "state_representation/state.pb.h"
-#include "state_representation/space/spatial_state.pb.h"
-#include "state_representation/space/cartesian/cartesian_state.pb.h"
-#include "state_representation/space/joint/jacobian.pb.h"
-#include "state_representation/space/joint/joint_state.pb.h"
+#include "state_representation/state_message.pb.h"
 
 using namespace state_representation;
 

--- a/protocol/clproto_cpp/src/encoders.cpp
+++ b/protocol/clproto_cpp/src/encoders.cpp
@@ -1,47 +1,33 @@
 #include "clproto/encoders.h"
 
-#include <state_representation/State.hpp>
-#include <state_representation/space/SpatialState.hpp>
-#include <state_representation/space/cartesian/CartesianState.hpp>
-#include <state_representation/robot/Jacobian.hpp>
-#include <state_representation/robot/JointState.hpp>
-
-#include "state_representation/state_message.pb.h"
-
 using namespace state_representation;
 
 namespace clproto {
 
-EncoderNotImplementedException::EncoderNotImplementedException(const std::string& msg) : std::runtime_error(msg) {}
-
-google::protobuf::RepeatedField<double> encoder(const Eigen::MatrixXd& matrix) {
+google::protobuf::RepeatedField<double> matrix_encoder(const Eigen::MatrixXd& matrix) {
   return encoder(std::vector<double>{matrix.data(), matrix.data() + matrix.size()});
 }
 
-template<>
 proto::StateType encoder(const StateType& type) {
   return static_cast<proto::StateType>(type);
 }
 
-template<>
 proto::State encoder(const State& state) {
   proto::State message;
   message.set_name(state.get_name());
-  message.set_type(encoder<proto::StateType>(state.get_type()));
+  message.set_type(encoder(state.get_type()));
   message.set_empty(state.is_empty());
   message.set_timestamp(state.get_timestamp().time_since_epoch().count());
   return message;
 }
 
-template<>
 proto::SpatialState encoder(const SpatialState& spatial_state) {
   proto::SpatialState message;
-  *message.mutable_state() = encoder<proto::State>(static_cast<State>(spatial_state));
+  *message.mutable_state() = encoder(static_cast<State>(spatial_state));
   message.set_reference_frame(spatial_state.get_reference_frame());
   return message;
 }
 
-template<>
 proto::Vector3d encoder(const Eigen::Vector3d& vector) {
   proto::Vector3d message;
   message.set_x(vector.x());
@@ -50,67 +36,62 @@ proto::Vector3d encoder(const Eigen::Vector3d& vector) {
   return message;
 }
 
-template<>
 proto::Quaterniond encoder(const Eigen::Quaterniond& quaternion) {
   proto::Quaterniond message;
   message.set_w(quaternion.w());
-  *message.mutable_vec() = encoder<proto::Vector3d>(Eigen::Vector3d(quaternion.vec()));
+  *message.mutable_vec() = encoder(Eigen::Vector3d(quaternion.vec()));
   return message;
 }
 
-template<>
 proto::CartesianState encoder(const CartesianState& cartesian_state) {
   proto::CartesianState message;
-  *message.mutable_spatial_state() = encoder<proto::SpatialState>(static_cast<SpatialState>(cartesian_state));
-  *message.mutable_position() = encoder<proto::Vector3d>(cartesian_state.get_position());
-  *message.mutable_orientation() = encoder<proto::Quaterniond>(cartesian_state.get_orientation());
-  *message.mutable_linear_velocity() = encoder<proto::Vector3d>(cartesian_state.get_linear_velocity());
-  *message.mutable_angular_velocity() = encoder<proto::Vector3d>(cartesian_state.get_angular_velocity());
-  *message.mutable_linear_acceleration() = encoder<proto::Vector3d>(cartesian_state.get_linear_acceleration());
-  *message.mutable_angular_acceleration() = encoder<proto::Vector3d>(cartesian_state.get_angular_acceleration());
-  *message.mutable_force() = encoder<proto::Vector3d>(cartesian_state.get_force());
-  *message.mutable_torque() = encoder<proto::Vector3d>(cartesian_state.get_torque());
+  *message.mutable_spatial_state() = encoder(static_cast<SpatialState>(cartesian_state));
+  *message.mutable_position() = encoder(cartesian_state.get_position());
+  *message.mutable_orientation() = encoder(cartesian_state.get_orientation());
+  *message.mutable_linear_velocity() = encoder(cartesian_state.get_linear_velocity());
+  *message.mutable_angular_velocity() = encoder(cartesian_state.get_angular_velocity());
+  *message.mutable_linear_acceleration() = encoder(cartesian_state.get_linear_acceleration());
+  *message.mutable_angular_acceleration() = encoder(cartesian_state.get_angular_acceleration());
+  *message.mutable_force() = encoder(cartesian_state.get_force());
+  *message.mutable_torque() = encoder(cartesian_state.get_torque());
   return message;
 }
 
-template<>
 proto::Jacobian encoder(const Jacobian& jacobian) {
   proto::Jacobian message;
-  *message.mutable_state() = encoder<proto::State>(static_cast<State>(jacobian));
+  *message.mutable_state() = encoder(static_cast<State>(jacobian));
   *message.mutable_joint_names() = {jacobian.get_joint_names().begin(), jacobian.get_joint_names().end()};
   message.set_frame(jacobian.get_frame());
   message.set_reference_frame(jacobian.get_reference_frame());
   message.set_rows(jacobian.rows());
   message.set_cols(jacobian.cols());
-  *message.mutable_data() = encoder(jacobian.data());
+  *message.mutable_data() = matrix_encoder(jacobian.data());
   return message;
 }
 
-template<>
 proto::JointState encoder(const JointState& joint_state) {
   proto::JointState message;
-  *message.mutable_state() = encoder<proto::State>(static_cast<State>(joint_state));
+  *message.mutable_state() = encoder(static_cast<State>(joint_state));
   *message.mutable_joint_names() = {joint_state.get_names().begin(), joint_state.get_names().end()};
-  *message.mutable_positions() = encoder(joint_state.get_positions());
-  *message.mutable_velocities() = encoder(joint_state.get_velocities());
-  *message.mutable_accelerations() = encoder(joint_state.get_accelerations());
-  *message.mutable_torques() = encoder(joint_state.get_torques());
+  *message.mutable_positions() = matrix_encoder(joint_state.get_positions());
+  *message.mutable_velocities() = matrix_encoder(joint_state.get_velocities());
+  *message.mutable_accelerations() = matrix_encoder(joint_state.get_accelerations());
+  *message.mutable_torques() = matrix_encoder(joint_state.get_torques());
   return message;
 }
 
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<double>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   message.mutable_parameter_value()->mutable_double_()->set_value(parameter.get_value());
   return message;
 }
+
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<std::vector<double>>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   *message.mutable_parameter_value()->mutable_double_array()->mutable_value() =
       {parameter.get_value().begin(), parameter.get_value().end()};
   return message;
@@ -118,16 +99,14 @@ state_representation::proto::Parameter encoder(const state_representation::Param
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<bool>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   message.mutable_parameter_value()->mutable_bool_()->set_value(parameter.get_value());
   return message;
 }
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<std::vector<bool>>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   *message.mutable_parameter_value()->mutable_bool_array()->mutable_value() =
       {parameter.get_value().begin(), parameter.get_value().end()};
   return message;
@@ -135,8 +114,7 @@ state_representation::proto::Parameter encoder(const state_representation::Param
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<std::string>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   message.mutable_parameter_value()->mutable_string()->set_value(parameter.get_value());
   return message;
 }
@@ -144,8 +122,7 @@ template<>
 state_representation::proto::Parameter
 encoder(const state_representation::Parameter<std::vector<std::string>>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   *message.mutable_parameter_value()->mutable_string_array()->mutable_value() =
       {parameter.get_value().begin(), parameter.get_value().end()};
   return message;
@@ -153,18 +130,16 @@ encoder(const state_representation::Parameter<std::vector<std::string>>& paramet
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<Eigen::VectorXd>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
-  *message.mutable_parameter_value()->mutable_vector()->mutable_value() = encoder(parameter.get_value());
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
+  *message.mutable_parameter_value()->mutable_vector()->mutable_value() = matrix_encoder(parameter.get_value());
   return message;
 }
 
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<Eigen::MatrixXd>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
-  *message.mutable_parameter_value()->mutable_matrix()->mutable_value() = encoder(parameter.get_value());
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
+  *message.mutable_parameter_value()->mutable_matrix()->mutable_value() = matrix_encoder(parameter.get_value());
   message.mutable_parameter_value()->mutable_matrix()->set_rows(parameter.get_value().rows());
   message.mutable_parameter_value()->mutable_matrix()->set_cols(parameter.get_value().cols());
   return message;

--- a/protocol/clproto_cpp/test/tests/test_parameter_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_parameter_proto.cpp
@@ -1,0 +1,162 @@
+#include <gtest/gtest.h>
+
+#include <state_representation/parameters/Parameter.hpp>
+
+#include "clproto.h"
+
+using namespace state_representation;
+
+TEST(CartesianProtoTest, EncodeDecodeParameterDouble) {
+  double value = 1.0;
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::DOUBLE);
+
+  Parameter<double> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<double>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value(), recv_state.get_value());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterDoubleArray) {
+  std::vector<double> value = {1.0, 2.0, 3.0};
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::DOUBLE_ARRAY);
+
+  Parameter<std::vector<double>> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<std::vector<double>>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value().size(), recv_state.get_value().size());
+  for(std::size_t index = 0; index < send_state.get_value().size(); ++index) {
+    EXPECT_EQ(send_state.get_value().at(index), recv_state.get_value().at(index));
+  }
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterBool) {
+  bool value = true;
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::BOOL);
+
+  Parameter<bool> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<bool>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value(), recv_state.get_value());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterBoolArray) {
+  std::vector<bool> value = {true, false, true, false};
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::BOOL_ARRAY);
+
+  Parameter<std::vector<bool>> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<std::vector<bool>>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value().size(), recv_state.get_value().size());
+  for(std::size_t index = 0; index < send_state.get_value().size(); ++index) {
+    EXPECT_EQ(send_state.get_value().at(index), recv_state.get_value().at(index));
+  }
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterString) {
+  std::string value = "value";
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::STRING);
+
+  Parameter<std::string> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<std::string>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_STREQ(send_state.get_value().c_str(), recv_state.get_value().c_str());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterStringArray) {
+  std::vector<std::string> value = {"value 1", "value 2", "value 3"};
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::STRING_ARRAY);
+
+  Parameter<std::vector<std::string>> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<std::vector<std::string>>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value().size(), recv_state.get_value().size());
+  for(std::size_t index = 0; index < send_state.get_value().size(); ++index) {
+    EXPECT_STREQ(send_state.get_value().at(index).c_str(), recv_state.get_value().at(index).c_str());
+  }
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterVector) {
+  Eigen::VectorXd value(5);
+  value << 1.0, 2.0, 3.0, 4.0, 5.0;
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::VECTOR);
+
+  Parameter<Eigen::VectorXd> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<Eigen::VectorXd>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value().size(), recv_state.get_value().size());
+  for(std::size_t index = 0; index < send_state.get_value().size(); ++index) {
+    EXPECT_EQ(send_state.get_value()(index), recv_state.get_value()(index));
+  }
+}
+
+TEST(CartesianProtoTest, EncodeDecodeParameterMatrix) {
+  Eigen::MatrixXd value(2, 3);
+  value << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+  auto send_state = Parameter("A", value);
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::MessageType::PARAMETER_MESSAGE);
+  EXPECT_TRUE(clproto::check_parameter_message_type(msg) == clproto::ParameterMessageType::MATRIX);
+
+  Parameter<Eigen::MatrixXd> recv_state("");
+  EXPECT_NO_THROW(clproto::decode<Parameter<Eigen::MatrixXd>>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_value().size(), recv_state.get_value().size());
+  EXPECT_EQ(send_state.get_value().rows(), recv_state.get_value().rows());
+  EXPECT_EQ(send_state.get_value().cols(), recv_state.get_value().cols());
+  for(std::size_t index = 0; index < send_state.get_value().size(); ++index) {
+    EXPECT_EQ(send_state.get_value()(index), recv_state.get_value()(index));
+  }
+}

--- a/protocol/protobuf/proto/state_representation/parameters/parameter.proto
+++ b/protocol/protobuf/proto/state_representation/parameters/parameter.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package state_representation.proto;
+
+import "state_representation/state.proto";
+import "state_representation/parameters/parameter_value.proto";
+
+message Parameter {
+  State state = 1;
+  ParameterValue parameter_value = 2;
+}
+
+message ParameterValue {
+  oneof value_type {
+    parameter.Double double = 1;
+    parameter.DoubleArray double_array = 2;
+    parameter.Bool bool = 3;
+    parameter.BoolArray bool_array = 4;
+    parameter.String string = 5;
+    parameter.StringArray string_array = 6;
+    parameter.Matrix matrix = 7;
+    parameter.Vector vector = 8;
+  }
+}

--- a/protocol/protobuf/proto/state_representation/parameters/parameter_value.proto
+++ b/protocol/protobuf/proto/state_representation/parameters/parameter_value.proto
@@ -31,7 +31,7 @@ message Vector {
 }
 
 message Matrix {
-  repeated double double = 1;
+  repeated double value = 1;
   uint32 rows = 2;
   uint32 cols = 3;
 }

--- a/protocol/protobuf/proto/state_representation/parameters/parameter_value.proto
+++ b/protocol/protobuf/proto/state_representation/parameters/parameter_value.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package state_representation.proto.parameter;
+
+message Double {
+  double value = 1;
+}
+
+message DoubleArray {
+  repeated double value = 1;
+}
+
+message Bool {
+  bool value = 1;
+}
+
+message BoolArray {
+  repeated bool value = 1;
+}
+
+message String {
+  string value = 1;
+}
+
+message StringArray {
+  repeated string value = 1;
+}
+
+message Vector {
+  repeated double value = 1;
+}
+
+message Matrix {
+  repeated double double = 1;
+  uint32 rows = 2;
+  uint32 cols = 3;
+}

--- a/protocol/protobuf/proto/state_representation/state_message.proto
+++ b/protocol/protobuf/proto/state_representation/state_message.proto
@@ -9,6 +9,7 @@ import "state_representation/space/joint/jacobian.proto";
 import "state_representation/space/joint/joint_state.proto";
 import "state_representation/geometry/shape.proto";
 import "state_representation/geometry/ellipsoid.proto";
+import "state_representation/parameters/parameter.proto";
 
 message StateMessage {
   oneof message_type {
@@ -27,5 +28,6 @@ message StateMessage {
     JointTorques joint_torques = 13;
     Shape shape = 14;
     Ellipsoid ellipsoid = 15;
+    Parameter parameter = 16;
   }
 }


### PR DESCRIPTION
Ok, this was a little bit more work / more lines of change than I originally anticipated.

I added support for the Parameter class to contain the following types:
- `double`
- `std::vector<double>`
- `bool`
- `std::vector<bool>`
- `std::string`
- `std::vector<std::string>`
- `Eigen::VectorXd`
- `Eigen::MatrixXd`

Because `state_representation::Parameter` is templated as a container, I had to bind each template explicitly. 250 lines of change in clproto.cpp is just that, copied binding for each type. The test file adds another 160 lines alone.

The significant implementations are done in the decoder / encoder helper functions that are templated for the parameter type. There are a few other cleanups that had to occur in these files make all the overloads and templates work nicely together.

I tried to contain meaningful chunks of change with each commit, but the tests obviously only pass when everything comes together. So, I recommend you go through one commit at a time in your review. Still, I can also split this into multiple PRs if desired, just let me know.

On the bright side, I feel the tests are comprehensive and they all pass :)