### PR TITLE
Add ldconfig at the end of install script

### DIFF
--- a/source/install.sh
+++ b/source/install.sh
@@ -131,6 +131,8 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 
 make -j && make install || exit 1
 
+ldconfig
+
 # cleanup any temporary folders
 rm -rf "${SOURCE_PATH}"/tmp
 


### PR DESCRIPTION
I realized that if you first install the source and then the protocol, you always need to run `ldconfig` manually in between such that the install script of the protocol sees the state_representation installation. This would avoid having this additional line in the installation procedures, and its small enough to go in 4.0 :smile: 