### PR TITLE
Refactor/documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ serializing and deserializing control library objects
 into serialized message packets (#182)
 - Add set_data function (#163)
 - Move set_data declaration to State and add it for Ellipsoid (#166)
-- Add automatic documentation generation and deployment to GitHub Pages (#170)
+- Add automatic documentation generation and deployment to GitHub Pages (#170, #199)
 - Build and push development dependencies image in CI and related 
   restructuring of Docker resources (#169)
 - Correct an error in the `makefile` of the protobuf bindings and remove

--- a/README.md
+++ b/README.md
@@ -21,135 +21,18 @@
 A set of libraries to facilitate the creation of full control loop algorithms,
 including trajectory planning, kinematics, dynamics and control.
 
+Documentation is available at <a href="https://epfl-lasa.github.io/control_libraries/versions/main/">epfl-lasa.github.io/control_libraries</a>
+
 ## Core libraries
 
-For the implementation and documentation of the core libraries, see the
-[source](./source) folder.
+For the implementation, installation and documentation of the core libraries, see the
+<a href="https://github.com/epfl-lasa/control_libraries/tree/main/source">source</a> folder.
 
 ## Python bindings
 
-There exist Python bindings for the control libraries (currently not all libraries
-supported). See the [python](./python) folder for installation instructions and
-currently supported libraries.
+There exist Python bindings for core control library modules. See the <a href="https://github.com/epfl-lasa/control_libraries/tree/main/python">python</a>
+folder for installation instructions and currently supported libraries.
 
 ## Demos
 
-For examples and demos in plain C++, ROS, and ROS2, refer to the [demos](./demos) folder.
-
----
-## Installation
-
-### Supported platforms
-
-These libraries have been developed and tested on Linux Ubuntu 18.04 and 20.04. 
-They should also work on macOS and Windows, though the installation 
-steps may differ. At this time no guarantees are made for library support on
-non-Linux systems.
-
-### Installation with the install script
-This project uses CMake to generate static library objects for each of the modules. 
-
-To facilitate the installation process, an [install script](source/install.sh) is provided. Users who are interested in 
-the manual installation steps and/or have already installed Pinocchio refer to the 
-[manual installation steps](#manual-installation-steps) in the next section.
-
-The install script takes care of all the installation steps, including the installation and configuration of Pinocchio. 
-It can be run with several optional arguments:
-- `-y`, `--auto`: Any input prompts will be suppressed and install steps automatically approved.
-- `-d [path]`, `--dir [path]`: If provided, the installation directory will be changed to `[path]`.
-- `--no-controllers`: The controllers library will be excluded from the installation.
-- `--no-dynamical-systems`: The dynamical systems library will be excluded from the installation.
-- `--no-robot-model`: The robot model library, and therefore Pinocchio, will be excluded from the installation.
-- `--build-tests`: The unittest targets will be included in the installation.
-- `--clean`: Any previously installed header files from `/usr/local/include` and any shared library files from
-`/usr/local/lib` will be deleted before the installation.
-- `--cleandir [path]`: Any previously installed header files shared library files from `[path]` will be deleted before 
-  the installation.
-
-### Manual installation steps
-
-Eigen3 is required for building `state_representation` and all other libraries.
-You can install it with:
-```shell script
-apt-get install libeigen3-dev
-```
-
-Pinocchio is required for building the `robot_model` library. Installing this requires
-some additional steps; see the [install script](source/install.sh) for reference.
-If the `robot_model` library is not needed, you can skip the installation of Pinocchio.
-
-Once the dependencies are installed, build and install the libraries by navigating
-to the source folder and invoking `cmake` and `make` as shown below.
-The library files are installed to `usr/local/lib`, and the library header files 
-are copied to `/usr/local/include`.
-
-```shell script
-cd control_libraries/source
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j
-make install
-```
-
-The CMake configuration flags `BUILD_CONTROLLERS`, `BUILD_DYNAMICAL_SYSTEMS` and `BUILD_ROBOT_MODEL` 
-determine which libraries are built, and are all defined as `ON` by default. 
-The building of the `state_representation` library cannot be disabled, as all other libraries depend on it.
-
-To selectively disable the build of a particular library, set the flag to `=OFF`.
-For example, the following flags will prevent the `robot_model` library from being built,
-which is useful if the Pinocchio dependency is not fulfilled on your system.
-
-```shell script
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ROBOT_MODEL=OFF ..
-```
-
-To also build the library tests, add the CMake flag `-DBUILD_TESTING=ON`.
-This requires GTest to be installed on your system. You can then use `make test` to run all test targets.
-
-Alternatively, you can include the source code for each library as submodules in your own CMake project,
-using the CMake directive `add_subdirectory(...)` to link it with your project.
-
-## Troubleshooting
-
-This section lists common problems that might come up when using the `control_libraries` modules.
-
-### Boost container limit compile error in ROS
-When using the `robot_model` module in ROS and trying to `catkin_make` the workspace, it might produce the following error:
-```bash
-/opt/openrobots/include/pinocchio/container/boost-container-limits.hpp:29:7: error: #error "BOOST_MPL_LIMIT_LIST_SIZE value is lower than the value of PINOCCHIO_BOOST_MPL_LIMIT_CONTAINER_SIZE"
-#23 2.389    29 |     # error "BOOST_MPL_LIMIT_LIST_SIZE value is lower than the value of PINOCCHIO_BOOST_MPL_LIMIT_CONTAINER_SIZE"
-```
-In order to avoid this error and successfully `catkin_make` the workspace, make sure that the `CMakeList.txt` of the ROS 
-package contains all the necessary directives, i.e. on top of
-```bash
-
-list(APPEND CMAKE_PREFIX_PATH /opt/openrobots)
-find_package(Eigen3 REQUIRED)
-find_package(pinocchio REQUIRED)
-find_package(OsqpEigen REQUIRED)
-find_package(osqp REQUIRED)
-
-find_library(state_representation REQUIRED)
-find_library(dynamical_systems REQUIRED)
-find_library(controllers REQUIRED)
-find_library(robot_model REQUIRED)
-...
-include_directories(
-    ${catkin_INCLUDE_DIRS}
-    ${Eigen3_INCLUDE_DIRS}
-    ${STATE_REPRESENTATION_INCLUDE_DIR}
-    ${DYNAMICAL_SYSTEMS_INCLUDE_DIR}
-    ${ROBOT_MODEL_INCLUDE_DIR}
-    ${CONTROLLERS_INCLUDE_DIR}
-    ${PINOCCHIO_INCLUDE_DIR}
-    ${OsqpEigen_INCLUDE_DIR}
-    /opt/openrobots/include
-)
-```
-it should also have
-```bash
-find_package(Boost REQUIRED COMPONENTS system)
-add_compile_definitions(BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS)
-add_compile_definitions(BOOST_MPL_LIMIT_LIST_SIZE=30)
-```
-For a comprehensive example, please check the [`CMakeLists.txt` of the ROS demos](/demos/ros_examples/CMakeLists.txt).
+For examples and demos in plain C++, ROS, and ROS2, refer to the <a href="https://github.com/epfl-lasa/control_libraries/tree/main/demos">demos</a> folder.

--- a/doxygen/doxygen.conf
+++ b/doxygen/doxygen.conf
@@ -462,7 +462,7 @@ EXTRACT_STATIC         = NO
 # for Java sources.
 # The default value is: YES.
 
-EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_CLASSES  = NO
 
 # This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are
@@ -791,7 +791,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../source
+INPUT                  = ../README.md ../source ../protocol ../python
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -826,6 +826,7 @@ FILE_PATTERNS          = *.c \
                          *.hxx \
                          *.hpp \
                          *.h++ \
+                         *.proto \
                          *.m \
                          *.markdown \
                          *.md
@@ -859,7 +860,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/*
+EXCLUDE_PATTERNS       = */tests/* */test/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -876,7 +877,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = ../demos
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -952,7 +953,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = ../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -965,7 +966,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.

--- a/protocol/clproto_cpp/README.md
+++ b/protocol/clproto_cpp/README.md
@@ -1,4 +1,4 @@
-# clproto_cpp - Control Libraries Protocol (C++)
+# clproto (C++)
 
 This library provides a simple interface for encoding and decoding
 control library type objects to and from a serialized binary string

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -7,6 +7,10 @@
 #define CLPROTO_PACKING_MAX_FIELD_LENGTH (4096)
 #define CLPROTO_PACKING_MAX_FIELDS (64)
 
+/**
+ * @namespace clproto
+ * @brief Bindings to encode and decode state objects into serialised binary message
+ */
 namespace clproto {
 
 /**
@@ -19,7 +23,7 @@ typedef std::size_t field_length_t;
 
 /**
  * @class DecodingException
- * @brief A DedocdingException is raised whenever a
+ * @brief A DecodingException is raised whenever a
  * decoding operation fails due to invalid encoding.
  */
 class DecodingException : public std::runtime_error {

--- a/python/source/state_representation/state_representation_bindings.cpp
+++ b/python/source/state_representation/state_representation_bindings.cpp
@@ -4,7 +4,7 @@
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
 
 PYBIND11_MODULE(state_representation, m) {
-  m.doc() = "Python bindings for control_libraries state_representation";
+  m.doc() = "Python bindings for control libraries state_representation";
 
   #ifdef MODULE_VERSION_INFO
   m.attr("__version__") = MACRO_STRINGIFY(MODULE_VERSION_INFO);

--- a/source/README.md
+++ b/source/README.md
@@ -1,4 +1,4 @@
-# Core libraries
+# Core Libraries
 
 ## `state_representation`
 
@@ -6,9 +6,9 @@ This library provides a set of classes to represent **states** in **Cartesian** 
 The classes define and combine variables such as position, velocity, acceleration and force into
 a consistent internal representation used across the other libraries.
 
-Dependencies: [Eigen3](https://eigen.tuxfamily.org/index.php?title=Main_Page)
+Source: [state_representation](./state_representation)
 
-[**Documentation**](source/state_representation/README.md)
+Dependencies: [Eigen3](https://eigen.tuxfamily.org/index.php?title=Main_Page)
 
 ---
 
@@ -18,9 +18,9 @@ This library provides a collection of classes that behave as differential equati
 a derivative of a state variable. For example, a position state input might
 yield a desired velocity output. This can be used to generate time-invariant trajectories.
 
-Dependencies: `state_representation`
+Source: [dynamical_systems](./dynamical_systems)
 
-[**Documentation**](source/dynamical_systems/README.md)
+Dependencies: `state_representation`
 
 ---
 
@@ -32,9 +32,9 @@ rigid-body algorithms for solving kinematic and dynamic problems.
 It is a wrapper for [Pinocchio](https://github.com/stack-of-tasks/pinocchio)
 that is compatible with the internal `state_representation` types.
 
-Dependencies: `state_representation`, [Pinocchio](https://stack-of-tasks.github.io/pinocchio/download.html)
+Source: [robot_model](./robot_model)
 
-[**Documentation**](source/robot_model/README.md)
+Dependencies: `state_representation`, [Pinocchio](https://stack-of-tasks.github.io/pinocchio/download.html)
 
 ---
 
@@ -43,6 +43,126 @@ Dependencies: `state_representation`, [Pinocchio](https://stack-of-tasks.github.
 This library provides classes designed to convert an input state to an output command in order to control
 a robot.
 
+Source: [controllers](./controllers)
+
 Dependencies: `state_representation`
 
-[**Documentation**](source/controllers/README.md)
+---
+
+
+## Installation
+
+### Supported platforms
+
+These libraries have been developed and tested on Linux Ubuntu 18.04 and 20.04.
+They should also work on macOS and Windows, though the installation
+steps may differ. At this time no guarantees are made for library support on
+non-Linux systems.
+
+### Installation with the install script
+This project uses CMake to generate static library objects for each of the modules.
+
+To facilitate the installation process, an [install script](./install.sh) is provided. Users who are interested in
+the manual installation steps and/or have already installed Pinocchio refer to the
+[manual installation steps](#manual-installation-steps) in the next section.
+
+The install script takes care of all the installation steps, including the installation and configuration of Pinocchio.
+It can be run with several optional arguments:
+- `-y`, `--auto`: Any input prompts will be suppressed and install steps automatically approved.
+- `-d [path]`, `--dir [path]`: If provided, the installation directory will be changed to `[path]`.
+- `--no-controllers`: The controllers library will be excluded from the installation.
+- `--no-dynamical-systems`: The dynamical systems library will be excluded from the installation.
+- `--no-robot-model`: The robot model library, and therefore Pinocchio, will be excluded from the installation.
+- `--build-tests`: The unittest targets will be included in the installation.
+- `--clean`: Any previously installed header files from `/usr/local/include` and any shared library files from
+  `/usr/local/lib` will be deleted before the installation.
+- `--cleandir [path]`: Any previously installed header files shared library files from `[path]` will be deleted before
+  the installation.
+
+### Manual installation steps
+
+Eigen3 is required for building `state_representation` and all other libraries.
+You can install it with:
+```shell script
+apt-get install libeigen3-dev
+```
+
+Pinocchio is required for building the `robot_model` library. Installing this requires
+some additional steps; see the [install script](./install.sh) for reference.
+If the `robot_model` library is not needed, you can skip the installation of Pinocchio.
+
+Once the dependencies are installed, build and install the libraries by navigating
+to the source folder and invoking `cmake` and `make` as shown below.
+The library files are installed to `usr/local/lib`, and the library header files
+are copied to `/usr/local/include`.
+
+```shell script
+cd control_libraries/source
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j
+make install
+```
+
+The CMake configuration flags `BUILD_CONTROLLERS`, `BUILD_DYNAMICAL_SYSTEMS` and `BUILD_ROBOT_MODEL`
+determine which libraries are built, and are all defined as `ON` by default.
+The building of the `state_representation` library cannot be disabled, as all other libraries depend on it.
+
+To selectively disable the build of a particular library, set the flag to `=OFF`.
+For example, the following flags will prevent the `robot_model` library from being built,
+which is useful if the Pinocchio dependency is not fulfilled on your system.
+
+```shell script
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ROBOT_MODEL=OFF ..
+```
+
+To also build the library tests, add the CMake flag `-DBUILD_TESTING=ON`.
+This requires GTest to be installed on your system. You can then use `make test` to run all test targets.
+
+Alternatively, you can include the source code for each library as submodules in your own CMake project,
+using the CMake directive `add_subdirectory(...)` to link it with your project.
+
+## Troubleshooting
+
+This section lists common problems that might come up when using the `control_libraries` modules.
+
+### Boost container limit compile error in ROS
+When using the `robot_model` module in ROS and trying to `catkin_make` the workspace, it might produce the following error:
+```bash
+/opt/openrobots/include/pinocchio/container/boost-container-limits.hpp:29:7: error: #error "BOOST_MPL_LIMIT_LIST_SIZE value is lower than the value of PINOCCHIO_BOOST_MPL_LIMIT_CONTAINER_SIZE"
+#23 2.389    29 |     # error "BOOST_MPL_LIMIT_LIST_SIZE value is lower than the value of PINOCCHIO_BOOST_MPL_LIMIT_CONTAINER_SIZE"
+```
+In order to avoid this error and successfully `catkin_make` the workspace, make sure that the `CMakeList.txt` of the ROS
+package contains all the necessary directives, i.e. on top of
+```bash
+
+list(APPEND CMAKE_PREFIX_PATH /opt/openrobots)
+find_package(Eigen3 REQUIRED)
+find_package(pinocchio REQUIRED)
+find_package(OsqpEigen REQUIRED)
+find_package(osqp REQUIRED)
+
+find_library(state_representation REQUIRED)
+find_library(dynamical_systems REQUIRED)
+find_library(controllers REQUIRED)
+find_library(robot_model REQUIRED)
+...
+include_directories(
+    ${catkin_INCLUDE_DIRS}
+    ${Eigen3_INCLUDE_DIRS}
+    ${STATE_REPRESENTATION_INCLUDE_DIR}
+    ${DYNAMICAL_SYSTEMS_INCLUDE_DIR}
+    ${ROBOT_MODEL_INCLUDE_DIR}
+    ${CONTROLLERS_INCLUDE_DIR}
+    ${PINOCCHIO_INCLUDE_DIR}
+    ${OsqpEigen_INCLUDE_DIR}
+    /opt/openrobots/include
+)
+```
+it should also have
+```bash
+find_package(Boost REQUIRED COMPONENTS system)
+add_compile_definitions(BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS)
+add_compile_definitions(BOOST_MPL_LIMIT_LIST_SIZE=30)
+```
+For a comprehensive example, please check the [`CMakeLists.txt` of the ROS demos](../demos/ros_examples/CMakeLists.txt).

--- a/source/controllers/README.md
+++ b/source/controllers/README.md
@@ -1,6 +1,6 @@
-# controllers library
+# Controllers
 
-This library introduces a set of controllers to be used in robotic control-loop schemes. Each controller are templated
+This library introduces a set of controllers to be used in robotic control-loop schemes. Each controller is templated
 to accepted an input space from `state_representation` and is derived from the `Controller` base class, e.g.,
 
 ```cpp

--- a/source/controllers/include/controllers/Controller.hpp
+++ b/source/controllers/include/controllers/Controller.hpp
@@ -6,6 +6,10 @@
 #include <list>
 #include <memory>
 
+/**
+ * @namespace controllers
+ * @brief Systems to determine a command output from measured and desired inputs
+ */
 namespace controllers {
 /**
  * @class Controller

--- a/source/dynamical_systems/README.md
+++ b/source/dynamical_systems/README.md
@@ -1,10 +1,7 @@
-# dynamical_systems
+# Dynamical Systems
 
 This library provides a set of classes to represent **Dynamical Systems**: 
 functions which map a state to a state derivative.
-Those are a set of helpers functions to handle common concepts in robotics such as transformations between frames and 
-the link between them and the robot state.
-This description covers most of the functionalities starting from the spatial transformations.
 
 ## Table of contents:
 * [Base DynamicalSystem](#base-dynamicalsystem)

--- a/source/dynamical_systems/include/dynamical_systems/Circular.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Circular.hpp
@@ -1,8 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/08/05
- */
-
 #pragma once
 
 #include "dynamical_systems/DynamicalSystem.hpp"

--- a/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/DynamicalSystem.hpp
@@ -1,15 +1,13 @@
-/**
- * @author Baptiste Busch
- * @date 2019/07/18
- *
- */
-
 #pragma once
 
 #include "state_representation/parameters/ParameterInterface.hpp"
 #include <list>
 #include <memory>
 
+/**
+ * @namespace dynamical_systems
+ * @brief Systems of equations relating state variables to their derivatives
+ */
 namespace dynamical_systems {
 /**
  * @class DynamicalSystem

--- a/source/dynamical_systems/include/dynamical_systems/Linear.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/Linear.hpp
@@ -1,9 +1,3 @@
-/**
- * @author Baptiste Busch
- * @date 2019/07/18
- *
- */
-
 #pragma once
 
 #include "dynamical_systems/DynamicalSystem.hpp"

--- a/source/robot_model/README.md
+++ b/source/robot_model/README.md
@@ -1,4 +1,4 @@
-# robot_model
+# Robot Model
 
 The `robot_model` library is a wrapper for the [Pinocchio](https://github.com/stack-of-tasks/pinocchio) library, used
 to compute dynamics model of a robot.

--- a/source/robot_model/include/robot_model/Model.hpp
+++ b/source/robot_model/include/robot_model/Model.hpp
@@ -15,6 +15,10 @@
 
 using namespace std::chrono_literals;
 
+/**
+ * @namespace robot_model
+ * @brief Robot kinematics and dynamics
+ */
 namespace robot_model {
 /**
  * @brief parameters for the inverse kinematics function

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -1,4 +1,4 @@
-# state_representation
+# State Representation
 
 This library provides a set of classes to represent **states** in **Cartesian** or **joint** spaces, **parameters**, 
 or **geometrical shapes** that can be used as obstacles.

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -8,6 +8,10 @@
 #include <iostream>
 #include <typeinfo>
 
+/**
+ * @namespace state_representation
+ * @brief Core state variables and objects
+ */
 namespace state_representation {
 enum class StateType {
   STATE,


### PR DESCRIPTION
Here's a minor documentation overall to make our released documentation more pleasing.

There is now a top-level page, a list of pages in the "related pages" tab, and all namespaces show up properly in the namespace tab.

I pushed the result to the website temporarily: 
https://epfl-lasa.github.io/control_libraries/versions/tmp/