### PR TITLE
Add scalar division operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ into serialized message packets (#182)
 - Add missing integration constructor from JointAccelerations for JointVelocities (#185)
 - Remove previously deprecated from_std_vector function (#186)
 - Refactor CartesianState tests and split them into separate test suites (#188)
+- Add scalar division operator for CartesianState and its derived classes (#192)
 
 ### Pending TODOs for the next release
 

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -183,9 +183,23 @@ public:
   /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
-   * @return the CartesianState multiplied by lambda
+   * @return the CartesianPose multiplied by lambda
    */
   CartesianPose operator*(double lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianPose divided by lambda
+   */
+  CartesianPose& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianPose divided by lambda
+   */
+  CartesianPose operator/(double lambda) const;
 
   /**
    * @brief Overload the += operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -415,6 +415,20 @@ public:
   CartesianState operator*(double lambda) const;
 
   /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianState divided by lambda
+   */
+  CartesianState& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianState divided by lambda
+   */
+  CartesianState operator/(double lambda) const;
+
+  /**
    * @brief Overload the += operator
    * @param state CartesianState to add
    * @return the current CartesianState added the CartesianState given in argument

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -75,24 +75,24 @@ public:
   /**
    * @brief Construct a CartesianTwist from a linear velocity given as a vector.
    */
-  explicit CartesianTwist(const std::string& name,
-                          const Eigen::Vector3d& linear_velocity,
-                          const std::string& reference = "world");
+  explicit CartesianTwist(
+      const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference = "world"
+  );
 
   /**
    * @brief Construct a CartesianTwist from a linear velocity and angular velocity given as vectors.
    */
-  explicit CartesianTwist(const std::string& name,
-                          const Eigen::Vector3d& linear_velocity,
-                          const Eigen::Vector3d& angular_velocity,
-                          const std::string& reference = "world");
+  explicit CartesianTwist(
+      const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity,
+      const std::string& reference = "world"
+  );
 
   /**
    * @brief Construct a CartesianTwist from a single 6d twist vector
    */
-  explicit CartesianTwist(const std::string& name,
-                          const Eigen::Matrix<double, 6, 1>& twist,
-                          const std::string& reference = "world");
+  explicit CartesianTwist(
+      const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference = "world"
+  );
 
   /**
    * @brief Constructor for the zero twist
@@ -243,10 +243,9 @@ public:
    * the angular velocity will be set to 0
    * @return the clamped twist
    */
-  CartesianTwist clamped(double max_linear,
-                         double max_angular,
-                         double noise_ratio = 0,
-                         double angular_noise_ratio = 0) const;
+  CartesianTwist clamped(
+      double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0
+  ) const;
 
   /**
    * @brief Return a copy of the CartesianTwist
@@ -283,7 +282,8 @@ public:
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector
    */
-  std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::TWIST) const override;
+  std::vector<double>
+  norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::TWIST) const override;
 
   /**
    * @brief Compute the normalized twist at the state variable given in argument (default is full twist)

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -190,9 +190,23 @@ public:
   /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
-   * @return the CartesianState multiplied by lambda
+   * @return the CartesianTwist multiplied by lambda
    */
   CartesianTwist operator*(double lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianTwist divided by lambda
+   */
+  CartesianTwist& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianTwist divided by lambda
+   */
+  CartesianTwist operator/(double lambda) const;
 
   /**
    * @brief Overload the *= operator with a gain matrix

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -177,16 +177,30 @@ public:
   /**
    * @brief Overload the *= operator with a scalar
    * @param lambda the scalar to multiply with
-   * @return the CartesianWrench multiply by lambda
+   * @return the CartesianWrench multiplied by lambda
    */
   CartesianWrench& operator*=(double lambda);
 
   /**
    * @brief Overload the * operator with a scalar
    * @param lambda the scalar to multiply with
-   * @return the CartesianWrench multiply by lambda
+   * @return the CartesianWrench multiplied by lambda
    */
   CartesianWrench operator*(double lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianWrench divided by lambda
+   */
+  CartesianWrench& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianWrench divided by lambda
+   */
+  CartesianWrench operator/(double lambda) const;
 
   /**
    * @brief Clamp inplace the magnitude of the wrench to the values in argument

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -69,24 +69,24 @@ public:
   /**
    * @brief Construct a CartesianWrench from a force given as a vector.
    */
-  explicit CartesianWrench(const std::string& name,
-                           const Eigen::Vector3d& force,
-                           const std::string& reference = "world");
+  explicit CartesianWrench(
+      const std::string& name, const Eigen::Vector3d& force, const std::string& reference = "world"
+  );
 
   /**
    * @brief Construct a CartesianWrench from a force and torque given as vectors.
    */
-  explicit CartesianWrench(const std::string& name,
-                           const Eigen::Vector3d& force,
-                           const Eigen::Vector3d& torque,
-                           const std::string& reference = "world");
+  explicit CartesianWrench(
+      const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque,
+      const std::string& reference = "world"
+  );
 
   /**
    * @brief Construct a CartesianWrench from a single 6d wrench vector
    */
-  explicit CartesianWrench(const std::string& name,
-                           const Eigen::Matrix<double, 6, 1>& wrench,
-                           const std::string& reference = "world");
+  explicit CartesianWrench(
+      const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference = "world"
+  );
 
   /**
    * @brief Constructor for the zero wrench
@@ -223,10 +223,9 @@ public:
    * the torque will be set to 0
    * @return the clamped wrench
    */
-  CartesianWrench clamped(double max_force,
-                          double max_torque,
-                          double force_noise_ratio = 0,
-                          double torque_noise_ratio = 0) const;
+  CartesianWrench clamped(
+      double max_force, double max_torque, double force_noise_ratio = 0, double torque_noise_ratio = 0
+  ) const;
 
   /**
    * @brief Return a copy of the CartesianWrench
@@ -263,7 +262,8 @@ public:
    * @param state_variable_type the type of state variable to compute the norms on
    * @return the norms of the state variables as a vector
    */
-  std::vector<double> norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::WRENCH) const override;
+  std::vector<double>
+  norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::WRENCH) const override;
 
   /**
    * @brief Compute the normalized wrench at the state variable given in argument (default is full wrench)

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -85,6 +85,15 @@ CartesianPose CartesianPose::operator*(double lambda) const {
   return this->CartesianState::operator*(lambda);
 }
 
+CartesianPose& CartesianPose::operator/=(double lambda) {
+  this->CartesianState::operator/=(lambda);
+  return (*this);
+}
+
+CartesianPose CartesianPose::operator/(double lambda) const {
+  return this->CartesianState::operator/(lambda);
+}
+
 CartesianPose& CartesianPose::operator+=(const CartesianPose& pose) {
   this->CartesianState::operator+=(pose);
   return (*this);

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -69,6 +69,17 @@ CartesianState CartesianState::operator*(double lambda) const {
   return result;
 }
 
+CartesianState& CartesianState::operator/=(double lambda) {
+  lambda = 1.0 / lambda;
+  return this->operator*=(lambda);
+}
+
+CartesianState CartesianState::operator/(double lambda) const {
+  CartesianState result(*this);
+  result /= lambda;
+  return result;
+}
+
 CartesianState CartesianState::copy() const {
   CartesianState result(*this);
   return result;

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -70,6 +70,9 @@ CartesianState CartesianState::operator*(double lambda) const {
 }
 
 CartesianState& CartesianState::operator/=(double lambda) {
+  if (std::abs(lambda) < std::numeric_limits<double>::min()) {
+    throw std::runtime_error("Division by zero is not allowed");
+  }
   lambda = 1.0 / lambda;
   return this->operator*=(lambda);
 }

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -101,6 +101,15 @@ CartesianTwist CartesianTwist::operator*(double lambda) const {
   return this->CartesianState::operator*(lambda);
 }
 
+CartesianTwist& CartesianTwist::operator/=(double lambda) {
+  this->CartesianState::operator/=(lambda);
+  return (*this);
+}
+
+CartesianTwist CartesianTwist::operator/(double lambda) const {
+  return this->CartesianState::operator/(lambda);
+}
+
 CartesianTwist& CartesianTwist::operator*=(const Eigen::Matrix<double, 6, 6>& lambda) {
   // sanity check
   if (this->is_empty()) {

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -7,26 +7,23 @@ namespace state_representation {
 CartesianTwist::CartesianTwist(const std::string& name, const std::string& reference) :
     CartesianState(name, reference) {}
 
-CartesianTwist::CartesianTwist(const std::string& name,
-                               const Eigen::Vector3d& linear_velocity,
-                               const std::string& reference) :
-    CartesianState(name, reference) {
+CartesianTwist::CartesianTwist(
+    const std::string& name, const Eigen::Vector3d& linear_velocity, const std::string& reference
+) : CartesianState(name, reference) {
   this->set_linear_velocity(linear_velocity);
 }
 
-CartesianTwist::CartesianTwist(const std::string& name,
-                               const Eigen::Vector3d& linear_velocity,
-                               const Eigen::Vector3d& angular_velocity,
-                               const std::string& reference) :
-    CartesianState(name, reference) {
+CartesianTwist::CartesianTwist(
+    const std::string& name, const Eigen::Vector3d& linear_velocity, const Eigen::Vector3d& angular_velocity,
+    const std::string& reference
+) : CartesianState(name, reference) {
   this->set_linear_velocity(linear_velocity);
   this->set_angular_velocity(angular_velocity);
 }
 
-CartesianTwist::CartesianTwist(const std::string& name,
-                               const Eigen::Matrix<double, 6, 1>& twist,
-                               const std::string& reference) :
-    CartesianState(name, reference) {
+CartesianTwist::CartesianTwist(
+    const std::string& name, const Eigen::Matrix<double, 6, 1>& twist, const std::string& reference
+) : CartesianState(name, reference) {
   this->set_twist(twist);
 }
 
@@ -37,7 +34,8 @@ CartesianTwist::CartesianTwist(const CartesianState& state) : CartesianState(sta
   this->set_empty(state.is_empty());
 }
 
-CartesianTwist::CartesianTwist(const CartesianTwist& twist) : CartesianTwist(static_cast<const CartesianState&>(twist)) {}
+CartesianTwist::CartesianTwist(const CartesianTwist& twist) :
+    CartesianTwist(static_cast<const CartesianState&>(twist)) {}
 
 CartesianTwist::CartesianTwist(const CartesianPose& pose) : CartesianTwist(pose / std::chrono::seconds(1)) {}
 
@@ -64,11 +62,9 @@ CartesianState CartesianTwist::operator*(const CartesianState& state) const {
   return this->CartesianState::operator*(state);
 }
 
-
 CartesianPose CartesianTwist::operator*(const CartesianPose& pose) const {
   return this->CartesianState::operator*(pose);
 }
-
 
 CartesianWrench CartesianTwist::operator*(const CartesianWrench& wrench) const {
   return this->CartesianState::operator*(wrench);
@@ -144,20 +140,18 @@ CartesianPose CartesianTwist::operator*(const std::chrono::nanoseconds& dt) cons
   return displacement;
 }
 
-void CartesianTwist::clamp(double max_linear,
-                           double max_angular,
-                           double linear_noise_ratio,
-                           double angular_noise_ratio) {
+void CartesianTwist::clamp(
+    double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio
+) {
   // clamp linear
   this->clamp_state_variable(max_linear, CartesianStateVariable::LINEAR_VELOCITY, linear_noise_ratio);
   // clamp angular
   this->clamp_state_variable(max_angular, CartesianStateVariable::ANGULAR_VELOCITY, angular_noise_ratio);
 }
 
-CartesianTwist CartesianTwist::clamped(double max_linear,
-                                       double max_angular,
-                                       double linear_noise_ratio,
-                                       double angular_noise_ratio) const {
+CartesianTwist CartesianTwist::clamped(
+    double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio
+) const {
   CartesianTwist result(*this);
   result.clamp(max_linear, max_angular, linear_noise_ratio, angular_noise_ratio);
   return result;

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -11,17 +11,16 @@ CartesianWrench::CartesianWrench(const std::string& name, const Eigen::Vector3d&
   this->set_force(force);
 }
 
-CartesianWrench::CartesianWrench(const std::string& name,
-                                 const Eigen::Vector3d& force,
-                                 const Eigen::Vector3d& torque,
-                                 const std::string& reference) : CartesianState(name, reference) {
+CartesianWrench::CartesianWrench(
+    const std::string& name, const Eigen::Vector3d& force, const Eigen::Vector3d& torque, const std::string& reference
+) : CartesianState(name, reference) {
   this->set_force(force);
   this->set_torque(torque);
 }
 
-CartesianWrench::CartesianWrench(const std::string& name,
-                                 const Eigen::Matrix<double, 6, 1>& wrench,
-                                 const std::string& reference) : CartesianState(name, reference) {
+CartesianWrench::CartesianWrench(
+    const std::string& name, const Eigen::Matrix<double, 6, 1>& wrench, const std::string& reference
+) : CartesianState(name, reference) {
   this->set_wrench(wrench);
 }
 
@@ -32,7 +31,8 @@ CartesianWrench::CartesianWrench(const CartesianState& state) : CartesianState(s
   this->set_empty(state.is_empty());
 }
 
-CartesianWrench::CartesianWrench(const CartesianWrench& wrench) : CartesianWrench(static_cast<const CartesianState&>(wrench)) {}
+CartesianWrench::CartesianWrench(const CartesianWrench& wrench) :
+    CartesianWrench(static_cast<const CartesianState&>(wrench)) {}
 
 CartesianWrench CartesianWrench::Zero(const std::string& name, const std::string& reference) {
   return CartesianState::Identity(name, reference);
@@ -57,11 +57,9 @@ CartesianState CartesianWrench::operator*(const CartesianState& state) const {
   return this->CartesianState::operator*(state);
 }
 
-
 CartesianPose CartesianWrench::operator*(const CartesianPose& pose) const {
   return this->CartesianState::operator*(pose);
 }
-
 
 CartesianTwist CartesianWrench::operator*(const CartesianTwist& twist) const {
   return this->CartesianState::operator*(twist);
@@ -110,10 +108,9 @@ void CartesianWrench::clamp(double max_force, double max_torque, double force_no
   this->clamp_state_variable(max_torque, CartesianStateVariable::TORQUE, torque_noise_ratio);
 }
 
-CartesianWrench CartesianWrench::clamped(double max_force,
-                                         double max_torque,
-                                         double force_noise_ratio,
-                                         double torque_noise_ratio) const {
+CartesianWrench CartesianWrench::clamped(
+    double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio
+) const {
   CartesianWrench result(*this);
   result.clamp(max_force, max_torque, force_noise_ratio, torque_noise_ratio);
   return result;

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -94,6 +94,15 @@ CartesianWrench CartesianWrench::operator*(double lambda) const {
   return this->CartesianState::operator*(lambda);
 }
 
+CartesianWrench& CartesianWrench::operator/=(double lambda) {
+  this->CartesianState::operator/=(lambda);
+  return (*this);
+}
+
+CartesianWrench CartesianWrench::operator/(double lambda) const {
+  return this->CartesianState::operator/(lambda);
+}
+
 void CartesianWrench::clamp(double max_force, double max_torque, double force_noise_ratio, double torque_noise_ratio) {
   // clamp force
   this->clamp_state_variable(max_force, CartesianStateVariable::FORCE, force_noise_ratio);

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_state.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
 #include "state_representation/exceptions/NotImplementedException.hpp"
 
 using namespace state_representation;
@@ -125,4 +126,23 @@ TEST(CartesianStateTest, TestNormalized) {
   for (double n: norms) {
     EXPECT_NEAR(n, 1.0, tolerance);
   }
+}
+
+TEST(CartesianStateTest, TestScalarDivison) {
+  double scalar = 2;
+  CartesianState cs = CartesianState::Random("test");
+  CartesianState cscaled = cs / scalar;
+  EXPECT_EQ(cscaled.get_position(), cs.get_position() / scalar);
+  Eigen::Quaterniond qscaled = math_tools::exp(math_tools::log(cs.get_orientation()), 1.0 / (2. * scalar));
+  EXPECT_TRUE(cscaled.get_orientation().coeffs().isApprox(qscaled.coeffs()));
+  EXPECT_EQ(cscaled.get_twist(), cs.get_twist() / scalar);
+  EXPECT_EQ(cscaled.get_accelerations(), cs.get_accelerations() / scalar);
+  EXPECT_EQ(cscaled.get_wrench(), cs.get_wrench() / scalar);
+  cs /= scalar;
+  EXPECT_EQ(cscaled.data(), cs.data());
+
+  EXPECT_THROW(cs / 0.0, std::runtime_error);
+
+  CartesianState empty;
+  EXPECT_THROW(empty / scalar, exceptions::EmptyStateException);
 }


### PR DESCRIPTION
Another small improvement..The scalar multiplication for CartesianState was implemented, but not the scalar division. I know its not technically necessary but I prefer it anyway for nice style.

First commit is the actual changes, second one only formatting.