### PR TITLE
Remove deprecated from_std_vector function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ into serialized message packets (#182)
 - Install tagged versions of osqp and osqpEigen (#184)
 - Refactor JointState tests and split them into separate test suites (#183)
 - Add missing integration constructor from JointAccelerations for JointVelocities (#185)
+- Remove previously deprecated from_std_vector function (#186)
 
 ### Pending TODOs for the next release
 

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -113,7 +113,6 @@ void cartesian_state(py::module_& m) {
   c.def("normalized", &CartesianState::normalized, "Compute the normalized state at the state variable given in argument (default is full state)", "state_variable_type"_a=CartesianStateVariable::ALL);
 
   c.def("to_list", &CartesianState::to_std_vector, "Return the state as a list");
-  c.def("from_list", &CartesianState::from_std_vector, "Set the state from a list");
 
   c.def("__repr__", [](const CartesianState& state) {
     std::stringstream buffer;

--- a/python/source/state_representation/bind_joint_space.cpp
+++ b/python/source/state_representation/bind_joint_space.cpp
@@ -76,7 +76,6 @@ void joint_state(py::module_& m) {
   c.def("dist", &JointState::dist, "Compute the distance to another state as the sum of distances between each features", "state"_a, "state_variable_type"_a=JointStateVariable::ALL);
 
   c.def("to_list", &JointState::to_std_vector, "Return the state as a list");
-  c.def("from_list", &JointState::from_std_vector, "Set the state from a list");
 
   c.def("__repr__", [](const JointState& state) {
     std::stringstream buffer;
@@ -134,8 +133,6 @@ void joint_positions(py::module_& m) {
   c.def("data", &JointPositions::data, "Returns the positions data as a vector");
   c.def("set_data", py::overload_cast<const Eigen::VectorXd&>(&JointPositions::set_data), "Set the positions data from a vector", "data"_a);
   c.def("set_data", py::overload_cast<const std::vector<double>&>(&JointPositions::set_data), "Set the positions data from a list", "data"_a);
-
-  c.def("from_list", &JointPositions::from_std_vector, "Set the value from a list");
 
   c.def("__repr__", [](const JointPositions& positions) {
     std::stringstream buffer;

--- a/python/test/test_cartesian_state.py
+++ b/python/test/test_cartesian_state.py
@@ -11,7 +11,6 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
     'data',
     'set_data',
     'dist',
-    'from_list',
     'get_accelerations',
     'get_angular_acceleration',
     'get_angular_velocity',

--- a/python/test/test_joint_state.py
+++ b/python/test/test_joint_state.py
@@ -10,7 +10,6 @@ JOINT_STATE_METHOD_EXPECTS = [
     'data',
     'set_data',
     'dist',
-    'from_list',
     'get_accelerations',
     'get_name',
     'get_names',

--- a/source/state_representation/include/state_representation/geometry/Ellipsoid.hpp
+++ b/source/state_representation/include/state_representation/geometry/Ellipsoid.hpp
@@ -111,12 +111,6 @@ public:
   const std::vector<double> to_std_vector() const;
 
   /**
-   * @brief Create an ellipsoid from an std vector representation of its parameter
-   * @param an std vector with [center_position, rotation_angle, axis_lengths]
-   */
-  [[deprecated]] void from_std_vector(const std::vector<double>& parameters);
-
-  /**
    * @brief Set the ellipsoid data from an Eigen vector
    * @param the data vector with [center_position, rotation_angle, axis_lengths]
    */
@@ -183,12 +177,6 @@ inline const std::vector<double> Ellipsoid::to_std_vector() const {
   representation[4] = this->get_axis_length(0);
   representation[5] = this->get_axis_length(1);
   return representation;
-}
-
-inline void Ellipsoid::from_std_vector(const std::vector<double>& parameters) {
-  this->set_center_position(Eigen::Vector3d(parameters[0], parameters[1], parameters[2]));
-  this->set_rotation_angle(parameters[3]);
-  this->set_axis_lengths({parameters[4], parameters[5]});
 }
 
 inline const CartesianPose Ellipsoid::get_rotation() const {

--- a/source/state_representation/include/state_representation/geometry/Ellipsoid.hpp
+++ b/source/state_representation/include/state_representation/geometry/Ellipsoid.hpp
@@ -89,9 +89,9 @@ public:
    * @brief Compute an ellipsoid from its algebraic equation ax2 + bxy + cy2 + cx + ey + f
    * @return the Ellipsoid in its geometric representation
    */
-  static const Ellipsoid from_algebraic_equation(const std::string& name,
-                                                 const std::vector<double>& coefficients,
-                                                 const std::string& reference_frame = "world");
+  static const Ellipsoid from_algebraic_equation(
+      const std::string& name, const std::vector<double>& coefficients, const std::string& reference_frame = "world"
+  );
 
   /**
    * @brief Fit an ellipsoid on a set of points
@@ -99,10 +99,10 @@ public:
    * Fitzgibbon, A., et al. (1999). "Direct least square fitting of ellipses."
     * IEEE Transactions on pattern analysis and machine intelligence 21(5)
    */
-  static const Ellipsoid fit(const std::string& name,
-                             const std::list<CartesianPose>& points,
-                             const std::string& reference_frame = "world",
-                             double noise_level = 0.01);
+  static const Ellipsoid fit(
+      const std::string& name, const std::list<CartesianPose>& points, const std::string& reference_frame = "world",
+      double noise_level = 0.01
+  );
 
   /**
    * @brief Convert the ellipse to an std vector representation of its parameter
@@ -181,9 +181,8 @@ inline const std::vector<double> Ellipsoid::to_std_vector() const {
 
 inline const CartesianPose Ellipsoid::get_rotation() const {
   Eigen::Quaterniond rotation(Eigen::AngleAxisd(this->rotation_angle_, Eigen::Vector3d::UnitZ()));
-  return CartesianPose(this->get_center_pose().get_name() + "_rotated",
-                       Eigen::Vector3d::Zero(),
-                       rotation,
-                       this->get_center_pose().get_name());
+  return CartesianPose(
+      this->get_center_pose().get_name() + "_rotated", Eigen::Vector3d::Zero(), rotation,
+      this->get_center_pose().get_name());
 }
 }

--- a/source/state_representation/include/state_representation/robot/JointPositions.hpp
+++ b/source/state_representation/include/state_representation/robot/JointPositions.hpp
@@ -293,11 +293,5 @@ public:
    * @return the JointPositions provided multiply by lambda
    */
   friend JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& positions);
-
-  /**
-   * @brief Set the value from a std vector
-   * @param value the value as a std vector
-   */
-  [[deprecated]] void from_std_vector(const std::vector<double>& value);
 };
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/robot/JointState.hpp
+++ b/source/state_representation/include/state_representation/robot/JointState.hpp
@@ -447,12 +447,6 @@ public:
    * @return std::vector<float> the joint vector as a std vector
    */
   std::vector<double> to_std_vector() const;
-
-  /**
-   * @brief Set the value from a std vector
-   * @param value the value as a std vector
-   */
-  [[deprecated]] virtual void from_std_vector(const std::vector<double>& value);
 };
 
 inline void swap(JointState& state1, JointState& state2) {

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -70,9 +70,9 @@ public:
    * @param position the position data given as Eigen vector
    * @param reference the name of the reference frame (default is "world")
    */
-  explicit CartesianPose(const std::string& name,
-                         const Eigen::Vector3d& position,
-                         const std::string& reference = "world");
+  explicit CartesianPose(
+      const std::string& name, const Eigen::Vector3d& position, const std::string& reference = "world"
+  );
 
   /**
    * @brief Constructor of a CartesianPose from a position given as three scalar coordinates
@@ -82,11 +82,9 @@ public:
    * @param z the z coordinate of the position
    * @param reference the name of the reference frame (default is "world")
    */
-  explicit CartesianPose(const std::string& name,
-                         double x,
-                         double y,
-                         double z,
-                         const std::string& reference = "world");
+  explicit CartesianPose(
+      const std::string& name, double x, double y, double z, const std::string& reference = "world"
+  );
 
   /**
    * @brief Constructor of a CartesianPose from a quaternion
@@ -94,9 +92,9 @@ public:
    * @param orientation the orientation given as Eigen quaternion
    * @param reference the name of the reference frame (default is "world")
    */
-  explicit CartesianPose(const std::string& name,
-                         const Eigen::Quaterniond& orientation,
-                         const std::string& reference = "world");
+  explicit CartesianPose(
+      const std::string& name, const Eigen::Quaterniond& orientation, const std::string& reference = "world"
+  );
 
   /**
    * @brief Constructor of a CartesianPose from a position given as a vector of coordinates and a quaternion
@@ -105,10 +103,10 @@ public:
    * @param orientation the orientation given as Eigen quaternion
    * @param reference the name of the reference frame (default is "world")
    */
-  explicit CartesianPose(const std::string& name,
-                         const Eigen::Vector3d& position,
-                         const Eigen::Quaterniond& orientation,
-                         const std::string& reference = "world");
+  explicit CartesianPose(
+      const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation,
+      const std::string& reference = "world"
+  );
 
   /**
    * @brief Constructor for the identity pose
@@ -253,7 +251,8 @@ public:
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector
    */
-  std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::POSE) const override;
+  std::vector<double>
+  norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::POSE) const override;
 
   /**
    * @brief Compute the inverse of the current CartesianPose

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -289,12 +289,6 @@ public:
    * @return the CartesianPose provided multiplied by lambda
    */
   friend CartesianPose operator*(double lambda, const CartesianPose& pose);
-
-  /**
-   * @brief Set the value from a std vector
-   * @param value the value as a std vector
-   */
-  [[deprecated]] void from_std_vector(const std::vector<double>& value) override;
 };
 
 inline std::vector<double> CartesianPose::norms(const CartesianStateVariable& state_variable_type) const {

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -512,12 +512,6 @@ public:
    * @return std::vector<double> the state vector as a std vector
    */
   std::vector<double> to_std_vector() const;
-
-  /**
-   * @brief Set the value from a std vector
-   * @param value the value as a std vector
-   */
-  [[deprecated]] virtual void from_std_vector(const std::vector<double>& value);
 };
 
 inline void swap(CartesianState& state1, CartesianState& state2) {

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -166,7 +166,7 @@ std::ostream& operator<<(std::ostream& os, const JointPositions& positions) {
   } else {
     os << positions.get_name() << " JointPositions" << std::endl;
     os << "names: [";
-    for (auto& n : positions.get_names()) { os << n << ", "; }
+    for (auto& n: positions.get_names()) { os << n << ", "; }
     os << "]" << std::endl;
     os << "positions: [";
     for (unsigned int i = 0; i < positions.get_size(); ++i) { os << positions.get_positions()(i) << ", "; }

--- a/source/state_representation/src/robot/JointPositions.cpp
+++ b/source/state_representation/src/robot/JointPositions.cpp
@@ -192,8 +192,4 @@ JointPositions operator*(const Eigen::MatrixXd& lambda, const JointPositions& po
   result *= lambda;
   return result;
 }
-
-void JointPositions::from_std_vector(const std::vector<double>& value) {
-  this->set_positions(value);
-}
 }// namespace state_representation

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -299,8 +299,4 @@ JointState operator*(const Eigen::ArrayXd& lambda, const JointState& state) {
   result *= lambda;
   return result;
 }
-
-void JointState::from_std_vector(const std::vector<double>&) {
-  throw NotImplementedException("from_std_vector() is not implemented for the base JointState class");
-}
 }// namespace state_representation

--- a/source/state_representation/src/robot/JointState.cpp
+++ b/source/state_representation/src/robot/JointState.cpp
@@ -223,8 +223,7 @@ void JointState::clamp_state_variable(
   int expected_size = state_variable.size();
   this->clamp_state_variable(
       max_absolute_value * Eigen::ArrayXd::Ones(expected_size), state_variable_type,
-      noise_ratio * Eigen::ArrayXd::Ones(expected_size)
-  );
+      noise_ratio * Eigen::ArrayXd::Ones(expected_size));
 }
 
 double JointState::dist(const JointState& state, const JointStateVariable& state_variable_type) const {
@@ -259,7 +258,7 @@ std::ostream& operator<<(std::ostream& os, const JointState& state) {
   } else {
     os << state.get_name() << " JointState" << std::endl;
     os << "names: [";
-    for (auto& n : state.names_) { os << n << ", "; }
+    for (auto& n: state.names_) { os << n << ", "; }
     os << "]" << std::endl;
     os << "positions: [";
     for (unsigned int i = 0; i < state.positions_.size(); ++i) { os << state.positions_(i) << ", "; }

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -179,16 +179,4 @@ CartesianPose operator*(const CartesianState& state, const CartesianPose& pose) 
 CartesianPose operator*(double lambda, const CartesianPose& pose) {
   return pose * lambda;
 }
-
-void CartesianPose::from_std_vector(const std::vector<double>& value) {
-  if (value.size() == 3) {
-    this->set_position(value);
-  } else if (value.size() == 4) {
-    this->set_orientation(value);
-  } else if (value.size() == 7) {
-    this->set_pose(value);
-  } else {
-    throw IncompatibleSizeException("The input vector is of incorrect size");
-  }
-}
 }// namespace state_representation

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -12,24 +12,22 @@ CartesianPose::CartesianPose(const std::string& name, const Eigen::Vector3d& pos
   this->set_position(position);
 }
 
-CartesianPose::CartesianPose(const std::string& name,
-                             double x,
-                             double y,
-                             double z,
-                             const std::string& reference) : CartesianState(name, reference) {
+CartesianPose::CartesianPose(
+    const std::string& name, double x, double y, double z, const std::string& reference
+) : CartesianState(name, reference) {
   this->set_position(x, y, z);
 }
 
-CartesianPose::CartesianPose(const std::string& name,
-                             const Eigen::Quaterniond& orientation,
-                             const std::string& reference) : CartesianState(name, reference) {
+CartesianPose::CartesianPose(
+    const std::string& name, const Eigen::Quaterniond& orientation, const std::string& reference
+) : CartesianState(name, reference) {
   this->set_orientation(orientation);
 }
 
-CartesianPose::CartesianPose(const std::string& name,
-                             const Eigen::Vector3d& position,
-                             const Eigen::Quaterniond& orientation,
-                             const std::string& reference) : CartesianState(name, reference) {
+CartesianPose::CartesianPose(
+    const std::string& name, const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation,
+    const std::string& reference
+) : CartesianState(name, reference) {
   this->set_position(position);
   this->set_orientation(orientation);
 }

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -437,8 +437,4 @@ CartesianState operator*(double lambda, const CartesianState& state) {
 double dist(const CartesianState& s1, const CartesianState& s2, const CartesianStateVariable& state_variable_type) {
   return s1.dist(s2, state_variable_type);
 }
-
-void CartesianState::from_std_vector(const std::vector<double>&) {
-  throw (NotImplementedException("from_std_vector() is not implemented for the base CartesianState class"));
-}
 }// namespace state_representation


### PR DESCRIPTION
To prepare for the next release, this PR removes everything related to `from_std_vector` that was already marked deprecated in PR #163.

Related to #165, but I believe this issue can be closed. 