### PR TITLE
Revise installation of clproto deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Release Versions:
 ## Upcoming changes (in development)
 
 - Protobuf message protocol and C++ binding library `clproto` for
-serializing and deserializing control library objects (#168, #175, #177, #179, #180)
+serializing and deserializing control library objects
+(#168, #175, #177, #179, #180, #190)
 - Methods for packing and unpacking multiple encoded state messages
 into serialized message packets (#182)
 - Add set_data function (#163)

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -25,7 +25,11 @@ The C++ `clproto` library requires control libraries [`state_representation`](..
 and [Google Protobuf](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)
 to be installed on your computer, which includes the compiler `protoc` and the runtime library `libprotobuf.so`.
 
-The easiest way to install `clproto` is to use the included [install script](./install.sh).
+An [install script](./install.sh) is provided in this directory. Run `./install.sh -h` for more information.
+
+### Automatic dependency installation
+
+The easiest way to install `clproto` is to use the included install script in automatic mode.
 By supplying the `--auto` flag to this script, it will automatically and recursively install any dependencies.
 If Protobuf is not yet installed, this step will take some time.
 ```shell
@@ -33,19 +37,15 @@ git clone https://github.com/epfl-lasa/control_libraries.git
 sudo control_libraries/clproto/install.sh --auto
 ```
 
-If you are using Docker, the Protobuf dependencies already built in the [`development-dependencies`](ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest) image.
-You can copy the artefacts across using docker `COPY` functionality:
+### Copying protobuf dependencies
+
+If you are using Docker, the Protobuf dependencies are already built in the [`development-dependencies`](ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest) image.
+Since building and installing Protobuf from source takes quite a long time, you can instead copy the final artefacts
+from this image into your image using docker `COPY` functionality:
 
 ```Dockerfile
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/include/google /usr/local/include/google
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/lib/libproto* /usr/local/lib
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/bin/protoc /usr/local/bin
 RUN ldconfig
-```
-
-If `state_representation`, `protoc` and `libprotobuf` are already installed,
-you can generate the bindings in the [protobuf](./protobuf) directory and the cmake target `clproto` in [clproto_cpp](./clproto_cpp) by running:
-
-```console
-(sudo) ./install.sh
 ```

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -21,9 +21,20 @@ string messages can be decoded back into the equivalent objects.
 
 ## Installation
 
-In order to generate and use those bindings, you need google protobuf to be installed on your computer (cf. https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
-If you are using Docker, `protoc` is already built in the `development-dependencies` image.
-You can copy the library using docker `COPY` functionality:
+The C++ `clproto` library requires control libraries [`state_representation`](../source/state_representation/README.md)
+and [Google Protobuf](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)
+to be installed on your computer, which includes the compiler `protoc` and the runtime library `libprotobuf.so`.
+
+The easiest way to install `clproto` is to use the included [install script](./install.sh).
+By supplying the `--auto` flag to this script, it will automatically and recursively install any dependencies.
+If Protobuf is not yet installed, this step will take some time.
+```shell
+git clone https://github.com/epfl-lasa/control_libraries.git
+sudo control_libraries/clproto/install.sh --auto
+```
+
+If you are using Docker, the Protobuf dependencies already built in the [`development-dependencies`](ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest) image.
+You can copy the artefacts across using docker `COPY` functionality:
 
 ```Dockerfile
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/include/google /usr/local/include/google
@@ -32,7 +43,8 @@ COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest 
 RUN ldconfig
 ```
 
-Once `protoc` is installed, you can generate the bindings in the [protobuf](./protobuf) directory and the cmake target `clproto` in [clproto_cpp](./clproto_cpp) by running:
+If `state_representation`, `protoc` and `libprotobuf` are already installed,
+you can generate the bindings in the [protobuf](./protobuf) directory and the cmake target `clproto` in [clproto_cpp](./clproto_cpp) by running:
 
 ```console
 (sudo) ./install.sh

--- a/protocol/install.sh
+++ b/protocol/install.sh
@@ -134,7 +134,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ -x "$(command -v protoc)" ]; then
+if ! [ -x "$(command -v protoc)" ]; then
   echo ">>> PROTOC NOT FOUND"
   install_protobuf || exit 1
 fi

--- a/protocol/install.sh
+++ b/protocol/install.sh
@@ -1,17 +1,165 @@
 #!/bin/bash
-SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
-PROTOBUF_DIR=$(dirname "${SCRIPT}")/protobuf
-CLPROTO_DIR=$(dirname "${SCRIPT}")/clproto_cpp
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PROTOBUF_DIR="${SCRIPT_DIR}"/protobuf
+CLPROTO_DIR="${SCRIPT_DIR}"/clproto_cpp
 
 INSTALL_DESTINATION="/usr/local"
+AUTO_INSTALL=""
+BINDINGS_ONLY=false
+PROTOBUF_VERSION="3.17.0"
+
+HELP_MESSAGE="Usage: [sudo] ./install.sh [OPTIONS]
+
+An install script for the clproto library.
+
+Options:
+  -y, --auto               Suppress any input prompts and
+                           automatically approve install steps.
+
+  --bindings-only          Only generate the protobuf bindings
+                           without building or installing clproto.
+
+  -d, --dir [path]         Configure the installation directory
+                           (default: ${INSTALL_DESTINATION}).
+
+  --clean-bindings         Clean any previously generated protobuf
+                           bindings.
+
+  --clean                  Delete any previously installed header
+                           files from ${INSTALL_DESTINATION}/include and any
+                           shared library files from ${INSTALL_DESTINATION}/lib.
+
+  --cleandir [path]        Delete any previously installed header
+                           and library files from the specified path.
+
+  -h, --help               Show this help message."
+
+function make_bindings() {
+  cd "${PROTOBUF_DIR}" && make -j all || exit 1
+}
+
+function clean_bindings() {
+  cd "${PROTOBUF_DIR}" && make clean
+}
+
+function install_protobuf() {
+  echo ">>> INSTALLING PROTOBUF DEPENDENCIES"
+  apt-get update && apt-get install "${AUTO_INSTALL}" autoconf automake libtool curl make g++ unzip || exit 1
+
+  mkdir -p "${SCRIPT_DIR}"/install
+  cd "${SCRIPT_DIR}"/install || exit 1
+  wget -O protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
+    https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz &&
+    tar -xzf protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz &&
+    rm protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz
+
+  cd "${SCRIPT_DIR}"/install/protobuf-"${PROTOBUF_VERSION}" || exit 1
+  ./autogen.sh && ./configure && make && make install || exit 1
+  ldconfig
+}
+
+function install_state_representation() {
+  echo ">> INSTALLING CONTROL LIBRARY DEPENDENCIES"
+  mkdir -p "${SCRIPT_DIR}"/install
+  cd "${SCRIPT_DIR}"/install || exit 1
+  CL_INSTALL_SCRIPT="$(dirname "${SCRIPT_DIR}")"/source/install.sh
+  if [ -f "$CL_INSTALL_SCRIPT" ]; then
+    bash "${CL_INSTALL_SCRIPT}" --no-controllers --no-dynamical-systems --no-robot-model "${AUTO_INSTALL}"
+  else
+    echo ">>> INSTALL SCRIPT NOT FOUND: ${CL_INSTALL_SCRIPT}!"
+    exit 1
+  fi
+  ldconfig
+}
+
+function install_clproto() {
+  cd "${CLPROTO_DIR}" && mkdir -p build && cd build || exit 1
+
+  cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" .. || exit 1
+
+  make -j && make install || exit 1
+  ldconfig
+}
+
+function uninstall() {
+  function delete_components() {
+    rm -r "${INSTALL_DESTINATION}"/include/clproto
+    rm -r "${INSTALL_DESTINATION}"/lib/libclproto*.so
+    clean_bindings
+  }
+
+  delete_components >/dev/null 2>&1
+
+  echo "Deleted any clproto artefacts from ${INSTALL_DESTINATION} and ${PROTOBUF_DIR}."
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  -y | --auto)
+    AUTO_INSTALL="-y"
+    shift 1
+    ;;
+  -d | --dir)
+    INSTALL_DESTINATION=$2
+    shift 2
+    ;;
+  --bindings-only)
+    BINDINGS_ONLY=true
+    shift 1
+    ;;
+  --clean-bindings)
+    clean_bindings
+    exit 0
+    ;;
+  --clean)
+    uninstall
+    exit 0
+    ;;
+  --cleandir)
+    INSTALL_DESTINATION=$2
+    uninstall
+    exit 0
+    ;;
+  -h | --help)
+    echo "$HELP_MESSAGE"
+    exit 0
+    ;;
+
+  -*)
+    echo "Unknown option: $1" >&2
+    echo "$FAIL_MESSAGE"
+    exit 1
+    ;;
+  esac
+done
+
+if [ -x "$(command -v protoc)" ]; then
+  echo ">>> PROTOC NOT FOUND"
+  install_protobuf || exit 1
+fi
 
 echo ">>> GENERATING PROTOBUF BINDINGS"
-cd ${PROTOBUF_DIR} && make -j all
+make_bindings || exit 1
+
+if [ $BINDINGS_ONLY == true ]; then
+  echo ">>> DONE!"
+  exit 0
+fi
+
+PROTOBUF_INSTALL=$(ldconfig -p | grep libprotobuf)
+if [ -z "$PROTOBUF_INSTALL" ] ]; then
+  echo ">>> LIBPROTOBUF NOT FOUND"
+  install_protobuf || exit 1
+fi
+
+STATE_REPRESENTATION_INSTALL=$(ldconfig -p | grep libstate_representation)
+if [ -z "$STATE_REPRESENTATION_INSTALL" ]; then
+  echo ">>> STATE REPRESENTATION LIBRARY NOT FOUND!"
+  install_state_representation
+fi
 
 echo ">>> INSTALLING CLPROTO"
-cd ${CLPROTO_DIR} && mkdir -p build && cd build || exit 1
+install_clproto || exit 1
 
-cmake -DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" .. 
-
-make -j && make install
+echo ">>> DONE"

--- a/protocol/protobuf/README.md
+++ b/protocol/protobuf/README.md
@@ -1,9 +1,24 @@
 # Protobuf
 
-## TODO
+This directory contains the .proto source files and build system to generate binding code for protobuf messages.
 
-- describe structure of proto files in more detail
+## StateMessage
 
-- describe installation of protobuf compiler protoc vs runtime library libprotobuf
+The [proto](./proto) directory contains the protobuf message description files for the state representation module.
 
-- explain makefile and procedure for regenerating language-specific bindings
+The design concept is a top-level `StateMessage` container in [state_message.proto](./proto/state_representation/state_message.proto)
+using a `oneof` field to distinguish between individual state message classes.
+Each contained message class is defined with a kind of inheritance from the `State` message in [state.proto](./proto/state_representation/state.proto),
+and follows a similar hierarchy as the original classes in the C++ `state_representation` namespace.
+
+## Generated bindings
+
+The [Makefile](./Makefile) invokes `protoc` to generate binding code from the .proto source files for various languages.
+The C++ bindings are used internally by the `clproto` encoding / decoding library to interface directly
+with the C++ `state_representation` classes, but could also be generated and used by client applications and libraries
+in other languages including Python, Java and Go. This allows the core data structure to be shared and handled
+across different platforms with a common encoding scheme.
+
+See the Protobuf [documentation](https://developers.google.com/protocol-buffers) and
+[language tutorials](https://developers.google.com/protocol-buffers/docs/tutorials) for more information.
+


### PR DESCRIPTION
* Add help message and arg parsing
to install script

* Add subfunctions to contain
the making / cleaning of clproto
and bindings

* Add checks for installation of
protoc and libprotobuf

* Protobuf dependencies  are prompted
/ installed by the script if needed

* state representation is installed
assuming a parent directory
if it isn't found

* Add option to build proto bindings
alone, without clproto_cpp

* Update README

---

I wanted to make the installation of clproto super simple. I tested it first using the `control-libraries/development-dependencies` image (which has protobuf already installed, but not state representation), then by first installing state_representation, and finally with the following dockerfile, where nothing was installed yet. All seemed to perform the steps as expected (although of course copying the pre-compiled protobuf deps is still much faster than rebuilding it, as the README suggests).

```dockerfile
FROM ubuntu:20.04
ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update && apt-get install -y \
    build-essential \
    cmake \
    git \
    sudo \
    wget

RUN git clone -b develop https://github.com/epfl-lasa/control_libraries.git
RUN bash control_libraries/protocol/install.sh --auto

RUN apt-get clean && rm -rf /var/lib/apt/lists/*
```