### PR TITLE
Revert templated en/decoders

### DIFF
--- a/.github/actions/build-test-protocol/entrypoint.sh
+++ b/.github/actions/build-test-protocol/entrypoint.sh
@@ -8,8 +8,9 @@ echo ">>> Building proto bindings..."
 cd /github/workspace/protocol/protobuf && make all || exit 2
 
 echo ">>> Configuring clproto_cpp cmake..."
-cd /github/workspace/protocol/clproto_cpp && mkdir build && cd build && cmake -DBUILD_TESTING=ON .. || \
-  (echo ">>> [ERROR] Configuration stage failed!" && exit 3) || exit $?
+cd /github/workspace/protocol/clproto_cpp && mkdir build && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=ON .. \
+  || (echo ">>> [ERROR] Configuration stage failed!" && exit 3) || exit $?
 
 echo ">>> Building clproto_cpp..."
 make all || (echo ">>> [ERROR] Build stage failed!" && exit 4) || exit $?

--- a/protocol/clproto_cpp/include/clproto/decoders.h
+++ b/protocol/clproto_cpp/include/clproto/decoders.h
@@ -1,27 +1,13 @@
 #pragma once
 
 #include <google/protobuf/repeated_field.h>
-#include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/parameters/parameter.pb.h>
 
