### PR TITLE
Remove CartesianState operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ into serialized message packets (#182)
 - Remove previously deprecated from_std_vector function (#186)
 - Refactor CartesianState tests and split them into separate test suites (#188)
 - Add scalar division operator for CartesianState and its derived classes (#192)
+- Remove invalid multiplication operators for CartesianState and its derived classes (#195)
 
 ### Pending TODOs for the next release
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11>=2.6.0",
+    "pybind11>=2.7.0",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -163,6 +163,9 @@ void cartesian_pose(py::module_& m) {
 
   c.def(py::self *= py::self);
   c.def(py::self * py::self);
+  c.def(py::self * CartesianState());
+  c.def(py::self * CartesianTwist());
+  c.def(py::self * CartesianWrench());
   c.def(py::self * Eigen::Vector3d());
   c.def(py::self *= double());
   c.def(py::self * double());
@@ -223,8 +226,6 @@ void cartesian_twist(py::module_& m) {
     c.def(std::string("set_" + attr).c_str(), [](const CartesianTwist& twist) -> CartesianTwist { return twist; }, "Deleted method from parent class.");
   }
 
-  c.def(py::self *= py::self);
-  c.def(py::self * py::self);
   c.def(py::self += py::self);
   c.def(py::self + py::self);
   c.def(py::self -= py::self);
@@ -289,8 +290,6 @@ void cartesian_wrench(py::module_& m) {
     c.def(std::string("set_" + attr).c_str(), [](const CartesianWrench& wrench) -> CartesianWrench { return wrench; }, "Deleted method from parent class.");
   }
 
-  c.def(py::self *= py::self);
-  c.def(py::self * py::self);
   c.def(py::self += py::self);
   c.def(py::self + py::self);
   c.def(py::self -= py::self);

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -286,7 +286,7 @@ void cartesian_wrench(py::module_& m) {
 
   for (const std::string& attr : deleted_attributes) {
     c.def(std::string("get_" + attr).c_str(), [](const CartesianWrench&) -> void {}, "Deleted method from parent class.");
-    c.def(std::string("set_" + attr).c_str(), [](const CartesianWrench& wrench) -> CartesianPose { return wrench; }, "Deleted method from parent class.");
+    c.def(std::string("set_" + attr).c_str(), [](const CartesianWrench& wrench) -> CartesianWrench { return wrench; }, "Deleted method from parent class.");
   }
 
   c.def(py::self *= py::self);

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -36,6 +36,7 @@ public:
   void set_force(const Eigen::Vector3d& force) = delete;
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
+  CartesianState operator*=(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -37,6 +37,7 @@ public:
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
   CartesianState operator*=(const CartesianState& state) = delete;
+  friend CartesianState operator*=(const CartesianState& state, const CartesianPose& pose) = delete;
 
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -46,6 +46,7 @@ public:
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
   CartesianState operator*=(const CartesianState& state) = delete;
   CartesianState operator*(const CartesianState& state) = delete;
+  friend CartesianState operator*=(const CartesianState& state, const CartesianTwist& twist) = delete;
 
   /**
    * @brief Empty constructor

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -44,6 +44,8 @@ public:
   void set_force(const Eigen::Vector3d& force) = delete;
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
+  CartesianState operator*=(const CartesianState& state) = delete;
+  CartesianState operator*(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor
@@ -116,41 +118,6 @@ public:
    * @return reference to the current twist with new values
    */
   CartesianTwist& operator=(const CartesianTwist& twist) = default;
-
-  /**
-   * @brief Overload the *= operator
-   * @param twist CartesianTwist to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
-   */
-  CartesianTwist& operator*=(const CartesianTwist& twist);
-
-  /**
-   * @brief Overload the * operator with a twist
-   * @param twist CartesianTwist to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianTwist given in argument
-   */
-  [[deprecated]] CartesianTwist operator*(const CartesianTwist& twist) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param state CartesianState to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianState given in argument
-   */
-  [[deprecated]] CartesianState operator*(const CartesianState& state) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param state CartesianPose to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianPose given in argument
-   */
-  [[deprecated]] CartesianPose operator*(const CartesianPose& pose) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param state CartesianWrench to multiply with
-   * @return the current CartesianTwist multiplied by the CartesianWrench given in argument
-   */
-  [[deprecated]] CartesianWrench operator*(const CartesianWrench& wrench) const;
 
   /**
    * @brief Overload the += operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -43,6 +43,8 @@ public:
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
   void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  CartesianState operator*=(const CartesianState& state) = delete;
+  CartesianState operator*(const CartesianState& state) = delete;
 
   /**
    * @brief Empty constructor
@@ -110,41 +112,6 @@ public:
    * @return reference to the current wrench with new values
    */
   CartesianWrench& operator=(const CartesianWrench& wrench) = default;
-
-  /**
-   * @brief Overload the *= operator
-   * @param wrench CartesianWrench to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
-   */
-  CartesianWrench& operator*=(const CartesianWrench& wrench);
-
-  /**
-   * @brief Overload the * operator with a wrench
-   * @param wrench CartesianWrench to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianWrench given in argument
-   */
-  [[deprecated]] CartesianWrench operator*(const CartesianWrench& wrench) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param state CartesianState to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianState given in argument
-   */
-  [[deprecated]] CartesianState operator*(const CartesianState& state) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param state CartesianPose to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianPose given in argument
-   */
-  [[deprecated]] CartesianPose operator*(const CartesianPose& pose) const;
-
-  /**
-   * @brief Overload the * operator
-   * @param state CartesianWrench to multiply with
-   * @return the current CartesianWrench multiplied by the CartesianTwist given in argument
-   */
-  [[deprecated]] CartesianTwist operator*(const CartesianTwist& twist) const;
 
   /**
    * @brief Overload the += operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -45,6 +45,7 @@ public:
   void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
   CartesianState operator*=(const CartesianState& state) = delete;
   CartesianState operator*(const CartesianState& state) = delete;
+  friend CartesianState operator*=(const CartesianState& state, const CartesianWrench& wrench) = delete;
 
   /**
    * @brief Empty constructor

--- a/source/state_representation/src/space/cartesian/CartesianTwist.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianTwist.cpp
@@ -49,27 +49,6 @@ CartesianTwist CartesianTwist::Random(const std::string& name, const std::string
   return CartesianTwist(name, random, reference);
 }
 
-CartesianTwist& CartesianTwist::operator*=(const CartesianTwist& twist) {
-  this->CartesianState::operator*=(twist);
-  return (*this);
-}
-
-CartesianTwist CartesianTwist::operator*(const CartesianTwist& twist) const {
-  return this->CartesianState::operator*(twist);
-}
-
-CartesianState CartesianTwist::operator*(const CartesianState& state) const {
-  return this->CartesianState::operator*(state);
-}
-
-CartesianPose CartesianTwist::operator*(const CartesianPose& pose) const {
-  return this->CartesianState::operator*(pose);
-}
-
-CartesianWrench CartesianTwist::operator*(const CartesianWrench& wrench) const {
-  return this->CartesianState::operator*(wrench);
-}
-
 CartesianTwist& CartesianTwist::operator+=(const CartesianTwist& twist) {
   this->CartesianState::operator+=(twist);
   return (*this);

--- a/source/state_representation/src/space/cartesian/CartesianWrench.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianWrench.cpp
@@ -44,27 +44,6 @@ CartesianWrench CartesianWrench::Random(const std::string& name, const std::stri
   return CartesianWrench(name, random, reference);
 }
 
-CartesianWrench& CartesianWrench::operator*=(const CartesianWrench& wrench) {
-  this->CartesianState::operator*=(wrench);
-  return (*this);
-}
-
-CartesianWrench CartesianWrench::operator*(const CartesianWrench& wrench) const {
-  return this->CartesianState::operator*(wrench);
-}
-
-CartesianState CartesianWrench::operator*(const CartesianState& state) const {
-  return this->CartesianState::operator*(state);
-}
-
-CartesianPose CartesianWrench::operator*(const CartesianPose& pose) const {
-  return this->CartesianState::operator*(pose);
-}
-
-CartesianTwist CartesianWrench::operator*(const CartesianTwist& twist) const {
-  return this->CartesianState::operator*(twist);
-}
-
 CartesianWrench& CartesianWrench::operator+=(const CartesianWrench& wrench) {
   this->CartesianState::operator+=(wrench);
   return (*this);


### PR DESCRIPTION
As discussed in several threads, this PR finally removes various operators for the CartesianState class and its derived ones. 

In the future, only the following operations will be possible:
```
state * ANYTHING
pose * ANYTHING
pose *= pose
state *= state
```
Everything else does not make sense.