### PR TITLE
Refactor JointState tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ into serialized message packets (#182)
 - Add class JointAccelerations (#173)
 - Fix clamp_state_variable function for CartesianState and JointState (#176)
 - Install tagged versions of osqp and osqpEigen (#184)
-- Refactor JointState tests and split them into separate test suites (#183)
+- Refactor JointState tests and split them into separate test suites (#183, #187)
 - Add missing integration constructor from JointAccelerations for JointVelocities (#185)
 - Remove previously deprecated from_std_vector function (#186)
 

--- a/source/state_representation/test/tests/robot/test_joint_accelerations.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_accelerations.cpp
@@ -1,79 +1,187 @@
 #include <gtest/gtest.h>
 #include "state_representation/robot/JointAccelerations.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
 
 using namespace state_representation;
 
-TEST(JointAccelerationsTest, RandomAccelerationsInitialization) {
+TEST(JointAccelerationsTest, Constructors) {
+  std::vector<std::string> joint_names{"joint_10", "joint_20"};
+  Eigen::Vector2d accelerations = Eigen::Vector2d::Random();
+  JointAccelerations ja1("test", accelerations);
+  EXPECT_EQ(ja1.get_name(), "test");
+  EXPECT_FALSE(ja1.is_empty());
+  EXPECT_EQ(ja1.get_size(), accelerations.size());
+  for (std::size_t i = 0; i < accelerations.size(); ++i) {
+    EXPECT_EQ(ja1.get_names().at(i), "joint" + std::to_string(i));
+  }
+  EXPECT_EQ(ja1.data(), accelerations);
+
+  JointAccelerations ja2("test", joint_names, accelerations);
+  EXPECT_EQ(ja2.get_name(), "test");
+  EXPECT_FALSE(ja2.is_empty());
+  EXPECT_EQ(ja2.get_size(), joint_names.size());
+  for (std::size_t i = 0; i < joint_names.size(); ++i) {
+    EXPECT_EQ(ja2.get_names().at(i), joint_names.at(i));
+  }
+  EXPECT_EQ(ja2.data(), accelerations);
+}
+
+TEST(JointAccelerationsTest, StateCopyConstructor) {
+  JointState random_state = JointState::Random("test", 3);
+  JointAccelerations copy1(random_state);
+  EXPECT_EQ(random_state.get_name(), copy1.get_name());
+  EXPECT_EQ(random_state.get_names(), copy1.get_names());
+  EXPECT_EQ(random_state.get_size(), copy1.get_size());
+  EXPECT_EQ(random_state.get_accelerations(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointAccelerations copy2 = random_state;
+  EXPECT_EQ(random_state.get_name(), copy2.get_name());
+  EXPECT_EQ(random_state.get_names(), copy2.get_names());
+  EXPECT_EQ(random_state.get_size(), copy2.get_size());
+  EXPECT_EQ(random_state.get_accelerations(), copy2.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointState empty_state;
+  JointAccelerations copy3(empty_state);
+  EXPECT_TRUE(copy3.is_empty());
+  JointAccelerations copy4 = empty_state;
+  EXPECT_TRUE(copy4.is_empty());
+  JointAccelerations copy5 = empty_state.copy();
+  EXPECT_TRUE(copy5.is_empty());
+}
+
+TEST(JointAccelerationsTest, VelocitiesCopyConstructor) {
+  JointVelocities random_velocities = JointVelocities::Random("test", 3);
+  JointAccelerations copy1(random_velocities);
+  EXPECT_EQ(random_velocities.get_name(), copy1.get_name());
+  EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
+  EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
+  EXPECT_EQ((random_velocities / std::chrono::seconds(1)).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointAccelerations copy2 = random_velocities;
+  EXPECT_EQ(random_velocities.get_name(), copy1.get_name());
+  EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
+  EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
+  EXPECT_EQ((random_velocities / std::chrono::seconds(1)).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointVelocities empty_velocities;
+  EXPECT_THROW(JointAccelerations copy(empty_velocities), exceptions::EmptyStateException);
+  EXPECT_THROW(JointAccelerations copy = empty_velocities, exceptions::EmptyStateException);
+}
+
+TEST(JointAccelerationsTest, RandomInitialization) {
   JointAccelerations random = JointAccelerations::Random("test", 3);
-  // only velocities should be random
+  EXPECT_GT(random.get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
-  EXPECT_GT(random.get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
-  // same for the second initializer
+
   JointAccelerations random2 = JointAccelerations::Random("test", std::vector<std::string>{"j0", "j1"});
-  // only velocities should be random
+  EXPECT_GT(random2.get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
-  EXPECT_GT(random2.get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
 }
 
-TEST(JointAccelerationsTest, CopyAccelerations) {
-  JointAccelerations accelerations1 = JointAccelerations::Random("test", 3);
-  JointAccelerations accelerations2(accelerations1);
-  EXPECT_EQ(accelerations1.get_name(), accelerations2.get_name());
-  EXPECT_TRUE(accelerations1.data().isApprox(accelerations2.data()));
-  EXPECT_EQ(static_cast<JointState&>(accelerations2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations2).get_torques().norm(), 0);
-  JointAccelerations accelerations3 = accelerations1;
-  EXPECT_EQ(accelerations1.get_name(), accelerations3.get_name());
-  EXPECT_TRUE(accelerations1.data().isApprox(accelerations3.data()));
-  EXPECT_EQ(static_cast<JointState&>(accelerations3).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations3).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations3).get_torques().norm(), 0);
-  // try to change non pose variables prior to the copy, those should be discarded
-  static_cast<JointState&>(accelerations1).set_positions(Eigen::Vector3d::Random());
-  static_cast<JointState&>(accelerations1).set_velocities(Eigen::Vector3d::Random());
-  static_cast<JointState&>(accelerations1).set_torques(Eigen::Vector3d::Random());
-  JointAccelerations accelerations4 = accelerations1;
-  EXPECT_TRUE(accelerations1.data().isApprox(accelerations4.data()));
-  EXPECT_EQ(static_cast<JointState&>(accelerations4).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations4).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations4).get_torques().norm(), 0);
-  // copy a state, only the pose variables should be non 0
-  JointAccelerations accelerations5 = JointState::Random("test", 3);
-  EXPECT_EQ(static_cast<JointState&>(accelerations5).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations5).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(accelerations5).get_torques().norm(), 0);
+TEST(JointAccelerationsTest, Clamping) {
+  JointAccelerations ja1("test", 3);
+  ja1.set_data(-10 * Eigen::VectorXd::Ones(ja1.get_size()));
+  ja1.clamp(15);
+  EXPECT_EQ(ja1.data(), -10 * Eigen::VectorXd::Ones(ja1.get_size()));
+  ja1.clamp(9);
+  EXPECT_EQ(ja1.data(), -9 * Eigen::VectorXd::Ones(ja1.get_size()));
+  ja1.clamp(20, 0.5);
+  EXPECT_EQ(ja1.data(), Eigen::VectorXd::Zero(ja1.get_size()));
 
-  JointAccelerations accelerations6;
-  EXPECT_TRUE(accelerations6.is_empty());
-  JointAccelerations accelerations7 = accelerations6;
-  EXPECT_TRUE(accelerations7.is_empty());
+  JointAccelerations ja2("test", 3);
+  Eigen::VectorXd accelerations(3), result(3);
+  accelerations << -2.0, 1.0, -4.0;
+  result << -2.0, 0.0, -3.0;
+  ja2.set_data(accelerations);
+  ja2.clamp(10);
+  EXPECT_EQ(ja2.data(), accelerations);
+  ja2.clamp(3 * Eigen::ArrayXd::Ones(ja2.get_size()), 0.5 * Eigen::ArrayXd::Ones(ja2.get_size()));
+  EXPECT_EQ(ja2.data(), result);
 }
 
-TEST(JointAccelerationsTest, SetData) {
-  JointAccelerations ja1 = JointAccelerations::Zero("test", 4);
-  JointAccelerations ja2 = JointAccelerations::Random("test", 4);
+TEST(JointAccelerationsTest, GetSetData) {
+  JointAccelerations ja1 = JointAccelerations::Zero("test", 3);
+  JointAccelerations ja2 = JointAccelerations::Random("test", 3);
+  Eigen::VectorXd data(ja1.get_size());
+  data << ja1.get_accelerations();
+  EXPECT_EQ(data, ja1.data());
+  for (std::size_t i = 0; i < ja1.get_size(); ++i) {
+    EXPECT_EQ(data.array()(i), ja1.array()(i));
+  }
+
   ja1.set_data(ja2.data());
   EXPECT_TRUE(ja2.data().isApprox(ja1.data()));
 
-  auto acc_vec = ja2.to_std_vector();
-  ja1.set_data(acc_vec);
-  for (std::size_t j = 0; j < acc_vec.size(); ++j) {
-    EXPECT_FLOAT_EQ(acc_vec.at(j), ja1.data()(j));
+  auto state_vec = ja2.to_std_vector();
+  ja1.set_data(state_vec);
+  for (std::size_t i = 0; i < state_vec.size(); ++i) {
+    EXPECT_EQ(state_vec.at(i), ja1.data()(i));
   }
-  std::vector<double> accelerations{1, 2, 3, 4, 5};
-  EXPECT_THROW(ja1.set_data(accelerations), exceptions::IncompatibleSizeException);
+  EXPECT_THROW(ja1.set_data(Eigen::Vector2d::Zero()), exceptions::IncompatibleSizeException);
 }
 
-TEST(JointAccelerationsTest, JointAccelerationsToStdVector) {
-  JointAccelerations ja = JointAccelerations::Random("test_robot", 4);
-  std::vector<double> vec_data = ja.to_std_vector();
-  EXPECT_EQ(vec_data.size(), ja.get_size());
-  for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_EQ(ja.get_accelerations()(i), vec_data[i]);
-  }
+TEST(JointAccelerationsTest, ScalarMultiplication) {
+  JointAccelerations ja = JointAccelerations::Random("test", 3);
+  JointAccelerations jscaled = 0.5 * ja;
+  EXPECT_EQ(jscaled.data(), 0.5 * ja.data());
+
+  JointAccelerations empty;
+  EXPECT_THROW(0.5 * empty, exceptions::EmptyStateException);
+}
+
+TEST(JointAccelerationsTest, MatrixMultiplication) {
+  JointAccelerations ja = JointAccelerations::Random("test", 3);
+  Eigen::MatrixXd gains = Eigen::VectorXd::Random(ja.get_size()).asDiagonal();
+
+  JointAccelerations jscaled = gains * ja;
+  EXPECT_EQ(jscaled.data(), gains * ja.data());
+  EXPECT_EQ((ja * gains).data(), jscaled.data());
+  ja *= gains;
+  EXPECT_EQ(jscaled.data(), ja.data());
+  JointAccelerations jscaled2 = ja * gains;
+
+  gains = Eigen::VectorXd::Random(2 * ja.get_size()).asDiagonal();
+  EXPECT_THROW(gains * ja, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointAccelerationsTest, ArrayMultiplication) {
+  JointAccelerations ja = JointAccelerations::Random("test", 3);
+  Eigen::ArrayXd gains = Eigen::ArrayXd::Random(ja.get_size());
+
+  JointAccelerations jscaled = gains * ja;
+  EXPECT_EQ(jscaled.data(), (gains * ja.array()).matrix());
+  EXPECT_EQ((ja * gains).data(), jscaled.data());
+  ja *= gains;
+  EXPECT_EQ(jscaled.data(), ja.data());
+
+  gains = Eigen::ArrayXd::Random(2 * ja.get_size());
+  EXPECT_THROW(gains * ja, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointAccelerationsTest, ChronoMultiplication) {
+  JointAccelerations ja = JointAccelerations::Random("test", 3);
+  auto time = std::chrono::seconds(2);
+  JointVelocities jv1 = ja * time;
+  EXPECT_EQ(jv1.get_velocities(), ja.get_accelerations() * time.count());
+  JointVelocities jv2 = time * ja;
+  EXPECT_EQ(jv2.get_velocities(), ja.get_accelerations() * time.count());
+
+  JointAccelerations empty;
+  EXPECT_THROW(empty * time, exceptions::EmptyStateException);
 }

--- a/source/state_representation/test/tests/robot/test_joint_accelerations.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_accelerations.cpp
@@ -4,6 +4,12 @@
 
 using namespace state_representation;
 
+static void expect_only_accelerations(JointAccelerations& acc) {
+  EXPECT_EQ(static_cast<JointState&>(acc).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(acc).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(acc).get_torques().norm(), 0);
+}
+
 TEST(JointAccelerationsTest, Constructors) {
   std::vector<std::string> joint_names{"joint_10", "joint_20"};
   Eigen::Vector2d accelerations = Eigen::Vector2d::Random();
@@ -11,7 +17,7 @@ TEST(JointAccelerationsTest, Constructors) {
   EXPECT_EQ(ja1.get_name(), "test");
   EXPECT_FALSE(ja1.is_empty());
   EXPECT_EQ(ja1.get_size(), accelerations.size());
-  for (std::size_t i = 0; i < accelerations.size(); ++i) {
+  for (auto i = 0; i < accelerations.size(); ++i) {
     EXPECT_EQ(ja1.get_names().at(i), "joint" + std::to_string(i));
   }
   EXPECT_EQ(ja1.data(), accelerations);
@@ -33,18 +39,14 @@ TEST(JointAccelerationsTest, StateCopyConstructor) {
   EXPECT_EQ(random_state.get_names(), copy1.get_names());
   EXPECT_EQ(random_state.get_size(), copy1.get_size());
   EXPECT_EQ(random_state.get_accelerations(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_accelerations(copy1);
 
   JointAccelerations copy2 = random_state;
   EXPECT_EQ(random_state.get_name(), copy2.get_name());
   EXPECT_EQ(random_state.get_names(), copy2.get_names());
   EXPECT_EQ(random_state.get_size(), copy2.get_size());
   EXPECT_EQ(random_state.get_accelerations(), copy2.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_accelerations(copy2);
 
   JointState empty_state;
   JointAccelerations copy3(empty_state);
@@ -62,18 +64,14 @@ TEST(JointAccelerationsTest, VelocitiesCopyConstructor) {
   EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
   EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
   EXPECT_EQ((random_velocities / std::chrono::seconds(1)).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_accelerations(copy1);
 
   JointAccelerations copy2 = random_velocities;
   EXPECT_EQ(random_velocities.get_name(), copy1.get_name());
   EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
   EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
   EXPECT_EQ((random_velocities / std::chrono::seconds(1)).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_accelerations(copy2);
 
   JointVelocities empty_velocities;
   EXPECT_THROW(JointAccelerations copy(empty_velocities), exceptions::EmptyStateException);
@@ -81,17 +79,13 @@ TEST(JointAccelerationsTest, VelocitiesCopyConstructor) {
 }
 
 TEST(JointAccelerationsTest, RandomInitialization) {
-  JointAccelerations random = JointAccelerations::Random("test", 3);
-  EXPECT_GT(random.get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
+  JointAccelerations random1 = JointAccelerations::Random("test", 3);
+  EXPECT_GT(random1.get_accelerations().norm(), 0);
+  expect_only_accelerations(random1);
 
   JointAccelerations random2 = JointAccelerations::Random("test", std::vector<std::string>{"j0", "j1"});
   EXPECT_GT(random2.get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
+  expect_only_accelerations(random2);
 }
 
 TEST(JointAccelerationsTest, Clamping) {

--- a/source/state_representation/test/tests/robot/test_joint_accelerations.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_accelerations.cpp
@@ -80,11 +80,11 @@ TEST(JointAccelerationsTest, VelocitiesCopyConstructor) {
 
 TEST(JointAccelerationsTest, RandomInitialization) {
   JointAccelerations random1 = JointAccelerations::Random("test", 3);
-  EXPECT_GT(random1.get_accelerations().norm(), 0);
+  EXPECT_NE(random1.get_accelerations().norm(), 0);
   expect_only_accelerations(random1);
 
   JointAccelerations random2 = JointAccelerations::Random("test", std::vector<std::string>{"j0", "j1"});
-  EXPECT_GT(random2.get_accelerations().norm(), 0);
+  EXPECT_NE(random2.get_accelerations().norm(), 0);
   expect_only_accelerations(random2);
 }
 

--- a/source/state_representation/test/tests/robot/test_joint_positions.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_positions.cpp
@@ -80,11 +80,11 @@ TEST(JointPositionsTest, VelocitiesCopyConstructor) {
 
 TEST(JointPositionsTest, RandomInitialization) {
   JointPositions random1 = JointPositions::Random("test", 3);
-  EXPECT_GT(random1.get_positions().norm(), 0);
+  EXPECT_NE(random1.get_positions().norm(), 0);
   expect_only_positions(random1);
 
   JointPositions random2 = JointPositions::Random("test", std::vector<std::string>{"j0", "j1"});
-  EXPECT_GT(random2.get_positions().norm(), 0);
+  EXPECT_NE(random2.get_positions().norm(), 0);
   expect_only_positions(random2);
 }
 

--- a/source/state_representation/test/tests/robot/test_joint_positions.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_positions.cpp
@@ -4,6 +4,12 @@
 
 using namespace state_representation;
 
+static void expect_only_positions(JointPositions& pos) {
+  EXPECT_EQ(static_cast<JointState&>(pos).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(pos).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(pos).get_torques().norm(), 0);
+}
+
 TEST(JointPositionsTest, Constructors) {
   std::vector<std::string> joint_names{"joint_10", "joint_20"};
   Eigen::Vector2d positions = Eigen::Vector2d::Random();
@@ -11,7 +17,7 @@ TEST(JointPositionsTest, Constructors) {
   EXPECT_EQ(jp1.get_name(), "test");
   EXPECT_FALSE(jp1.is_empty());
   EXPECT_EQ(jp1.get_size(), positions.size());
-  for (std::size_t i = 0; i < positions.size(); ++i) {
+  for (auto i = 0; i < positions.size(); ++i) {
     EXPECT_EQ(jp1.get_names().at(i), "joint" + std::to_string(i));
   }
   EXPECT_EQ(jp1.data(), positions);
@@ -33,18 +39,14 @@ TEST(JointPositionsTest, StateCopyConstructor) {
   EXPECT_EQ(random_state.get_names(), copy1.get_names());
   EXPECT_EQ(random_state.get_size(), copy1.get_size());
   EXPECT_EQ(random_state.get_positions(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_positions(copy1);
 
   JointPositions copy2 = random_state;
   EXPECT_EQ(random_state.get_name(), copy2.get_name());
   EXPECT_EQ(random_state.get_names(), copy2.get_names());
   EXPECT_EQ(random_state.get_size(), copy2.get_size());
   EXPECT_EQ(random_state.get_positions(), copy2.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_positions(copy2);
 
   JointState empty_state;
   JointPositions copy3(empty_state);
@@ -62,18 +64,14 @@ TEST(JointPositionsTest, VelocitiesCopyConstructor) {
   EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
   EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
   EXPECT_EQ((std::chrono::seconds(1) * random_velocities).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_positions(copy1);
 
   JointPositions copy2 = random_velocities;
   EXPECT_EQ(random_velocities.get_name(), copy1.get_name());
   EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
   EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
   EXPECT_EQ((std::chrono::seconds(1) * random_velocities).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_positions(copy2);
 
   JointVelocities empty_velocities;
   EXPECT_THROW(JointPositions copy(empty_velocities), exceptions::EmptyStateException);
@@ -81,17 +79,13 @@ TEST(JointPositionsTest, VelocitiesCopyConstructor) {
 }
 
 TEST(JointPositionsTest, RandomInitialization) {
-  JointPositions random = JointPositions::Random("test", 3);
-  EXPECT_GT(random.get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
+  JointPositions random1 = JointPositions::Random("test", 3);
+  EXPECT_GT(random1.get_positions().norm(), 0);
+  expect_only_positions(random1);
 
   JointPositions random2 = JointPositions::Random("test", std::vector<std::string>{"j0", "j1"});
   EXPECT_GT(random2.get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
+  expect_only_positions(random2);
 }
 
 TEST(JointPositionsTest, Clamping) {

--- a/source/state_representation/test/tests/robot/test_joint_positions.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_positions.cpp
@@ -1,77 +1,185 @@
 #include <gtest/gtest.h>
 #include "state_representation/robot/JointPositions.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
 
 using namespace state_representation;
 
-TEST(JointPositionsTest, RandomPositionsInitialization) {
+TEST(JointPositionsTest, Constructors) {
+  std::vector<std::string> joint_names{"joint_10", "joint_20"};
+  Eigen::Vector2d positions = Eigen::Vector2d::Random();
+  JointPositions jp1("test", positions);
+  EXPECT_EQ(jp1.get_name(), "test");
+  EXPECT_FALSE(jp1.is_empty());
+  EXPECT_EQ(jp1.get_size(), positions.size());
+  for (std::size_t i = 0; i < positions.size(); ++i) {
+    EXPECT_EQ(jp1.get_names().at(i), "joint" + std::to_string(i));
+  }
+  EXPECT_EQ(jp1.data(), positions);
+
+  JointPositions jp2("test", joint_names, positions);
+  EXPECT_EQ(jp2.get_name(), "test");
+  EXPECT_FALSE(jp2.is_empty());
+  EXPECT_EQ(jp2.get_size(), joint_names.size());
+  for (std::size_t i = 0; i < joint_names.size(); ++i) {
+    EXPECT_EQ(jp2.get_names().at(i), joint_names.at(i));
+  }
+  EXPECT_EQ(jp2.data(), positions);
+}
+
+TEST(JointPositionsTest, StateCopyConstructor) {
+  JointState random_state = JointState::Random("test", 3);
+  JointPositions copy1(random_state);
+  EXPECT_EQ(random_state.get_name(), copy1.get_name());
+  EXPECT_EQ(random_state.get_names(), copy1.get_names());
+  EXPECT_EQ(random_state.get_size(), copy1.get_size());
+  EXPECT_EQ(random_state.get_positions(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointPositions copy2 = random_state;
+  EXPECT_EQ(random_state.get_name(), copy2.get_name());
+  EXPECT_EQ(random_state.get_names(), copy2.get_names());
+  EXPECT_EQ(random_state.get_size(), copy2.get_size());
+  EXPECT_EQ(random_state.get_positions(), copy2.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointState empty_state;
+  JointPositions copy3(empty_state);
+  EXPECT_TRUE(copy3.is_empty());
+  JointPositions copy4 = empty_state;
+  EXPECT_TRUE(copy4.is_empty());
+  JointPositions copy5 = empty_state.copy();
+  EXPECT_TRUE(copy5.is_empty());
+}
+
+TEST(JointPositionsTest, VelocitiesCopyConstructor) {
+  JointVelocities random_velocities = JointVelocities::Random("test", 3);
+  JointPositions copy1(random_velocities);
+  EXPECT_EQ(random_velocities.get_name(), copy1.get_name());
+  EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
+  EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
+  EXPECT_EQ((std::chrono::seconds(1) * random_velocities).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointPositions copy2 = random_velocities;
+  EXPECT_EQ(random_velocities.get_name(), copy1.get_name());
+  EXPECT_EQ(random_velocities.get_names(), copy1.get_names());
+  EXPECT_EQ(random_velocities.get_size(), copy1.get_size());
+  EXPECT_EQ((std::chrono::seconds(1) * random_velocities).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointVelocities empty_velocities;
+  EXPECT_THROW(JointPositions copy(empty_velocities), exceptions::EmptyStateException);
+  EXPECT_THROW(JointPositions copy = empty_velocities, exceptions::EmptyStateException);
+}
+
+TEST(JointPositionsTest, RandomInitialization) {
   JointPositions random = JointPositions::Random("test", 3);
-  // only position should be random
   EXPECT_GT(random.get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
-  // same for the second initializer
+
   JointPositions random2 = JointPositions::Random("test", std::vector<std::string>{"j0", "j1"});
-  // only position should be random
   EXPECT_GT(random2.get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
 }
 
-TEST(JointPositionsTest, CopyPosisitions) {
-  JointPositions positions1 = JointPositions::Random("test", 3);
-  JointPositions positions2(positions1);
-  EXPECT_EQ(positions1.get_name(), positions2.get_name());
-  EXPECT_TRUE(positions1.data().isApprox(positions2.data()));
-  EXPECT_EQ(static_cast<JointState&>(positions2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions2).get_torques().norm(), 0);
-  JointPositions positions3 = positions1;
-  EXPECT_EQ(positions1.get_name(), positions3.get_name());
-  EXPECT_TRUE(positions1.data().isApprox(positions3.data()));
-  EXPECT_EQ(static_cast<JointState&>(positions3).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions3).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions3).get_torques().norm(), 0);
-  // try to change non pose variables prior to the copy, those should be discarded
-  static_cast<JointState&>(positions1).set_velocities(Eigen::Vector3d::Random());
-  static_cast<JointState&>(positions1).set_accelerations(Eigen::Vector3d::Random());
-  static_cast<JointState&>(positions1).set_torques(Eigen::Vector3d::Random());
-  JointPositions positions4 = positions1;
-  EXPECT_TRUE(positions1.data().isApprox(positions4.data()));
-  EXPECT_EQ(static_cast<JointState&>(positions4).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions4).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions4).get_torques().norm(), 0);
-  // copy a state, only the pose variables should be non 0
-  JointPositions positions5 = JointState::Random("test", 3);
-  EXPECT_EQ(static_cast<JointState&>(positions5).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions5).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(positions5).get_torques().norm(), 0);
+TEST(JointPositionsTest, Clamping) {
+  JointPositions jp1("test", 3);
+  jp1.set_data(-10 * Eigen::VectorXd::Ones(jp1.get_size()));
+  jp1.clamp(15);
+  EXPECT_EQ(jp1.data(), -10 * Eigen::VectorXd::Ones(jp1.get_size()));
+  jp1.clamp(9);
+  EXPECT_EQ(jp1.data(), -9 * Eigen::VectorXd::Ones(jp1.get_size()));
+  jp1.clamp(20, 0.5);
+  EXPECT_EQ(jp1.data(), Eigen::VectorXd::Zero(jp1.get_size()));
 
-  JointPositions positions6;
-  EXPECT_TRUE(positions6.is_empty());
-  JointPositions positions7 = positions6;
-  EXPECT_TRUE(positions7.is_empty());
+  JointPositions jp2("test", 3);
+  Eigen::VectorXd positions(3), result(3);
+  positions << -2.0, 1.0, -4.0;
+  result << -2.0, 0.0, -3.0;
+  jp2.set_data(positions);
+  jp2.clamp(10);
+  EXPECT_EQ(jp2.data(), positions);
+  jp2.clamp(3 * Eigen::ArrayXd::Ones(jp2.get_size()), 0.5 * Eigen::ArrayXd::Ones(jp2.get_size()));
+  EXPECT_EQ(jp2.data(), result);
 }
 
-TEST(JointPositionsTest, SetData) {
-  JointPositions jp1 = JointPositions::Zero("test", 4);
-  JointPositions jp2 = JointPositions::Random("test", 4);
+TEST(JointPositionsTest, GetSetData) {
+  JointPositions jp1 = JointPositions::Zero("test", 3);
+  JointPositions jp2 = JointPositions::Random("test", 3);
+  Eigen::VectorXd data(jp1.get_size());
+  data << jp1.get_positions();
+  EXPECT_EQ(data, jp1.data());
+  for (std::size_t i = 0; i < jp1.get_size(); ++i) {
+    EXPECT_EQ(data.array()(i), jp1.array()(i));
+  }
+
   jp1.set_data(jp2.data());
   EXPECT_TRUE(jp2.data().isApprox(jp1.data()));
 
-  auto pos_vec = jp2.to_std_vector();
-  jp1.set_data(pos_vec);
-  for (std::size_t j = 0; j < pos_vec.size(); ++j) {
-    EXPECT_FLOAT_EQ(pos_vec.at(j), jp1.data()(j));
+  auto state_vec = jp2.to_std_vector();
+  jp1.set_data(state_vec);
+  for (std::size_t i = 0; i < state_vec.size(); ++i) {
+    EXPECT_EQ(state_vec.at(i), jp1.data()(i));
   }
+  EXPECT_THROW(jp1.set_data(Eigen::Vector2d::Zero()), exceptions::IncompatibleSizeException);
 }
 
-TEST(JointPositionsTest, JointPositionsToStdVector) {
-  JointPositions jp = JointPositions::Random("test_robot", 4);
-  std::vector<double> vec_data = jp.to_std_vector();
-  EXPECT_EQ(vec_data.size(), jp.get_size());
-  for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_EQ(jp.get_positions()(i), vec_data[i]);
-  }
+TEST(JointPositionsTest, ScalarMultiplication) {
+  JointPositions jp = JointPositions::Random("test", 3);
+  JointPositions jscaled = 0.5 * jp;
+  EXPECT_EQ(jscaled.data(), 0.5 * jp.data());
+
+  JointPositions empty;
+  EXPECT_THROW(0.5 * empty, exceptions::EmptyStateException);
+}
+
+TEST(JointPositionsTest, MatrixMultiplication) {
+  JointPositions jp = JointPositions::Random("test", 3);
+  Eigen::MatrixXd gains = Eigen::VectorXd::Random(jp.get_size()).asDiagonal();
+
+  JointPositions jscaled = gains * jp;
+  EXPECT_EQ(jscaled.data(), gains * jp.data());
+  EXPECT_EQ((jp * gains).data(), jscaled.data());
+  jp *= gains;
+  EXPECT_EQ(jscaled.data(), jp.data());
+  JointPositions jscaled2 = jp * gains;
+
+  gains = Eigen::VectorXd::Random(2 * jp.get_size()).asDiagonal();
+  EXPECT_THROW(gains * jp, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointPositionsTest, ArrayMultiplication) {
+  JointPositions jp = JointPositions::Random("test", 3);
+  Eigen::ArrayXd gains = Eigen::ArrayXd::Random(jp.get_size());
+
+  JointPositions jscaled = gains * jp;
+  EXPECT_EQ(jscaled.data(), (gains * jp.array()).matrix());
+  EXPECT_EQ((jp * gains).data(), jscaled.data());
+  jp *= gains;
+  EXPECT_EQ(jscaled.data(), jp.data());
+
+  gains = Eigen::ArrayXd::Random(2 * jp.get_size());
+  EXPECT_THROW(gains * jp, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointStateTest, ChronoDivision) {
+  JointPositions jp = JointPositions::Random("test", 3);
+  auto time = std::chrono::seconds(1);
+  JointVelocities jv = jp / time;
+  EXPECT_EQ(jv.get_velocities(), jp.get_positions() / time.count());
+
+  JointPositions empty;
+  EXPECT_THROW(empty / time, exceptions::EmptyStateException);
 }

--- a/source/state_representation/test/tests/robot/test_joint_state.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_state.cpp
@@ -202,9 +202,9 @@ TEST(JointStateTest, ClampVariable) {
   EXPECT_EQ(js2.get_torques(), result);
 
   EXPECT_THROW(js2.clamp_state_variable(Eigen::Array2d::Ones(), JointStateVariable::ALL, Eigen::Array3d::Zero()),
-               IncompatibleSizeException);
+               exceptions::IncompatibleSizeException);
   EXPECT_THROW(js2.clamp_state_variable(Eigen::Array3d::Ones(), JointStateVariable::ALL, Eigen::Array2d::Zero()),
-               IncompatibleSizeException);
+               exceptions::IncompatibleSizeException);
 }
 
 TEST(JointStateTest, GetSetData) {
@@ -240,9 +240,9 @@ TEST(JointStateTest, Distance) {
   JointState js;
   JointState js1 = JointState::Random("test", 3);
   JointState js2 = JointState::Random("test", 2);
-  EXPECT_THROW(js.dist(js1), EmptyStateException);
-  EXPECT_THROW(js1.dist(js), EmptyStateException);
-  EXPECT_THROW(js1.dist(js2), IncompatibleStatesException);
+  EXPECT_THROW(js.dist(js1), exceptions::EmptyStateException);
+  EXPECT_THROW(js1.dist(js), exceptions::EmptyStateException);
+  EXPECT_THROW(js1.dist(js2), exceptions::IncompatibleStatesException);
 
   Eigen::VectorXd data1 = Eigen::VectorXd::Random(js1.get_size() * 4);
   js1.set_data(data1);
@@ -266,7 +266,7 @@ TEST(JointStateTest, Addition) {
   JointState js1 = JointState::Random("test", 3);
   JointState js2 = JointState::Random("test", 3);
   JointState js3 = JointState::Random("test", 4);
-  EXPECT_THROW(js1 + js3, IncompatibleStatesException);
+  EXPECT_THROW(js1 + js3, exceptions::IncompatibleStatesException);
   JointState jsum = js1 + js2;
   EXPECT_EQ(jsum.data(), js1.data() + js2.data());
   js2 += js1;
@@ -277,7 +277,7 @@ TEST(JointStateTest, Subtraction) {
   JointState js1 = JointState::Random("test", 3);
   JointState js2 = JointState::Random("test", 3);
   JointState js3 = JointState::Random("test", 4);
-  EXPECT_THROW(js1 - js3, IncompatibleStatesException);
+  EXPECT_THROW(js1 - js3, exceptions::IncompatibleStatesException);
   JointState jdiff = js1 - js2;
   EXPECT_EQ(jdiff.data(), js1.data() - js2.data());
   js1 -= js2;
@@ -293,7 +293,7 @@ TEST(JointStateTest, ScalarMultiplication) {
   EXPECT_EQ(jscaled.data(), js.data());
 
   JointState empty;
-  EXPECT_THROW(0.5 * empty, EmptyStateException);
+  EXPECT_THROW(0.5 * empty, exceptions::EmptyStateException);
 }
 
 TEST(JointStateTest, ScalarDivision) {
@@ -304,7 +304,7 @@ TEST(JointStateTest, ScalarDivision) {
   EXPECT_EQ(jscaled.data(), js.data());
 
   JointState empty;
-  EXPECT_THROW(empty / 0.5, EmptyStateException);
+  EXPECT_THROW(empty / 0.5, exceptions::EmptyStateException);
 }
 
 TEST(JointStateTest, MatrixMultiplication) {
@@ -319,7 +319,7 @@ TEST(JointStateTest, MatrixMultiplication) {
   JointState jscaled2 = js * gains;
 
   gains = Eigen::VectorXd::Random(js.get_size()).asDiagonal();
-  EXPECT_THROW(gains * js, IncompatibleSizeException);
+  EXPECT_THROW(gains * js, exceptions::IncompatibleSizeException);
 }
 
 TEST(JointStateTest, ArrayMultiplication) {
@@ -333,6 +333,6 @@ TEST(JointStateTest, ArrayMultiplication) {
   EXPECT_EQ(jscaled.data(), js.data());
 
   gains = Eigen::ArrayXd::Random(js.get_size());
-  EXPECT_THROW(gains * js, IncompatibleSizeException);
+  EXPECT_THROW(gains * js, exceptions::IncompatibleSizeException);
 }
 

--- a/source/state_representation/test/tests/robot/test_joint_state.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_state.cpp
@@ -47,16 +47,16 @@ TEST(JointStateTest, ZeroInitialization) {
 
 TEST(JointStateTest, RandomStateInitialization) {
   JointState random = JointState::Random("test", 3);
-  EXPECT_GT(random.get_positions().norm(), 0);
-  EXPECT_GT(random.get_velocities().norm(), 0);
-  EXPECT_GT(random.get_accelerations().norm(), 0);
-  EXPECT_GT(random.get_torques().norm(), 0);
+  EXPECT_NE(random.get_positions().norm(), 0);
+  EXPECT_NE(random.get_velocities().norm(), 0);
+  EXPECT_NE(random.get_accelerations().norm(), 0);
+  EXPECT_NE(random.get_torques().norm(), 0);
 
   JointState random2 = JointState::Random("test", std::vector<std::string>{"j0", "j1"});
-  EXPECT_GT(random2.get_positions().norm(), 0);
-  EXPECT_GT(random2.get_velocities().norm(), 0);
-  EXPECT_GT(random2.get_accelerations().norm(), 0);
-  EXPECT_GT(random2.get_torques().norm(), 0);
+  EXPECT_NE(random2.get_positions().norm(), 0);
+  EXPECT_NE(random2.get_velocities().norm(), 0);
+  EXPECT_NE(random2.get_accelerations().norm(), 0);
+  EXPECT_NE(random2.get_torques().norm(), 0);
 }
 
 TEST(JointStateTest, CopyConstructor) {

--- a/source/state_representation/test/tests/robot/test_joint_state.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_state.cpp
@@ -228,14 +228,6 @@ TEST(JointStateTest, GetSetData) {
   EXPECT_THROW(js1.set_data(Eigen::Vector2d::Zero()), exceptions::IncompatibleSizeException);
 }
 
-TEST(JointStateTest, JointStateToStdVector) {
-  JointState js = JointState::Random("test", 3);
-  std::vector<double> vec_data = js.to_std_vector();
-  for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_EQ(js.data()(i), vec_data.at(i));
-  }
-}
-
 TEST(JointStateTest, Distance) {
   JointState js;
   JointState js1 = JointState::Random("test", 3);

--- a/source/state_representation/test/tests/robot/test_joint_torques.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_torques.cpp
@@ -4,6 +4,12 @@
 
 using namespace state_representation;
 
+static void expect_only_torques(JointTorques& tor) {
+  EXPECT_EQ(static_cast<JointState&>(tor).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(tor).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(tor).get_velocities().norm(), 0);
+}
+
 TEST(JointTorquesTest, Constructors) {
   std::vector<std::string> joint_names{"joint_10", "joint_20"};
   Eigen::Vector2d torques = Eigen::Vector2d::Random();
@@ -11,7 +17,7 @@ TEST(JointTorquesTest, Constructors) {
   EXPECT_EQ(jt1.get_name(), "test");
   EXPECT_FALSE(jt1.is_empty());
   EXPECT_EQ(jt1.get_size(), torques.size());
-  for (std::size_t i = 0; i < torques.size(); ++i) {
+  for (auto i = 0; i < torques.size(); ++i) {
     EXPECT_EQ(jt1.get_names().at(i), "joint" + std::to_string(i));
   }
   EXPECT_EQ(jt1.data(), torques);
@@ -33,18 +39,14 @@ TEST(JointTorquesTest, StateCopyConstructor) {
   EXPECT_EQ(random_state.get_names(), copy1.get_names());
   EXPECT_EQ(random_state.get_size(), copy1.get_size());
   EXPECT_EQ(random_state.get_torques(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+  expect_only_torques(copy1);
 
   JointTorques copy2 = random_state;
   EXPECT_EQ(random_state.get_name(), copy2.get_name());
   EXPECT_EQ(random_state.get_names(), copy2.get_names());
   EXPECT_EQ(random_state.get_size(), copy2.get_size());
   EXPECT_EQ(random_state.get_torques(), copy2.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+  expect_only_torques(copy2);
 
   JointState empty_state;
   JointTorques copy3(empty_state);
@@ -56,17 +58,13 @@ TEST(JointTorquesTest, StateCopyConstructor) {
 }
 
 TEST(JointTorquesTest, RandomInitialization) {
-  JointTorques random = JointTorques::Random("test", 3);
-  EXPECT_GT(random.get_torques().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
+  JointTorques random1 = JointTorques::Random("test", 3);
+  EXPECT_GT(random1.get_torques().norm(), 0);
+  expect_only_torques(random1);
 
   JointTorques random2 = JointTorques::Random("test", std::vector<std::string>{"j0", "j1"});
   EXPECT_GT(random2.get_torques().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
+  expect_only_torques(random2);
 }
 
 TEST(JointTorquesTest, Clamping) {

--- a/source/state_representation/test/tests/robot/test_joint_torques.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_torques.cpp
@@ -1,77 +1,150 @@
 #include <gtest/gtest.h>
 #include "state_representation/robot/JointTorques.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
 
 using namespace state_representation;
 
-TEST(JointTorquesTest, RandomTorquesInitialization) {
+TEST(JointTorquesTest, Constructors) {
+  std::vector<std::string> joint_names{"joint_10", "joint_20"};
+  Eigen::Vector2d torques = Eigen::Vector2d::Random();
+  JointTorques jt1("test", torques);
+  EXPECT_EQ(jt1.get_name(), "test");
+  EXPECT_FALSE(jt1.is_empty());
+  EXPECT_EQ(jt1.get_size(), torques.size());
+  for (std::size_t i = 0; i < torques.size(); ++i) {
+    EXPECT_EQ(jt1.get_names().at(i), "joint" + std::to_string(i));
+  }
+  EXPECT_EQ(jt1.data(), torques);
+
+  JointTorques jt2("test", joint_names, torques);
+  EXPECT_EQ(jt2.get_name(), "test");
+  EXPECT_FALSE(jt2.is_empty());
+  EXPECT_EQ(jt2.get_size(), joint_names.size());
+  for (std::size_t i = 0; i < joint_names.size(); ++i) {
+    EXPECT_EQ(jt2.get_names().at(i), joint_names.at(i));
+  }
+  EXPECT_EQ(jt2.data(), torques);
+}
+
+TEST(JointTorquesTest, StateCopyConstructor) {
+  JointState random_state = JointState::Random("test", 3);
+  JointTorques copy1(random_state);
+  EXPECT_EQ(random_state.get_name(), copy1.get_name());
+  EXPECT_EQ(random_state.get_names(), copy1.get_names());
+  EXPECT_EQ(random_state.get_size(), copy1.get_size());
+  EXPECT_EQ(random_state.get_torques(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+
+  JointTorques copy2 = random_state;
+  EXPECT_EQ(random_state.get_name(), copy2.get_name());
+  EXPECT_EQ(random_state.get_names(), copy2.get_names());
+  EXPECT_EQ(random_state.get_size(), copy2.get_size());
+  EXPECT_EQ(random_state.get_torques(), copy2.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+
+  JointState empty_state;
+  JointTorques copy3(empty_state);
+  EXPECT_TRUE(copy3.is_empty());
+  JointTorques copy4 = empty_state;
+  EXPECT_TRUE(copy4.is_empty());
+  JointTorques copy5 = empty_state.copy();
+  EXPECT_TRUE(copy5.is_empty());
+}
+
+TEST(JointTorquesTest, RandomInitialization) {
   JointTorques random = JointTorques::Random("test", 3);
-  // only torques should be random
+  EXPECT_GT(random.get_torques().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_velocities().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
-  EXPECT_GT(random.get_torques().norm(), 0);
-  // same for the second initializer
+
   JointTorques random2 = JointTorques::Random("test", std::vector<std::string>{"j0", "j1"});
-  // only torques should be random
+  EXPECT_GT(random2.get_torques().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_velocities().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
-  EXPECT_GT(random2.get_torques().norm(), 0);
 }
 
-TEST(JointTorquesTest, CopyTorques) {
-  JointTorques torques1 = JointTorques::Random("test", 3);
-  JointTorques torques2(torques1);
-  EXPECT_EQ(torques1.get_name(), torques2.get_name());
-  EXPECT_TRUE(torques1.data().isApprox(torques2.data()));
-  EXPECT_EQ(static_cast<JointState&>(torques2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques2).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques2).get_accelerations().norm(), 0);
-  JointTorques torques3 = torques1;
-  EXPECT_EQ(torques1.get_name(), torques3.get_name());
-  EXPECT_TRUE(torques1.data().isApprox(torques3.data()));
-  EXPECT_EQ(static_cast<JointState&>(torques3).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques3).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques3).get_accelerations().norm(), 0);
-  // try to change non pose variables prior to the copy, those should be discarded
-  static_cast<JointState&>(torques1).set_positions(Eigen::Vector3d::Random());
-  static_cast<JointState&>(torques1).set_velocities(Eigen::Vector3d::Random());
-  static_cast<JointState&>(torques1).set_accelerations(Eigen::Vector3d::Random());
-  JointTorques torques4 = torques1;
-  EXPECT_TRUE(torques1.data().isApprox(torques4.data()));
-  EXPECT_EQ(static_cast<JointState&>(torques4).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques4).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques4).get_accelerations().norm(), 0);
-  // copy a state, only the pose variables should be non 0
-  JointTorques torques5 = JointState::Random("test", 3);
-  EXPECT_EQ(static_cast<JointState&>(torques5).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques5).get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(torques5).get_accelerations().norm(), 0);
+TEST(JointTorquesTest, Clamping) {
+  JointTorques jt1("test", 3);
+  jt1.set_data(-10 * Eigen::VectorXd::Ones(jt1.get_size()));
+  jt1.clamp(15);
+  EXPECT_EQ(jt1.data(), -10 * Eigen::VectorXd::Ones(jt1.get_size()));
+  jt1.clamp(9);
+  EXPECT_EQ(jt1.data(), -9 * Eigen::VectorXd::Ones(jt1.get_size()));
+  jt1.clamp(20, 0.5);
+  EXPECT_EQ(jt1.data(), Eigen::VectorXd::Zero(jt1.get_size()));
 
-  JointTorques torques6;
-  EXPECT_TRUE(torques6.is_empty());
-  JointTorques torques7 = torques6;
-  EXPECT_TRUE(torques7.is_empty());
+  JointTorques jt2("test", 3);
+  Eigen::VectorXd torques(3), result(3);
+  torques << -2.0, 1.0, -4.0;
+  result << -2.0, 0.0, -3.0;
+  jt2.set_data(torques);
+  jt2.clamp(10);
+  EXPECT_EQ(jt2.data(), torques);
+  jt2.clamp(3 * Eigen::ArrayXd::Ones(jt2.get_size()), 0.5 * Eigen::ArrayXd::Ones(jt2.get_size()));
+  EXPECT_EQ(jt2.data(), result);
 }
 
-TEST(JointTorquesTest, SetData) {
-  JointTorques jt1 = JointTorques::Zero("test", 4);
-  JointTorques jt2 = JointTorques::Random("test", 4);
+TEST(JointTorquesTest, GetSetData) {
+  JointTorques jt1 = JointTorques::Zero("test", 3);
+  JointTorques jt2 = JointTorques::Random("test", 3);
+  Eigen::VectorXd data(jt1.get_size());
+  data << jt1.get_torques();
+  EXPECT_EQ(data, jt1.data());
+  for (std::size_t i = 0; i < jt1.get_size(); ++i) {
+    EXPECT_EQ(data.array()(i), jt1.array()(i));
+  }
+
   jt1.set_data(jt2.data());
   EXPECT_TRUE(jt2.data().isApprox(jt1.data()));
 
-  auto torque_vec = jt2.to_std_vector();
-  jt1.set_data(torque_vec);
-  for (std::size_t j = 0; j < torque_vec.size(); ++j) {
-    EXPECT_FLOAT_EQ(torque_vec.at(j), jt1.data()(j));
+  auto state_vec = jt2.to_std_vector();
+  jt1.set_data(state_vec);
+  for (std::size_t i = 0; i < state_vec.size(); ++i) {
+    EXPECT_EQ(state_vec.at(i), jt1.data()(i));
   }
+  EXPECT_THROW(jt1.set_data(Eigen::Vector2d::Zero()), exceptions::IncompatibleSizeException);
 }
 
-TEST(JointTorquesTest, JointTorquesToStdVector) {
-  JointTorques jt = JointTorques::Random("test_robot", 4);
-  std::vector<double> vec_data = jt.to_std_vector();
-  EXPECT_EQ(vec_data.size(), jt.get_size());
-  for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_EQ(jt.get_torques()(i), vec_data[i]);
-  }
+TEST(JointTorquesTest, ScalarMultiplication) {
+  JointTorques jt = JointTorques::Random("test", 3);
+  JointTorques jscaled = 0.5 * jt;
+  EXPECT_EQ(jscaled.data(), 0.5 * jt.data());
+
+  JointTorques empty;
+  EXPECT_THROW(0.5 * empty, exceptions::EmptyStateException);
+}
+
+TEST(JointTorquesTest, MatrixMultiplication) {
+  JointTorques jt = JointTorques::Random("test", 3);
+  Eigen::MatrixXd gains = Eigen::VectorXd::Random(jt.get_size()).asDiagonal();
+
+  JointTorques jscaled = gains * jt;
+  EXPECT_EQ(jscaled.data(), gains * jt.data());
+  EXPECT_EQ((jt * gains).data(), jscaled.data());
+  jt *= gains;
+  EXPECT_EQ(jscaled.data(), jt.data());
+  JointTorques jscaled2 = jt * gains;
+
+  gains = Eigen::VectorXd::Random(2 * jt.get_size()).asDiagonal();
+  EXPECT_THROW(gains * jt, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointTorquesTest, ArrayMultiplication) {
+  JointTorques jt = JointTorques::Random("test", 3);
+  Eigen::ArrayXd gains = Eigen::ArrayXd::Random(jt.get_size());
+
+  JointTorques jscaled = gains * jt;
+  EXPECT_EQ(jscaled.data(), (gains * jt.array()).matrix());
+  EXPECT_EQ((jt * gains).data(), jscaled.data());
+  jt *= gains;
+  EXPECT_EQ(jscaled.data(), jt.data());
+
+  gains = Eigen::ArrayXd::Random(2 * jt.get_size());
+  EXPECT_THROW(gains * jt, exceptions::IncompatibleSizeException);
 }

--- a/source/state_representation/test/tests/robot/test_joint_torques.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_torques.cpp
@@ -59,11 +59,11 @@ TEST(JointTorquesTest, StateCopyConstructor) {
 
 TEST(JointTorquesTest, RandomInitialization) {
   JointTorques random1 = JointTorques::Random("test", 3);
-  EXPECT_GT(random1.get_torques().norm(), 0);
+  EXPECT_NE(random1.get_torques().norm(), 0);
   expect_only_torques(random1);
 
   JointTorques random2 = JointTorques::Random("test", std::vector<std::string>{"j0", "j1"});
-  EXPECT_GT(random2.get_torques().norm(), 0);
+  EXPECT_NE(random2.get_torques().norm(), 0);
   expect_only_torques(random2);
 }
 

--- a/source/state_representation/test/tests/robot/test_joint_velocities.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_velocities.cpp
@@ -1,79 +1,222 @@
 #include <gtest/gtest.h>
 #include "state_representation/robot/JointVelocities.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
 
 using namespace state_representation;
 
-TEST(JointVelocitiesTest, RandomVelocitiesInitialization) {
+TEST(JointVelocitiesTest, Constructors) {
+  std::vector<std::string> joint_names{"joint_10", "joint_20"};
+  Eigen::Vector2d velocities = Eigen::Vector2d::Random();
+  JointVelocities jv1("test", velocities);
+  EXPECT_EQ(jv1.get_name(), "test");
+  EXPECT_FALSE(jv1.is_empty());
+  EXPECT_EQ(jv1.get_size(), velocities.size());
+  for (std::size_t i = 0; i < velocities.size(); ++i) {
+    EXPECT_EQ(jv1.get_names().at(i), "joint" + std::to_string(i));
+  }
+  EXPECT_EQ(jv1.data(), velocities);
+
+  JointVelocities jv2("test", joint_names, velocities);
+  EXPECT_EQ(jv2.get_name(), "test");
+  EXPECT_FALSE(jv2.is_empty());
+  EXPECT_EQ(jv2.get_size(), joint_names.size());
+  for (std::size_t i = 0; i < joint_names.size(); ++i) {
+    EXPECT_EQ(jv2.get_names().at(i), joint_names.at(i));
+  }
+  EXPECT_EQ(jv2.data(), velocities);
+}
+
+TEST(JointVelocitiesTest, StateCopyConstructor) {
+  JointState random_state = JointState::Random("test", 3);
+  JointVelocities copy1(random_state);
+  EXPECT_EQ(random_state.get_name(), copy1.get_name());
+  EXPECT_EQ(random_state.get_names(), copy1.get_names());
+  EXPECT_EQ(random_state.get_size(), copy1.get_size());
+  EXPECT_EQ(random_state.get_velocities(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointVelocities copy2 = random_state;
+  EXPECT_EQ(random_state.get_name(), copy2.get_name());
+  EXPECT_EQ(random_state.get_names(), copy2.get_names());
+  EXPECT_EQ(random_state.get_size(), copy2.get_size());
+  EXPECT_EQ(random_state.get_velocities(), copy2.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointState empty_state;
+  JointVelocities copy3(empty_state);
+  EXPECT_TRUE(copy3.is_empty());
+  JointVelocities copy4 = empty_state;
+  EXPECT_TRUE(copy4.is_empty());
+  JointVelocities copy5 = empty_state.copy();
+  EXPECT_TRUE(copy5.is_empty());
+}
+
+TEST(JointVelocitiesTest, AccelerationsCopyConstructor) {
+  JointAccelerations random_accelerations = JointAccelerations::Random("test", 3);
+  JointVelocities copy1(random_accelerations);
+  EXPECT_EQ(random_accelerations.get_name(), copy1.get_name());
+  EXPECT_EQ(random_accelerations.get_names(), copy1.get_names());
+  EXPECT_EQ(random_accelerations.get_size(), copy1.get_size());
+  EXPECT_EQ((std::chrono::seconds(1) * random_accelerations).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointVelocities copy2 = random_accelerations;
+  EXPECT_EQ(random_accelerations.get_name(), copy1.get_name());
+  EXPECT_EQ(random_accelerations.get_names(), copy1.get_names());
+  EXPECT_EQ(random_accelerations.get_size(), copy1.get_size());
+  EXPECT_EQ((std::chrono::seconds(1) * random_accelerations).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointAccelerations empty_accelerations;
+  EXPECT_THROW(JointVelocities copy(empty_accelerations), exceptions::EmptyStateException);
+  EXPECT_THROW(JointVelocities copy = empty_accelerations, exceptions::EmptyStateException);
+}
+
+TEST(JointVelocitiesTest, PositionsCopyConstructor) {
+  JointPositions random_positions = JointPositions::Random("test", 3);
+  JointVelocities copy1(random_positions);
+  EXPECT_EQ(random_positions.get_name(), copy1.get_name());
+  EXPECT_EQ(random_positions.get_names(), copy1.get_names());
+  EXPECT_EQ(random_positions.get_size(), copy1.get_size());
+  EXPECT_EQ((random_positions / std::chrono::seconds(1)).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+
+  JointVelocities copy2 = random_positions;
+  EXPECT_EQ(random_positions.get_name(), copy1.get_name());
+  EXPECT_EQ(random_positions.get_names(), copy1.get_names());
+  EXPECT_EQ(random_positions.get_size(), copy1.get_size());
+  EXPECT_EQ((random_positions / std::chrono::seconds(1)).data(), copy1.data());
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+
+  JointPositions empty_positions;
+  EXPECT_THROW(JointVelocities copy(empty_positions), exceptions::EmptyStateException);
+  EXPECT_THROW(JointVelocities copy = empty_positions, exceptions::EmptyStateException);
+}
+
+TEST(JointVelocitiesTest, RandomInitialization) {
   JointVelocities random = JointVelocities::Random("test", 3);
-  // only velocities should be random
-  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
   EXPECT_GT(random.get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
-  // same for the second initializer
+
   JointVelocities random2 = JointVelocities::Random("test", std::vector<std::string>{"j0", "j1"});
-  // only velocities should be random
-  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_GT(random2.get_velocities().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
   EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
 }
 
-TEST(JointVelocitiesTest, CopyVelocities) {
-  JointVelocities velocities1 = JointVelocities::Random("test", 3);
-  JointVelocities velocities2(velocities1);
-  EXPECT_EQ(velocities1.get_name(), velocities2.get_name());
-  EXPECT_TRUE(velocities1.data().isApprox(velocities2.data()));
-  EXPECT_EQ(static_cast<JointState&>(velocities2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities2).get_torques().norm(), 0);
-  JointVelocities velocities3 = velocities1;
-  EXPECT_EQ(velocities1.get_name(), velocities3.get_name());
-  EXPECT_TRUE(velocities1.data().isApprox(velocities3.data()));
-  EXPECT_EQ(static_cast<JointState&>(velocities3).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities3).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities3).get_torques().norm(), 0);
-  // try to change non pose variables prior to the copy, those should be discarded
-  static_cast<JointState&>(velocities1).set_positions(Eigen::Vector3d::Random());
-  static_cast<JointState&>(velocities1).set_accelerations(Eigen::Vector3d::Random());
-  static_cast<JointState&>(velocities1).set_torques(Eigen::Vector3d::Random());
-  JointVelocities velocities4 = velocities1;
-  EXPECT_TRUE(velocities1.data().isApprox(velocities4.data()));
-  EXPECT_EQ(static_cast<JointState&>(velocities4).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities4).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities4).get_torques().norm(), 0);
-  // copy a state, only the pose variables should be non 0
-  JointVelocities velocities5 = JointState::Random("test", 3);
-  EXPECT_EQ(static_cast<JointState&>(velocities5).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities5).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(velocities5).get_torques().norm(), 0);
+TEST(JointVelocitiesTest, Clamping) {
+  JointVelocities jv1("test", 3);
+  jv1.set_data(-10 * Eigen::VectorXd::Ones(jv1.get_size()));
+  jv1.clamp(15);
+  EXPECT_EQ(jv1.data(), -10 * Eigen::VectorXd::Ones(jv1.get_size()));
+  jv1.clamp(9);
+  EXPECT_EQ(jv1.data(), -9 * Eigen::VectorXd::Ones(jv1.get_size()));
+  jv1.clamp(20, 0.5);
+  EXPECT_EQ(jv1.data(), Eigen::VectorXd::Zero(jv1.get_size()));
 
-  JointVelocities velocities6;
-  EXPECT_TRUE(velocities6.is_empty());
-  JointVelocities velocities7 = velocities6;
-  EXPECT_TRUE(velocities7.is_empty());
+  JointVelocities jv2("test", 3);
+  Eigen::VectorXd velocities(3), result(3);
+  velocities << -2.0, 1.0, -4.0;
+  result << -2.0, 0.0, -3.0;
+  jv2.set_data(velocities);
+  jv2.clamp(10);
+  EXPECT_EQ(jv2.data(), velocities);
+  jv2.clamp(3 * Eigen::ArrayXd::Ones(jv2.get_size()), 0.5 * Eigen::ArrayXd::Ones(jv2.get_size()));
+  EXPECT_EQ(jv2.data(), result);
 }
 
-TEST(JointVelocitiesTest, SetData) {
-  JointVelocities jv1 = JointVelocities::Zero("test", 4);
-  JointVelocities jv2 = JointVelocities::Random("test", 4);
+TEST(JointVelocitiesTest, GetSetData) {
+  JointVelocities jv1 = JointVelocities::Zero("test", 3);
+  JointVelocities jv2 = JointVelocities::Random("test", 3);
+  Eigen::VectorXd data(jv1.get_size());
+  data << jv1.get_velocities();
+  EXPECT_EQ(data, jv1.data());
+  for (std::size_t i = 0; i < jv1.get_size(); ++i) {
+    EXPECT_EQ(data.array()(i), jv1.array()(i));
+  }
+
   jv1.set_data(jv2.data());
   EXPECT_TRUE(jv2.data().isApprox(jv1.data()));
 
-  auto vel_vec = jv2.to_std_vector();
-  jv1.set_data(vel_vec);
-  for (std::size_t j = 0; j < vel_vec.size(); ++j) {
-    EXPECT_FLOAT_EQ(vel_vec.at(j), jv1.data()(j));
+  auto state_vec = jv2.to_std_vector();
+  jv1.set_data(state_vec);
+  for (std::size_t i = 0; i < state_vec.size(); ++i) {
+    EXPECT_EQ(state_vec.at(i), jv1.data()(i));
   }
-  std::vector<double> velocities{1, 2, 3, 4, 5};
-  EXPECT_THROW(jv1.set_data(velocities), exceptions::IncompatibleSizeException);
+  EXPECT_THROW(jv1.set_data(Eigen::Vector2d::Zero()), exceptions::IncompatibleSizeException);
 }
 
-TEST(JointVelocitiesTest, JointVelocitiesToStdVector) {
-  JointVelocities jv = JointVelocities::Random("test_robot", 4);
-  std::vector<double> vec_data = jv.to_std_vector();
-  EXPECT_EQ(vec_data.size(), jv.get_size());
-  for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_EQ(jv.get_velocities()(i), vec_data[i]);
-  }
+TEST(JointVelocitiesTest, ScalarMultiplication) {
+  JointVelocities jv = JointVelocities::Random("test", 3);
+  JointVelocities jscaled = 0.5 * jv;
+  EXPECT_EQ(jscaled.data(), 0.5 * jv.data());
+
+  JointVelocities empty;
+  EXPECT_THROW(0.5 * empty, exceptions::EmptyStateException);
+}
+
+TEST(JointVelocitiesTest, MatrixMultiplication) {
+  JointVelocities jv = JointVelocities::Random("test", 3);
+  Eigen::MatrixXd gains = Eigen::VectorXd::Random(jv.get_size()).asDiagonal();
+
+  JointVelocities jscaled = gains * jv;
+  EXPECT_EQ(jscaled.data(), gains * jv.data());
+  EXPECT_EQ((jv * gains).data(), jscaled.data());
+  jv *= gains;
+  EXPECT_EQ(jscaled.data(), jv.data());
+  JointVelocities jscaled2 = jv * gains;
+
+  gains = Eigen::VectorXd::Random(2 * jv.get_size()).asDiagonal();
+  EXPECT_THROW(gains * jv, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointVelocitiesTest, ArrayMultiplication) {
+  JointVelocities jv = JointVelocities::Random("test", 3);
+  Eigen::ArrayXd gains = Eigen::ArrayXd::Random(jv.get_size());
+
+  JointVelocities jscaled = gains * jv;
+  EXPECT_EQ(jscaled.data(), (gains * jv.array()).matrix());
+  EXPECT_EQ((jv * gains).data(), jscaled.data());
+  jv *= gains;
+  EXPECT_EQ(jscaled.data(), jv.data());
+
+  gains = Eigen::ArrayXd::Random(2 * jv.get_size());
+  EXPECT_THROW(gains * jv, exceptions::IncompatibleSizeException);
+}
+
+TEST(JointVelocitiesTest, ChronoMultiplication) {
+  JointVelocities jv = JointVelocities::Random("test", 3);
+  auto time = std::chrono::seconds(2);
+  JointPositions jp1 = jv * time;
+  EXPECT_EQ(jp1.get_positions(), jv.get_velocities() * time.count());
+  JointPositions jp2 = time * jv;
+  EXPECT_EQ(jp2.get_positions(), jv.get_velocities() * time.count());
+
+  JointVelocities empty;
+  EXPECT_THROW(empty * time, exceptions::EmptyStateException);
+}
+
+TEST(JointVelocitiesTest, ChronoDivision) {
+  JointVelocities jv = JointVelocities::Random("test", 3);
+  auto time = std::chrono::seconds(2);
+  JointAccelerations ja = jv / time;
+  EXPECT_EQ(ja.get_accelerations(), jv.get_velocities() / time.count());
+
+  JointVelocities empty;
+  EXPECT_THROW(empty / time, exceptions::EmptyStateException);
 }

--- a/source/state_representation/test/tests/robot/test_joint_velocities.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_velocities.cpp
@@ -101,11 +101,11 @@ TEST(JointVelocitiesTest, PositionsCopyConstructor) {
 
 TEST(JointVelocitiesTest, RandomInitialization) {
   JointVelocities random1 = JointVelocities::Random("test", 3);
-  EXPECT_GT(random1.get_velocities().norm(), 0);
+  EXPECT_NE(random1.get_velocities().norm(), 0);
   expect_only_velocities(random1);
 
   JointVelocities random2 = JointVelocities::Random("test", std::vector<std::string>{"j0", "j1"});
-  EXPECT_GT(random2.get_velocities().norm(), 0);
+  EXPECT_NE(random2.get_velocities().norm(), 0);
   expect_only_velocities(random2);
 }
 

--- a/source/state_representation/test/tests/robot/test_joint_velocities.cpp
+++ b/source/state_representation/test/tests/robot/test_joint_velocities.cpp
@@ -4,6 +4,12 @@
 
 using namespace state_representation;
 
+static void expect_only_velocities(JointVelocities& vel) {
+  EXPECT_EQ(static_cast<JointState&>(vel).get_positions().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(vel).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<JointState&>(vel).get_torques().norm(), 0);
+}
+
 TEST(JointVelocitiesTest, Constructors) {
   std::vector<std::string> joint_names{"joint_10", "joint_20"};
   Eigen::Vector2d velocities = Eigen::Vector2d::Random();
@@ -11,7 +17,7 @@ TEST(JointVelocitiesTest, Constructors) {
   EXPECT_EQ(jv1.get_name(), "test");
   EXPECT_FALSE(jv1.is_empty());
   EXPECT_EQ(jv1.get_size(), velocities.size());
-  for (std::size_t i = 0; i < velocities.size(); ++i) {
+  for (auto i = 0; i < velocities.size(); ++i) {
     EXPECT_EQ(jv1.get_names().at(i), "joint" + std::to_string(i));
   }
   EXPECT_EQ(jv1.data(), velocities);
@@ -33,18 +39,14 @@ TEST(JointVelocitiesTest, StateCopyConstructor) {
   EXPECT_EQ(random_state.get_names(), copy1.get_names());
   EXPECT_EQ(random_state.get_size(), copy1.get_size());
   EXPECT_EQ(random_state.get_velocities(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_velocities(copy1);
 
   JointVelocities copy2 = random_state;
   EXPECT_EQ(random_state.get_name(), copy2.get_name());
   EXPECT_EQ(random_state.get_names(), copy2.get_names());
   EXPECT_EQ(random_state.get_size(), copy2.get_size());
   EXPECT_EQ(random_state.get_velocities(), copy2.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_velocities(copy2);
 
   JointState empty_state;
   JointVelocities copy3(empty_state);
@@ -62,18 +64,14 @@ TEST(JointVelocitiesTest, AccelerationsCopyConstructor) {
   EXPECT_EQ(random_accelerations.get_names(), copy1.get_names());
   EXPECT_EQ(random_accelerations.get_size(), copy1.get_size());
   EXPECT_EQ((std::chrono::seconds(1) * random_accelerations).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_velocities(copy1);
 
   JointVelocities copy2 = random_accelerations;
   EXPECT_EQ(random_accelerations.get_name(), copy1.get_name());
   EXPECT_EQ(random_accelerations.get_names(), copy1.get_names());
   EXPECT_EQ(random_accelerations.get_size(), copy1.get_size());
   EXPECT_EQ((std::chrono::seconds(1) * random_accelerations).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_velocities(copy2);
 
   JointAccelerations empty_accelerations;
   EXPECT_THROW(JointVelocities copy(empty_accelerations), exceptions::EmptyStateException);
@@ -87,18 +85,14 @@ TEST(JointVelocitiesTest, PositionsCopyConstructor) {
   EXPECT_EQ(random_positions.get_names(), copy1.get_names());
   EXPECT_EQ(random_positions.get_size(), copy1.get_size());
   EXPECT_EQ((random_positions / std::chrono::seconds(1)).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy1).get_torques().norm(), 0);
+  expect_only_velocities(copy1);
 
   JointVelocities copy2 = random_positions;
   EXPECT_EQ(random_positions.get_name(), copy1.get_name());
   EXPECT_EQ(random_positions.get_names(), copy1.get_names());
   EXPECT_EQ(random_positions.get_size(), copy1.get_size());
   EXPECT_EQ((random_positions / std::chrono::seconds(1)).data(), copy1.data());
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(copy2).get_torques().norm(), 0);
+  expect_only_velocities(copy2);
 
   JointPositions empty_positions;
   EXPECT_THROW(JointVelocities copy(empty_positions), exceptions::EmptyStateException);
@@ -106,17 +100,13 @@ TEST(JointVelocitiesTest, PositionsCopyConstructor) {
 }
 
 TEST(JointVelocitiesTest, RandomInitialization) {
-  JointVelocities random = JointVelocities::Random("test", 3);
-  EXPECT_GT(random.get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random).get_torques().norm(), 0);
+  JointVelocities random1 = JointVelocities::Random("test", 3);
+  EXPECT_GT(random1.get_velocities().norm(), 0);
+  expect_only_velocities(random1);
 
   JointVelocities random2 = JointVelocities::Random("test", std::vector<std::string>{"j0", "j1"});
   EXPECT_GT(random2.get_velocities().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_positions().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_accelerations().norm(), 0);
-  EXPECT_EQ(static_cast<JointState&>(random2).get_torques().norm(), 0);
+  expect_only_velocities(random2);
 }
 
 TEST(JointVelocitiesTest, Clamping) {


### PR DESCRIPTION
To finish what I started in PR #183...
As suggested earlier today, I tried to test everything in the derived classes that is *new*, or in other words, I didn't test the operators and constructors that simply point to the parent class operator/constructor.