### PR TITLE
Pack / unpack methods in clproto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Release Versions:
 
 - Protobuf message protocol and C++ binding library `clproto` for
 serializing and deserializing control library objects (#168, #175, #177, #179, #180)
+- Methods for packing and unpacking multiple encoded state messages
+into serialized message packets (#181)
 - Add set_data function (#163)
 - Move set_data declaration to State and add it for Ellipsoid (#166)
 - Add automatic documentation generation and deployment to GitHub Pages (#170)

--- a/protocol/clproto_cpp/README.md
+++ b/protocol/clproto_cpp/README.md
@@ -40,3 +40,107 @@ if (!clproto::is_valid(message)) {
 clproto::MessageType type = clproto::check_message_type(msg);
 
 ```
+
+## Combining multiple message into a packet
+
+The serialized binary string encoding of a state message is not self-delimiting.
+The consequence of this is that when multiple encoded messages are combined on the wire,
+it is not possible to know where the first message ends and the second one starts.
+
+There will often be cases where it makes sense to combine multiple state messages 
+into one high level message packet. For example, a robot might broadcast the `CartesianState`
+of its end-effector together with its `JointState`. A client controller might want to listen
+for the combined "Robot State" on a single subscription topic.
+
+```c++
+#include <clproto.h>
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/robot/JointState.hpp>
+
+using namespace state_representation;
+
+// A robot can produce multiple state messages
+auto cart_state = CartesianState::Random("robot_ee", "robot_base");
+auto joint_state = JointState::Random("robot", 7);
+
+// Encode each state variable and add them to an ordered vector
+std::vector<std::string> encoded_robot_state;
+encoded_robot_state.emplace_back(clproto::encode(cart_state));
+encoded_robot_state.emplace_back(clproto::encode(joint_state));
+
+// Pack the message fields into a raw data buffer,
+// reserving sufficient space to contain all messages
+char encoded_packet_buffer[2 * CLPROTO_PACKING_MAX_FIELD_LENGTH];
+clproto::pack_fields(encoded_robot_state, encoded_packet_buffer);
+
+// The message fields can also be packed into a std::string,
+// provided that sufficient space is reserved for all messages
+std::string encoded_packet_str();
+encoded_packet_str.reserve(2 * CLPROTO_PACKING_MAX_FIELD_LENGTH);
+clproto::pack_fields(encoded_robot_state, encoded_packet_str.data());
+
+// Unpack a combined message packet back into an ordered vector of encoded state variables
+std::vector<std::string> unpacked_encoded_robot_state = clproto::unpack(encoded_packet_buffer);
+// (or, for a string type encoded packet:)
+unpacked_encoded_robot_state = clproto::unpack(encoded_packet_str.c_str());
+
+// Finally, decode the encoded fields in the same order as the original packing
+auto decoded_cart_state = clproto::decode<CartesianState>(unpacked_encoded_robot_state.at(0));
+auto decoded_joint_state = clproto::decode<JointState>(unpacked_encoded_robot_state.at(1));
+```
+
+The pack / unpack methods are provided as a convenience only for simple synthesis of messages
+from core state message types. The communication implementation can always be extended further
+by the end user as necessary, for example to prepend an indication of the field types to the message, 
+or to add other delimiting behaviour.
+
+### ZMQ example
+
+The packing and unpacking of the message should be handled according to the network requirements.
+This sections shows an example for ZMQ messaging.
+
+```c++
+
+#include <zmq.h>
+
+// Combine encoded state messages into an ordered vector
+std::vector<std::string> encoded_robot_state = ...;
+
+// Pack and publish the combined state messages, assuming a pre-configured publishing socket
+zmq::socket_t publisher;
+zmq::message_t zmq_message(encoded_robot_state.size() * CLPROTO_PACKING_MAX_FIELD_LENGTH);
+pack_fields(encoded_robot_state, static_cast<char *>(zmq_message.data()));
+publisher.send(zmq_message, zmq::send_flags::none);
+
+// On the receiving side, cast the message data to a char pointer before unpacking
+zmq::message_t received_zmq_message;
+zmq::socket_t subscriber;
+auto result = subscriber.recv(received_zmq_message);
+if (result) {
+  received_encoded_robot_state = unpack_fields(static_cast<const char*>(received_zmq_message.data()));
+}
+```
+
+### Reserving packet size
+Note that, because the packing function writes to a buffer through a raw pointer, the associated
+buffer must have enough reserved size to contain the entire packet. For simplicity, the
+message size can be reserved as `number_of_fields * CLPROTO_PACKING_MAX_FIELD_LENGTH`, but
+this is almost much larger than necessary. Since the resultant packed data is not self-delimiting,
+the actual data length cannot be calculated post-hoc. 
+
+If bandwidth is limited, the following formula can be used to calculate the minimum needed buffer size.
+
+```c++
+std::vector<std::string> encoded_fields = ...;
+
+// The packet header starts with N + 1 values of size proto::field_length_t,
+// where N is the number of fields N. The first value stores the number of fields,
+// while the following N values store the data length of each respective field.
+std::size_t packet_size = sizeof(proto::field_length_t) * encoded_fields.size();
+
+// Add the size of each field
+for (const auto& field : encoded_fields) {
+  packet_size += field.size();
+}
+
+```

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -2,8 +2,20 @@
 
 #include <stdexcept>
 #include <string>
+#include <vector>
+
+#define CLPROTO_PACKING_MAX_FIELD_LENGTH (4096)
+#define CLPROTO_PACKING_MAX_FIELDS (64)
 
 namespace clproto {
+
+/**
+ * @typedef field_length_t
+ * @brief Size type used to indicate number of fields
+ * and field data length in ::pack_fields() and
+ * ::unpack_fields() methods
+ */
+typedef std::size_t field_length_t;
 
 /**
  * @class DecodingException
@@ -123,5 +135,33 @@ T decode(const std::string& msg);
  */
 template<typename T>
 bool decode(const std::string& msg, T& obj);
+
+/**
+ * @brief Pack an ordered vector of encoded field messages into a single data array.
+ * @details To send multiple messages in one packet, there must
+ * be some delimiting logic to distinguish the end of one field from the
+ * start of the next. This packing function encodes the number of fields (N)
+ * as the first data entry in the packet, then the size of each field in the
+ * next N data entries, followed by the raw concatenated data of each field.
+ * The order of the original vector is preserved. The corresponding
+ * ::unpack_fields() method can be used to restore the original vector
+ * of fields from the data buffer.
+ * @param fields An ordered vector of encoded message fields
+ * @param[out] data A raw data array to be packed with the fields
+ */
+void pack_fields(const std::vector<std::string>& fields, char* data);
+
+/**
+ * @brief Unpack a data array into an ordered vector of encoded field messages.
+ * @details A buffer of encoded fields serialized by ::pack_fields()
+ * can be unpacked by this method. It expects the first data entry
+ * in the data buffer to contain the number of fields (N). The next
+ * N data entries then must contain the data length of each subsequent
+ * field. Finally, the rest of the data is broken into ordered fields
+ * based on the interpreted field data lengths.
+ * @param data A raw data array that has been packed by ::pack_fields()
+ * @return An ordered vector of encoded message fields
+ */
+std::vector<std::string> unpack_fields(const char* data);
 
 }

--- a/protocol/clproto_cpp/test/tests/test_packing.cpp
+++ b/protocol/clproto_cpp/test/tests/test_packing.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/robot/Jacobian.hpp>
+#include <state_representation/robot/JointState.hpp>
+
+#include "clproto.h"
+
+using namespace state_representation;
+
+class PackUnpackTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    cart_state_ = CartesianState::Random("robot_ee", "robot_base");
+    joint_state_ = JointState::Random("robot", 7);
+    jacobian_ = Jacobian("robot", 7, "robot_ee", "robot_base");
+  }
+
+  std::vector<std::string> combine_state_message() {
+    std::vector<std::string> message_fields;
+    message_fields.emplace_back(clproto::encode(cart_state_));
+    message_fields.emplace_back(clproto::encode(joint_state_));
+    message_fields.emplace_back(clproto::encode(jacobian_));
+    return message_fields;
+  }
+
+  void validate_state_messages(const std::vector<std::string>& message_fields) {
+    ASSERT_EQ(message_fields.size(), nfields_);
+
+    CartesianState decoded_cart_state;
+    EXPECT_TRUE(clproto::is_valid(message_fields.at(0)));
+    EXPECT_TRUE(clproto::check_message_type(message_fields.at(0)) == clproto::CARTESIAN_STATE_MESSAGE);
+    EXPECT_NO_THROW(decoded_cart_state = clproto::decode<CartesianState>(message_fields.at(0)));
+    EXPECT_STREQ(decoded_cart_state.get_name().c_str(), cart_state_.get_name().c_str());
+
+    JointState decoded_joint_state;
+    EXPECT_TRUE(clproto::is_valid(message_fields.at(1)));
+    EXPECT_TRUE(clproto::check_message_type(message_fields.at(1)) == clproto::JOINT_STATE_MESSAGE);
+    EXPECT_NO_THROW(decoded_joint_state = clproto::decode<JointState>(message_fields.at(1)));
+    EXPECT_STREQ(decoded_joint_state.get_name().c_str(), decoded_joint_state.get_name().c_str());
+
+    Jacobian decoded_jacobian;
+    EXPECT_TRUE(clproto::is_valid(message_fields.at(2)));
+    EXPECT_TRUE(clproto::check_message_type(message_fields.at(2)) == clproto::JACOBIAN_MESSAGE);
+    EXPECT_NO_THROW(decoded_jacobian = clproto::decode<Jacobian>(message_fields.at(2)));
+    EXPECT_STREQ(decoded_jacobian.get_name().c_str(), jacobian_.get_name().c_str());
+  }
+
+private:
+  const int nfields_ = 3;
+  CartesianState cart_state_;
+  JointState joint_state_;
+  Jacobian jacobian_;
+};
+
+TEST_F(PackUnpackTest, PackUnpackDataBuffer) {
+  // combine some messages into a vector
+  auto message_fields = combine_state_message();
+
+  // pack the message fields into a raw char buffer
+  char data_buffer[3 * CLPROTO_PACKING_MAX_FIELD_LENGTH];
+  clproto::pack_fields(message_fields, data_buffer);
+
+  // unpack message
+  auto unpacked_fields = clproto::unpack_fields(data_buffer);
+  validate_state_messages(unpacked_fields);
+}
+
+TEST_F(PackUnpackTest, PackUnpackStringBuffer) {
+  // combine some messages into a vector
+  auto message_fields = combine_state_message();
+
+  // pack the message fields into a std string
+  std::string encoded_packet;
+  encoded_packet.reserve(2 * CLPROTO_PACKING_MAX_FIELD_LENGTH);
+  clproto::pack_fields(message_fields, encoded_packet.data());
+
+  // unpack and validate message
+  auto unpacked_fields = clproto::unpack_fields(encoded_packet.c_str());
+  validate_state_messages(unpacked_fields);
+}


### PR DESCRIPTION
* Add clproto methods to pack_fields
and unpack_fields

* Add tests for packing and unpacking
using char buffers and string

* Extend README with pack / unpack
information and ZMQ messaging example

---

This was tested in action on the franka, and works great! It makes sense to me to have these convenient utilities in the library itself to make it as easy as possible for any end user to compose packets of multiple state message.