### PR TITLE
Clamp all state variables is not implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ into serialized message packets (#182)
   the generated bindings from the repository, while providing installation
   scripts (#174)
 - Add class JointAccelerations (#173)
-- Fix clamp_state_variable function for CartesianState and JointState (#176)
+- Fix clamp_state_variable function for CartesianState and JointState (#176, #191)
 - Install tagged versions of osqp and osqpEigen (#184)
 - Refactor JointState tests and split them into separate test suites (#183, #187)
 - Add missing integration constructor from JointAccelerations for JointVelocities (#185)

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -239,8 +239,8 @@ CartesianState CartesianState::inverse() const {
 void CartesianState::clamp_state_variable(
     double max_norm, const CartesianStateVariable& state_variable_type, double noise_ratio
 ) {
-  if (state_variable_type == CartesianStateVariable::ORIENTATION
-      || state_variable_type == CartesianStateVariable::POSE) {
+  if (state_variable_type == CartesianStateVariable::ORIENTATION || state_variable_type == CartesianStateVariable::POSE
+      || state_variable_type == CartesianStateVariable::ALL) {
     throw NotImplementedException("clamp_state_variable is not implemented for this CartesianStateVariable");
   }
   Eigen::VectorXd state_variable_value = this->get_state_variable(state_variable_type);


### PR DESCRIPTION
Obviously, if we don't allow to clamp the POSE and ORIENTATION, we cannot allow ALL either.