-#include "clproto.h"
+#include <state_representation/State.hpp>
+#include <state_representation/parameters/Parameter.hpp>
+
+#include "state_representation/state_message.pb.h"
 
 namespace clproto {
-
-class DecoderNotImplementedException : public DecodingException {
-public:
-  explicit DecoderNotImplementedException(const std::string& msg);
-};
-
-/**
- * @brief Decoding helper method.
- * @tparam ObjT The control libraries output type
- * @tparam MsgT The protocol message input type
- * @param message The protocol message object
- * @return The equivalent decoded control libraries object
- */
-template<typename ObjT, typename MsgT>
-ObjT decoder(const MsgT& message);
 
 /**
  * @brief Decoding helper method for a RepeatedField message
@@ -52,11 +38,17 @@ std::vector<FieldT> decoder(const google::protobuf::RepeatedPtrField<FieldT>& me
 template<typename ParamT>
 state_representation::Parameter<ParamT> decoder(const state_representation::proto::Parameter& message);
 
-template<typename ObjT, typename MsgT>
-ObjT decoder(const MsgT&) {
-  throw DecoderNotImplementedException("Templated decoder function not implemented!");
-}
+/*
+ * Declarations for decoding helpers
+ */
+std::vector<bool> decoder(const google::protobuf::RepeatedField<bool>& message);
+state_representation::StateType decoder(const state_representation::proto::StateType& message);
+Eigen::Vector3d decoder(const state_representation::proto::Vector3d& message);
+Eigen::Quaterniond decoder(const state_representation::proto::Quaterniond& message);
 
+/*
+ * Definitions for templated RepeatedField methods
+ */
 template<typename FieldT>
 std::vector<FieldT> decoder(const google::protobuf::RepeatedField<FieldT>& message) {
   return {message.begin(), message.end()};
@@ -66,4 +58,5 @@ template<typename FieldT>
 std::vector<FieldT> decoder(const google::protobuf::RepeatedPtrField<FieldT>& message) {
   return {message.begin(), message.end()};
 }
+
 }

--- a/protocol/clproto_cpp/include/clproto/encoders.h
+++ b/protocol/clproto_cpp/include/clproto/encoders.h
@@ -1,25 +1,17 @@
 #pragma once
 
 #include <google/protobuf/repeated_field.h>
+
+#include <state_representation/State.hpp>
+#include <state_representation/space/SpatialState.hpp>
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/robot/Jacobian.hpp>
+#include <state_representation/robot/JointState.hpp>
 #include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/parameters/parameter.pb.h>
+
+#include "state_representation/state_message.pb.h"
 
 namespace clproto {
-
-class EncoderNotImplementedException : public std::runtime_error {
-public:
-  explicit EncoderNotImplementedException(const std::string& msg);
-};
-
-/**
- * @brief Encoding helper method.
- * @tparam MsgT The protocol message output type
- * @tparam ObjT The control libraries input type
- * @param object The control libraries object
- * @return The equivalent encoded protocol message object
- */
-template<typename MsgT, typename ObjT>
-MsgT encoder(const ObjT& object);
 
 /**
  * @brief Encoding helper method for the Parameter type.
@@ -46,16 +38,25 @@ google::protobuf::RepeatedField<FieldT> encoder(const std::vector<FieldT>& data)
  * @param matrix An Eigen matrix of data
  * @return The encoded RepeatedField protocol message object
  */
-google::protobuf::RepeatedField<double> encoder(const Eigen::MatrixXd& matrix);
+google::protobuf::RepeatedField<double> matrix_encoder(const Eigen::MatrixXd& matrix);
 
-template<typename MsgT, typename ObjT>
-MsgT encoder(const ObjT&) {
-  throw EncoderNotImplementedException("Templated encoder function not implemented!");
-}
+/*
+ * Declarations for encoding helpers
+ */
+state_representation::proto::StateType encoder(const state_representation::StateType& type);
+state_representation::proto::State encoder(const state_representation::State& state);
+state_representation::proto::SpatialState encoder(const state_representation::SpatialState& spatial_state);
+state_representation::proto::Vector3d encoder(const Eigen::Vector3d& vector);
+state_representation::proto::Quaterniond encoder(const Eigen::Quaterniond& quaternion);
+state_representation::proto::CartesianState encoder(const state_representation::CartesianState& cartesian_state);
+state_representation::proto::Jacobian encoder(const state_representation::Jacobian& jacobian);
+state_representation::proto::JointState encoder(const state_representation::JointState& joint_state);
 
+/*
+ * Definitions for templated RepeatedField methods
+ */
 template<typename FieldT>
 google::protobuf::RepeatedField<FieldT> encoder(const std::vector<FieldT>& data) {
   return google::protobuf::RepeatedField<FieldT>({data.begin(), data.end()});
 }
-
 }

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -72,7 +72,7 @@ bool decode(const std::string& msg, State& obj);
 template<>
 std::string encode<State>(const State& obj) {
   proto::StateMessage message;
-  *message.mutable_state() = encoder<proto::State>(obj);
+  *message.mutable_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -95,7 +95,7 @@ bool decode(const std::string& msg, State& obj) {
     }
 
     auto state = message.state();
-    obj = State(decoder<StateType>(state.type()), state.name(), state.empty());
+    obj = State(decoder(state.type()), state.name(), state.empty());
 
     //TODO: (maybe) add set_timestamp method to State and add decoder for int to chrono
     //obj.set_timestamp(state.timestamp());
@@ -118,7 +118,7 @@ bool decode(const std::string& msg, SpatialState& obj);
 template<>
 std::string encode<SpatialState>(const SpatialState& obj) {
   proto::StateMessage message;
-  *message.mutable_spatial_state() = encoder<proto::SpatialState>(obj);
+  *message.mutable_spatial_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -142,7 +142,7 @@ bool decode(const std::string& msg, SpatialState& obj) {
 
     auto spatial_state = message.spatial_state();
     obj = SpatialState(
-        decoder<StateType>(spatial_state.state().type()), spatial_state.state().name(), spatial_state.reference_frame(),
+        decoder(spatial_state.state().type()), spatial_state.state().name(), spatial_state.reference_frame(),
         spatial_state.state().empty());
 
     return true;
@@ -163,7 +163,7 @@ bool decode(const std::string& msg, CartesianState& obj);
 template<>
 std::string encode<CartesianState>(const CartesianState& obj) {
   proto::StateMessage message;
-  *message.mutable_cartesian_state() = encoder<proto::CartesianState>(obj);
+  *message.mutable_cartesian_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -188,14 +188,14 @@ bool decode(const std::string& msg, CartesianState& obj) {
     auto state = message.cartesian_state();
     obj.set_name(state.spatial_state().state().name());
     obj.set_reference_frame(state.spatial_state().reference_frame());
-    obj.set_position(decoder<Eigen::Vector3d>(state.position()));
-    obj.set_orientation(decoder<Eigen::Quaterniond, proto::Quaterniond>(state.orientation()));
-    obj.set_linear_velocity(decoder<Eigen::Vector3d>(state.linear_velocity()));
-    obj.set_angular_velocity(decoder<Eigen::Vector3d>(state.angular_velocity()));
-    obj.set_linear_acceleration(decoder<Eigen::Vector3d>(state.linear_acceleration()));
-    obj.set_angular_acceleration(decoder<Eigen::Vector3d>(state.angular_acceleration()));
-    obj.set_force(decoder<Eigen::Vector3d>(state.force()));
-    obj.set_torque(decoder<Eigen::Vector3d>(state.torque()));
+    obj.set_position(decoder(state.position()));
+    obj.set_orientation(decoder(state.orientation()));
+    obj.set_linear_velocity(decoder(state.linear_velocity()));
+    obj.set_angular_velocity(decoder(state.angular_velocity()));
+    obj.set_linear_acceleration(decoder(state.linear_acceleration()));
+    obj.set_angular_acceleration(decoder(state.angular_acceleration()));
+    obj.set_force(decoder(state.force()));
+    obj.set_torque(decoder(state.torque()));
     obj.set_empty(state.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -215,7 +215,7 @@ bool decode(const std::string& msg, CartesianPose& obj);
 template<>
 std::string encode<CartesianPose>(const CartesianPose& obj) {
   proto::StateMessage message;
-  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_pose()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_pose()->mutable_position() = cartesian_state.position();
   *message.mutable_cartesian_pose()->mutable_orientation() = cartesian_state.orientation();
@@ -242,8 +242,8 @@ bool decode(const std::string& msg, CartesianPose& obj) {
     auto pose = message.cartesian_pose();
     obj.set_name(pose.spatial_state().state().name());
     obj.set_reference_frame(pose.spatial_state().reference_frame());
-    obj.set_position(decoder<Eigen::Vector3d>(pose.position()));
-    obj.set_orientation(decoder<Eigen::Quaterniond, proto::Quaterniond>(pose.orientation()));
+    obj.set_position(decoder(pose.position()));
+    obj.set_orientation(decoder(pose.orientation()));
     obj.set_empty(pose.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -263,7 +263,7 @@ bool decode(const std::string& msg, CartesianTwist& obj);
 template<>
 std::string encode<CartesianTwist>(const CartesianTwist& obj) {
   proto::StateMessage message;
-  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_twist()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_twist()->mutable_linear_velocity() = cartesian_state.linear_velocity();
   *message.mutable_cartesian_twist()->mutable_angular_velocity() = cartesian_state.angular_velocity();
@@ -290,8 +290,8 @@ bool decode(const std::string& msg, CartesianTwist& obj) {
     auto twist = message.cartesian_twist();
     obj.set_name(twist.spatial_state().state().name());
     obj.set_reference_frame(twist.spatial_state().reference_frame());
-    obj.set_linear_velocity(decoder<Eigen::Vector3d>(twist.linear_velocity()));
-    obj.set_angular_velocity(decoder<Eigen::Vector3d>(twist.angular_velocity()));
+    obj.set_linear_velocity(decoder(twist.linear_velocity()));
+    obj.set_angular_velocity(decoder(twist.angular_velocity()));
     obj.set_empty(twist.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -311,7 +311,7 @@ bool decode(const std::string& msg, CartesianWrench& obj);
 template<>
 std::string encode<CartesianWrench>(const CartesianWrench& obj) {
   proto::StateMessage message;
-  auto cartesian_state = encoder<proto::CartesianState>(static_cast<CartesianState>(obj));
+  auto cartesian_state = encoder(static_cast<CartesianState>(obj));
   *message.mutable_cartesian_wrench()->mutable_spatial_state() = cartesian_state.spatial_state();
   *message.mutable_cartesian_wrench()->mutable_force() = cartesian_state.force();
   *message.mutable_cartesian_wrench()->mutable_torque() = cartesian_state.torque();
@@ -338,8 +338,8 @@ bool decode(const std::string& msg, CartesianWrench& obj) {
     auto wrench = message.cartesian_wrench();
     obj.set_name(wrench.spatial_state().state().name());
     obj.set_reference_frame(wrench.spatial_state().reference_frame());
-    obj.set_force(decoder<Eigen::Vector3d>(wrench.force()));
-    obj.set_torque(decoder<Eigen::Vector3d>(wrench.torque()));
+    obj.set_force(decoder(wrench.force()));
+    obj.set_torque(decoder(wrench.torque()));
     obj.set_empty(wrench.spatial_state().state().empty());
     return true;
   } catch (...) {
@@ -359,7 +359,7 @@ bool decode(const std::string& msg, Jacobian& obj);
 template<>
 std::string encode<Jacobian>(const Jacobian& obj) {
   proto::StateMessage message;
-  *message.mutable_jacobian() = encoder<proto::Jacobian>(obj);
+  *message.mutable_jacobian() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -385,8 +385,7 @@ bool decode(const std::string& msg, Jacobian& obj) {
     auto raw_data = const_cast<double*>(jacobian.data().data());
     auto data = Eigen::Map<Eigen::MatrixXd>(raw_data, jacobian.rows(), jacobian.cols());
     obj = Jacobian(
-        jacobian.state().name(), decoder<std::string>(jacobian.joint_names()), jacobian.frame(), data,
-        jacobian.reference_frame());
+        jacobian.state().name(), decoder(jacobian.joint_names()), jacobian.frame(), data, jacobian.reference_frame());
     return true;
   } catch (...) {
     return false;
@@ -405,7 +404,7 @@ bool decode(const std::string& msg, JointState& obj);
 template<>
 std::string encode<JointState>(const JointState& obj) {
   proto::StateMessage message;
-  *message.mutable_joint_state() = encoder<proto::JointState>(obj);
+  *message.mutable_joint_state() = encoder(obj);
   return message.SerializeAsString();
 }
 template<>
@@ -428,7 +427,7 @@ bool decode(const std::string& msg, JointState& obj) {
     }
 
     auto state = message.joint_state();
-    obj = JointState(state.state().name(), decoder<std::string>(state.joint_names()));
+    obj = JointState(state.state().name(), decoder(state.joint_names()));
     obj.set_positions(decoder(state.positions()));
     obj.set_velocities(decoder(state.velocities()));
     obj.set_accelerations(decoder(state.accelerations()));
@@ -452,7 +451,7 @@ bool decode(const std::string& msg, JointPositions& obj);
 template<>
 std::string encode<JointPositions>(const JointPositions& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_positions()->mutable_state() = joint_state.state();
   *message.mutable_joint_positions()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_positions()->mutable_positions() = joint_state.positions();
@@ -499,7 +498,7 @@ bool decode(const std::string& msg, JointVelocities& obj);
 template<>
 std::string encode<JointVelocities>(const JointVelocities& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_velocities()->mutable_state() = joint_state.state();
   *message.mutable_joint_velocities()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_velocities()->mutable_velocities() = joint_state.velocities();
@@ -546,7 +545,7 @@ bool decode(const std::string& msg, JointAccelerations& obj);
 template<>
 std::string encode<JointAccelerations>(const JointAccelerations& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_accelerations()->mutable_state() = joint_state.state();
   *message.mutable_joint_accelerations()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_accelerations()->mutable_accelerations() = joint_state.accelerations();
@@ -593,7 +592,7 @@ bool decode(const std::string& msg, JointTorques& obj);
 template<>
 std::string encode<JointTorques>(const JointTorques& obj) {
   proto::StateMessage message;
-  auto joint_state = encoder<proto::JointState>(static_cast<JointState>(obj));
+  auto joint_state = encoder(static_cast<JointState>(obj));
   *message.mutable_joint_torques()->mutable_state() = joint_state.state();
   *message.mutable_joint_torques()->mutable_joint_names() = joint_state.joint_names();
   *message.mutable_joint_torques()->mutable_torques() = joint_state.torques();

--- a/protocol/clproto_cpp/src/decoders.cpp
+++ b/protocol/clproto_cpp/src/decoders.cpp
@@ -1,31 +1,23 @@
 #include "clproto/decoders.h"
 
-#include "state_representation/state_message.pb.h"
-
 using namespace state_representation;
 
 namespace clproto {
 
-DecoderNotImplementedException::DecoderNotImplementedException(const std::string& msg) : DecodingException(msg) {}
-
-template<>
 std::vector<bool> decoder(const google::protobuf::RepeatedField<bool>& message) {
   // explicit construction is needed for the bool vector due to stl optimisations
   std::vector<bool> vec(message.begin(), message.end());
   return vec;
 }
 
-template<>
 StateType decoder(const proto::StateType& message) {
   return static_cast<StateType>(message);
 }
 
-template<>
 Eigen::Vector3d decoder(const proto::Vector3d& message) {
   return {message.x(), message.y(), message.z()};
 }
 
-template<>
 Eigen::Quaterniond decoder(const proto::Quaterniond& message) {
   return {message.w(), message.vec().x(), message.vec().y(), message.vec().z()};
 }

--- a/protocol/clproto_cpp/src/encoders.cpp
+++ b/protocol/clproto_cpp/src/encoders.cpp
@@ -1,47 +1,33 @@
 #include "clproto/encoders.h"
 
-#include <state_representation/State.hpp>
-#include <state_representation/space/SpatialState.hpp>
-#include <state_representation/space/cartesian/CartesianState.hpp>
-#include <state_representation/robot/Jacobian.hpp>
-#include <state_representation/robot/JointState.hpp>
-
-#include "state_representation/state_message.pb.h"
-
 using namespace state_representation;
 
 namespace clproto {
 
-EncoderNotImplementedException::EncoderNotImplementedException(const std::string& msg) : std::runtime_error(msg) {}
-
-google::protobuf::RepeatedField<double> encoder(const Eigen::MatrixXd& matrix) {
+google::protobuf::RepeatedField<double> matrix_encoder(const Eigen::MatrixXd& matrix) {
   return encoder(std::vector<double>{matrix.data(), matrix.data() + matrix.size()});
 }
 
-template<>
 proto::StateType encoder(const StateType& type) {
   return static_cast<proto::StateType>(type);
 }
 
-template<>
 proto::State encoder(const State& state) {
   proto::State message;
   message.set_name(state.get_name());
-  message.set_type(encoder<proto::StateType>(state.get_type()));
+  message.set_type(encoder(state.get_type()));
   message.set_empty(state.is_empty());
   message.set_timestamp(state.get_timestamp().time_since_epoch().count());
   return message;
 }
 
-template<>
 proto::SpatialState encoder(const SpatialState& spatial_state) {
   proto::SpatialState message;
-  *message.mutable_state() = encoder<proto::State>(static_cast<State>(spatial_state));
+  *message.mutable_state() = encoder(static_cast<State>(spatial_state));
   message.set_reference_frame(spatial_state.get_reference_frame());
   return message;
 }
 
-template<>
 proto::Vector3d encoder(const Eigen::Vector3d& vector) {
   proto::Vector3d message;
   message.set_x(vector.x());
@@ -50,67 +36,62 @@ proto::Vector3d encoder(const Eigen::Vector3d& vector) {
   return message;
 }
 
-template<>
 proto::Quaterniond encoder(const Eigen::Quaterniond& quaternion) {
   proto::Quaterniond message;
   message.set_w(quaternion.w());
-  *message.mutable_vec() = encoder<proto::Vector3d>(Eigen::Vector3d(quaternion.vec()));
+  *message.mutable_vec() = encoder(Eigen::Vector3d(quaternion.vec()));
   return message;
 }
 
-template<>
 proto::CartesianState encoder(const CartesianState& cartesian_state) {
   proto::CartesianState message;
-  *message.mutable_spatial_state() = encoder<proto::SpatialState>(static_cast<SpatialState>(cartesian_state));
-  *message.mutable_position() = encoder<proto::Vector3d>(cartesian_state.get_position());
-  *message.mutable_orientation() = encoder<proto::Quaterniond>(cartesian_state.get_orientation());
-  *message.mutable_linear_velocity() = encoder<proto::Vector3d>(cartesian_state.get_linear_velocity());
-  *message.mutable_angular_velocity() = encoder<proto::Vector3d>(cartesian_state.get_angular_velocity());
-  *message.mutable_linear_acceleration() = encoder<proto::Vector3d>(cartesian_state.get_linear_acceleration());
-  *message.mutable_angular_acceleration() = encoder<proto::Vector3d>(cartesian_state.get_angular_acceleration());
-  *message.mutable_force() = encoder<proto::Vector3d>(cartesian_state.get_force());
-  *message.mutable_torque() = encoder<proto::Vector3d>(cartesian_state.get_torque());
+  *message.mutable_spatial_state() = encoder(static_cast<SpatialState>(cartesian_state));
+  *message.mutable_position() = encoder(cartesian_state.get_position());
+  *message.mutable_orientation() = encoder(cartesian_state.get_orientation());
+  *message.mutable_linear_velocity() = encoder(cartesian_state.get_linear_velocity());
+  *message.mutable_angular_velocity() = encoder(cartesian_state.get_angular_velocity());
+  *message.mutable_linear_acceleration() = encoder(cartesian_state.get_linear_acceleration());
+  *message.mutable_angular_acceleration() = encoder(cartesian_state.get_angular_acceleration());
+  *message.mutable_force() = encoder(cartesian_state.get_force());
+  *message.mutable_torque() = encoder(cartesian_state.get_torque());
   return message;
 }
 
-template<>
 proto::Jacobian encoder(const Jacobian& jacobian) {
   proto::Jacobian message;
-  *message.mutable_state() = encoder<proto::State>(static_cast<State>(jacobian));
+  *message.mutable_state() = encoder(static_cast<State>(jacobian));
   *message.mutable_joint_names() = {jacobian.get_joint_names().begin(), jacobian.get_joint_names().end()};
   message.set_frame(jacobian.get_frame());
   message.set_reference_frame(jacobian.get_reference_frame());
   message.set_rows(jacobian.rows());
   message.set_cols(jacobian.cols());
-  *message.mutable_data() = encoder(jacobian.data());
+  *message.mutable_data() = matrix_encoder(jacobian.data());
   return message;
 }
 
-template<>
 proto::JointState encoder(const JointState& joint_state) {
   proto::JointState message;
-  *message.mutable_state() = encoder<proto::State>(static_cast<State>(joint_state));
+  *message.mutable_state() = encoder(static_cast<State>(joint_state));
   *message.mutable_joint_names() = {joint_state.get_names().begin(), joint_state.get_names().end()};
-  *message.mutable_positions() = encoder(joint_state.get_positions());
-  *message.mutable_velocities() = encoder(joint_state.get_velocities());
-  *message.mutable_accelerations() = encoder(joint_state.get_accelerations());
-  *message.mutable_torques() = encoder(joint_state.get_torques());
+  *message.mutable_positions() = matrix_encoder(joint_state.get_positions());
+  *message.mutable_velocities() = matrix_encoder(joint_state.get_velocities());
+  *message.mutable_accelerations() = matrix_encoder(joint_state.get_accelerations());
+  *message.mutable_torques() = matrix_encoder(joint_state.get_torques());
   return message;
 }
 
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<double>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   message.mutable_parameter_value()->mutable_double_()->set_value(parameter.get_value());
   return message;
 }
+
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<std::vector<double>>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   *message.mutable_parameter_value()->mutable_double_array()->mutable_value() =
       {parameter.get_value().begin(), parameter.get_value().end()};
   return message;
@@ -118,16 +99,14 @@ state_representation::proto::Parameter encoder(const state_representation::Param
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<bool>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   message.mutable_parameter_value()->mutable_bool_()->set_value(parameter.get_value());
   return message;
 }
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<std::vector<bool>>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   *message.mutable_parameter_value()->mutable_bool_array()->mutable_value() =
       {parameter.get_value().begin(), parameter.get_value().end()};
   return message;
@@ -135,8 +114,7 @@ state_representation::proto::Parameter encoder(const state_representation::Param
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<std::string>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   message.mutable_parameter_value()->mutable_string()->set_value(parameter.get_value());
   return message;
 }
@@ -144,8 +122,7 @@ template<>
 state_representation::proto::Parameter
 encoder(const state_representation::Parameter<std::vector<std::string>>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
   *message.mutable_parameter_value()->mutable_string_array()->mutable_value() =
       {parameter.get_value().begin(), parameter.get_value().end()};
   return message;
@@ -153,18 +130,16 @@ encoder(const state_representation::Parameter<std::vector<std::string>>& paramet
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<Eigen::VectorXd>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
-  *message.mutable_parameter_value()->mutable_vector()->mutable_value() = encoder(parameter.get_value());
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
+  *message.mutable_parameter_value()->mutable_vector()->mutable_value() = matrix_encoder(parameter.get_value());
   return message;
 }
 
 template<>
 state_representation::proto::Parameter encoder(const state_representation::Parameter<Eigen::MatrixXd>& parameter) {
   state_representation::proto::Parameter message;
-  *message.mutable_state() =
-      encoder<state_representation::proto::State>(static_cast<state_representation::State>(parameter));
-  *message.mutable_parameter_value()->mutable_matrix()->mutable_value() = encoder(parameter.get_value());
+  *message.mutable_state() = encoder(static_cast<state_representation::State>(parameter));
+  *message.mutable_parameter_value()->mutable_matrix()->mutable_value() = matrix_encoder(parameter.get_value());
   message.mutable_parameter_value()->mutable_matrix()->set_rows(parameter.get_value().rows());
   message.mutable_parameter_value()->mutable_matrix()->set_cols(parameter.get_value().cols());
   return message;


### PR DESCRIPTION
* Remove templated encoder and decoder helper methods (of the form `MsgT encode(ObjT)` and `ObjT decode(MsgT)` in favor of explicitly declared and overloaded methods. This is because in release build, the templated function definitions
get lost without additional forward declaration / special instantiation. This would make template usage far more verbose than necessary, and so it is easier just to declare the overloaded methods in the respective helper header files.

* Remove `Encoder/DecoderNotImplemented` exceptions since the templates have been removed

* Update calls to `encoder` / `decoder` to remove template specifications

* CI workflow to test in release build

--- 

I was using the latest branch of clproto while refactoring franka lwi, when I realised the [earlier PR](https://github.com/epfl-lasa/control_libraries/pull/180) I made for "cleaning up clproto" actually broke the release build. Due to optimisations in release build configuration, the templated helper function definitions get lost, leading to segmentation faults. I don't want to push these changes directly to the previous PR since it's already so big, but it would also be a bit of a pain to rebase the other PR on top of this commit. I figured I could show the changes here, see that the CI tests pass in release build also, and then merge onto the previous feature branch before reviewing and closing that one.